### PR TITLE
📝 docs: K/N Pattern 7 carrier for a Stage-5 LLM/ adapter (#1482)

### DIFF
--- a/.claude/rules/engine.md
+++ b/.claude/rules/engine.md
@@ -78,6 +78,16 @@ reason. A wording change is a *behaviour* change: give its harness A/B a
 **deleted-text control arm**, or "the two wordings tie" cannot be told apart from
 "this text does nothing".
 
+## Conforming to a K/N-exported protocol from `LLM/`
+
+A Stage-5 adapter (ADR-023 §6) wrapping `LlamaCppService` as an `LLMBackend` conformer hits
+one trap with no diagnostic: the protocol imports unannotated, so the conforming type must be
+`nonisolated` or the `@objc` thunk traps at runtime — `.claude/rules/swift-isolation.md`
+Pattern 7, K/N instance. The rest of the K/N boundary (every Kotlin-defaulted member lands
+`@required`, so `knownTurnMarkers` must be stated; no Swift `Sendable` on exports) is
+`.claude/rules/kmp-interop.md`, which loads for `shared/**` only — read it before writing the
+adapter. Reference: the KDoc on `knownTurnMarkers` in `shared/engine/.../LLMBackend.kt`.
+
 ## SimulationEvent & the projection contract
 
 Every production `switch` over `SimulationEvent`, `PhaseType`, or

--- a/.claude/rules/engine.md
+++ b/.claude/rules/engine.md
@@ -81,12 +81,13 @@ reason. A wording change is a *behaviour* change: give its harness A/B a
 ## Conforming to a K/N-exported protocol from `LLM/`
 
 A Stage-5 adapter (ADR-023 §6) wrapping `LlamaCppService` as an `LLMBackend` conformer hits
-one trap with no diagnostic: the protocol imports unannotated, so the conforming type must be
-`nonisolated` or the `@objc` thunk traps at runtime — `.claude/rules/swift-isolation.md`
-Pattern 7, K/N instance. The rest of the K/N boundary (every Kotlin-defaulted member lands
-`@required`, so `knownTurnMarkers` must be stated; no Swift `Sendable` on exports) is
-`.claude/rules/kmp-interop.md`, which loads for `shared/**` only — read it before writing the
-adapter. Reference: the KDoc on `knownTurnMarkers` in `shared/engine/.../LLMBackend.kt`.
+one trap with no diagnostic: the protocol imports unannotated (per the KDoc, unprobed), so the
+conforming type must be `nonisolated` or the `@objc` thunk traps at runtime —
+`.claude/rules/swift-isolation.md` Pattern 7, K/N instance. The rest of the K/N boundary (every
+Kotlin-defaulted member lands `@required`, so `knownTurnMarkers` must be stated; no Swift
+`Sendable` on exports) is `.claude/rules/kmp-interop.md`, which loads for `shared/**` and
+`tools/kmp-gate-spike/**` only — read it before writing the adapter. Reference: the KDoc on
+`knownTurnMarkers` in `shared/engine/src/commonMain/kotlin/com/pastura/engine/LLMBackend.kt`.
 
 ## SimulationEvent & the projection contract
 

--- a/.claude/rules/swift-isolation.md
+++ b/.claude/rules/swift-isolation.md
@@ -49,12 +49,12 @@ Pair `nonisolated` with `Sendable` when every stored member is an immutable `Sen
 Reference: `Views/Components/ShareCaptionItemSource.swift` (`UIActivityItemSource` is nonisolated; measured 2026-07-24).
 
 A Kotlin/Native-exported protocol is the same case, not a UIKit one: `LLMBackend` imports as an
-unannotated Obj-C protocol and its members are read from `Dispatchers.Default`, so a Stage-5
-adapter in `LLM/` conforming to it must be `nonisolated` — every gate-spike conformer carries it
-for this reason (`tools/kmp-gate-spike/Sources/KMPGateSpike/ScriptedStreamingBackend.swift`).
-Stated from the KDoc on `knownTurnMarkers` in `shared/engine/.../LLMBackend.kt`, not yet from the
-probe above — run it against the staged framework before relying on it (`kmp-interop.md` owns
-the other K/N import traps and does not load for an `LLM/` edit; `engine.md` carries the pointer).
+unannotated Obj-C protocol and `knownTurnMarkers` is read from `Dispatchers.Default`, so a
+Stage-5 adapter in `LLM/` conforming to it must be `nonisolated`. The gate-spike conformers all
+carry it (`tools/kmp-gate-spike/Sources/KMPGateSpike/ScriptedStreamingBackend.swift`) — follow
+that precedent, not the compiler's silence. Stated from the KDoc on `knownTurnMarkers` in
+`shared/engine/.../LLMBackend.kt`, not yet from the probe above — run it against the staged
+framework before relying on it.
 
 ## Pattern 8 — MainActor-inferred closure handed to a framework callback
 

--- a/.claude/rules/swift-isolation.md
+++ b/.claude/rules/swift-isolation.md
@@ -48,6 +48,14 @@ Pair `nonisolated` with `Sendable` when every stored member is an immutable `Sen
 
 Reference: `Views/Components/ShareCaptionItemSource.swift` (`UIActivityItemSource` is nonisolated; measured 2026-07-24).
 
+A Kotlin/Native-exported protocol is the same case, not a UIKit one: `LLMBackend` imports as an
+unannotated Obj-C protocol and its members are read from `Dispatchers.Default`, so a Stage-5
+adapter in `LLM/` conforming to it must be `nonisolated` — every gate-spike conformer carries it
+for this reason (`tools/kmp-gate-spike/Sources/KMPGateSpike/ScriptedStreamingBackend.swift`).
+Stated from the KDoc on `knownTurnMarkers` in `shared/engine/.../LLMBackend.kt`, not yet from the
+probe above — run it against the staged framework before relying on it (`kmp-interop.md` owns
+the other K/N import traps and does not load for an `LLM/` edit; `engine.md` carries the pointer).
+
 ## Pattern 8 — MainActor-inferred closure handed to a framework callback
 
 A framework initializer taking a **non-`@Sendable`** escaping closure (`UIColor(dynamicProvider:)`, any `@escaping` UIKit callback) accepts a closure literal written in a MainActor context, where it is inferred `@MainActor`. The framework may then invoke it off the main actor. The build succeeds either way.


### PR DESCRIPTION
## Summary

Closes #1482 by delivering its item 1 and recording items 2–4 as moot. Rule files only.

`LLMBackend.kt`'s KDoc warns that a Stage-5 Swift adapter omitting type-level `nonisolated` compiles clean and traps at runtime on the `@objc` thunk — a K/N-exported protocol imports as an unannotated Obj-C protocol and is read from `Dispatchers.Default`. Nothing carried that to the person who will write the adapter: `kmp-interop.md` loads for `shared/**` + `tools/kmp-gate-spike/**` only, and always-loaded `swift-isolation.md` framed Pattern 7 entirely around UIKit delegates.

- **`swift-isolation.md` Pattern 7** — one paragraph naming the K/N protocol as an instance, cited from tracked sources (the KDoc and the gate-spike conformers, not the generated `PasturaSharedEngine.h`) and stated as derived from the KDoc rather than probed, so the file's own "ask the compiler" bar is not quietly lowered.
- **`engine.md`** — a short section for an `LLM/` adapter author: the Pattern 7 trap, and the reminder that the rest of the K/N boundary lives in `kmp-interop.md`, which will not load for that edit.

### Items 2–4 are moot

#1522's zero-base rebuild of `kmp-interop.md` removed the content they targeted — the "Artifact note, Patterns 1–2" blockquote, the header / compile criterion it carried, and the hedged `extension PasturaShared.Pairing` line. Pattern 1 is now two sentences with no copyable line to de-literalize; Pattern 2 states which umbrella measured construction versus casting in one clause. There is nothing left to lift, move, or correct.

### Deferred, not dropped

Re-measuring Pattern 2's construction rows under `PasturaSharedEngine` (the issue's "Also worth deciding") needs a staged XCFramework and a compile — Stage 5 work. `kmp-interop.md` Pattern 2 already states which umbrella measured what, so the rule is honest about its evidence until then.

## Test plan

- Rule files only — `scripts/precommit-gate-classify.sh` emits no `build` / `lint` token, so the Swift build, test suite and SwiftLint are skipped (stated per the carve-out).
- Injection check per #1312 (fresh Haiku subagent reading `Pastura/Pastura/LLM/LLMService.swift` in this worktree, asked what reached its context without opening any rule file): `xcodebuild-cli.md` **present** (positive control valid); `engine.md` **present, with the new "Conforming to a K/N-exported protocol from `LLM/`" section** — so the worktree copy was the one injected for the `LLM/` read; `kmp-interop.md` **absent** (negative control holds); `swift-isolation.md` present but without the new paragraph — always-loaded files come from the session's launch checkout (`main`), not the worktree, so this is expected and says nothing about the edit; it lands once merged.
- Every path the new text cites is tracked (`git ls-files` on `LLMBackend.kt` and `ScriptedStreamingBackend.swift`).

## Review

Reviewer: `code-reviewer` on **Opus** — **PASS**, 0 Critical / 1 Warning / 5 Suggestion. It verified every factual claim against its source (the KDoc, `LLMCaller.kt:158` / `SimulationEngine.kt:75` for the `Dispatchers.Default` read, all 7 gate-spike conformers carrying `nonisolated`, ADR-023 §6, `kmp-interop.md` Patterns 1 and 3). Applied in the last commit:

- W1 — `engine.md` said `kmp-interop.md` loads for `shared/**` *only*; it also loads for `tools/kmp-gate-spike/**`, which is where the sibling paragraph sends the reader → fixed.
- S1 — the `engine.md` copy carries the same "per the KDoc, unprobed" hedge as the always-loaded one.
- S2 / S3 — the Pattern 7 paragraph narrows to what the KDoc states (the property, not "its members") and frames the gate-spike conformers as precedent to follow rather than evidence — four lines above, the file says compiling proves nothing.
- S4 — the authoring-bookkeeping clause ("`engine.md` carries the pointer") is dropped from the always-loaded file.
- S5 — the path-scoped copy spells the full `LLMBackend.kt` path.
- S6 — the injection probe is recorded above.

Plan critique (`claude-kit:critic`, Opus): its actions for this PR — cite tracked sources instead of the generated header, mark the claim unmeasured, add the `engine.md` carrier, run the #1312 probe — are all in.

## Device QA

実機QA不要 — rule-file text only; no source changed.

Closes #1482.
