### PR TITLE
🧪 test: execute the large-text claims of mossSoft / contentTextBar (#1495)

### DIFF
--- a/Pastura/PasturaTests/Views/DesignTokensTests+MossSoftGround.swift
+++ b/Pastura/PasturaTests/Views/DesignTokensTests+MossSoftGround.swift
@@ -39,7 +39,10 @@ extension DesignTokensTests {
   ///
   /// Each row carries the label's font (``OpaqueLabelSite``), so the
   /// large-text admission criterion below is executed per row rather than
-  /// claimed in this comment.
+  /// claimed in this comment. The streak row is hand-recorded a second time in
+  /// `+MutedTranscript.swift`'s `predictionBadgeLabelSites`, for the #1427
+  /// arms; a weight change in the view has to be transcribed in both, and
+  /// nothing detects updating only one.
   static let mossSoftTextSites = [
     OpaqueLabelSite(
       "ContradictionBadge", pointSize: WashLabelSemanticSize.caption, weight: .semibold),

--- a/Pastura/PasturaTests/Views/DesignTokensTests+MossSoftGround.swift
+++ b/Pastura/PasturaTests/Views/DesignTokensTests+MossSoftGround.swift
@@ -36,34 +36,42 @@ extension DesignTokensTests {
   /// at 2.136 / 2.413), but that is a fact about today's tree, not a property of
   /// this fixture — so still read this guard as "the moss-family labels clear
   /// AA", never "every label on `mossSoft` does".
+  ///
+  /// Each row carries the label's font (``OpaqueLabelSite``), so the
+  /// large-text admission criterion below is executed per row rather than
+  /// claimed in this comment.
   static let mossSoftTextSites = [
-    "ContradictionBadge",
-    "PredictionOutcomeBadge.hitArm",
-    "PredictionOutcomeBadge.streak",
-    "HighlightCandidatesSection.revealedChip"
+    OpaqueLabelSite(
+      "ContradictionBadge", pointSize: WashLabelSemanticSize.caption, weight: .semibold),
+    OpaqueLabelSite(
+      "PredictionOutcomeBadge.hitArm", pointSize: WashLabelSemanticSize.caption, weight: .semibold),
+    OpaqueLabelSite(
+      "PredictionOutcomeBadge.streak", pointSize: WashLabelSemanticSize.caption, weight: .medium),
+    OpaqueLabelSite("HighlightCandidatesSection.revealedChip", pointSize: 10, weight: .bold)
   ]
 
-  /// WCAG 1.4.3 normal-text bar. All four labels are under the "large text"
-  /// threshold (≥14pt bold / ≥18pt regular) — the largest is `caption`-class at
-  /// ~12pt and the chip is 10pt bold — so 3:1 never applies to any of them.
-  ///
-  /// ⚠️ **Prose, observed by nothing** — `mossSoftTextSites` is a `[String]`,
-  /// so neither that claim nor the superlative inside it can redden when a
-  /// fifth label arrives. This is the shape #1466 falsified; ``WashLabelWeight``
-  /// made the criterion executable for the *wash* fixtures and #1495 tracks
-  /// bringing this one along. When adding a row, promote the list to a row type
-  /// rather than re-deriving the superlative by hand.
+  /// The WCAG 1.4.3 normal-text bar — the right bar because every row's
+  /// `isNormalText` is asserted in `mossInkClearsAAOnTheOpaqueMossSoftGround`:
+  /// a large-text row reddens there instead of being admitted silently
+  /// (#1495; the shape #1466 falsified).
   private static let textBar = 4.5
 
   /// The ground is the token itself, not a composite: unlike the wash sites,
   /// `mossSoft` here fills the capsule at full opacity, so whatever card or
   /// screen sits behind it is occluded and cannot move the ratio.
   @Test func mossInkClearsAAOnTheOpaqueMossSoftGround() {
-    // Size pin: the assertions below don't iterate the fixture, so an emptied
-    // list wouldn't make them vacuous — it would silently drop the record of
-    // which views this guard speaks for. Residual: it catches a row added or
-    // removed, never one *renamed* to a view that no longer draws on this ground.
+    // Size pin: the CONTRAST assertions below don't iterate the fixture, so an
+    // emptied list wouldn't make them vacuous — it would silently drop the
+    // record of which views this guard speaks for. Residual: it catches a row
+    // added or removed, never one *renamed* to a view that no longer draws on
+    // this ground. (The admission loop just below DOES iterate the fixture.)
     #expect(Self.mossSoftTextSites.count == 4)
+
+    for site in Self.mossSoftTextSites {
+      #expect(
+        site.isNormalText,
+        "\(largeTextRejection(site.name, pointSize: site.pointSize, weight: site.weight))")
+    }
 
     let light = contrastRatio(PasturaPalette.mossInk, PasturaPalette.mossSoft)
     #expect(light >= Self.textBar, "light: \(light)")

--- a/Pastura/PasturaTests/Views/DesignTokensTests+MutedAsContent.swift
+++ b/Pastura/PasturaTests/Views/DesignTokensTests+MutedAsContent.swift
@@ -27,10 +27,14 @@ import Testing
 extension DesignTokensTests {
 
   /// WCAG 1.4.3 normal-text bar. The ceiling arms use it over *grounds*, where
-  /// no label font applies. The two floor arms speak for `PredictionOutcomeBadge`'s
-  /// #1427 labels, and that they are normal text — so this is their bar — is
-  /// asserted per row by `predictionBadgeLabelsAreNormalTextSoTheContentBarApplies`
-  /// in `+MutedTranscript.swift` (#1495).
+  /// no label font applies. The two `PredictionOutcomeBadge` floor arms speak
+  /// for the #1427 labels, and that those are normal text — so this is their
+  /// bar — is asserted per row by
+  /// `predictionBadgeLabelsAreNormalTextSoTheContentBarApplies` in
+  /// `+MutedTranscript.swift` (#1495). Its two other floor consumers —
+  /// `+MutedDirection`'s selected-`ModelRow` arm (a wash) and
+  /// `+MutedTranscript`'s `page` arm — speak for labels whose size is still
+  /// observed by nothing.
   static let contentTextBar = 4.5  // internal: `+MutedTranscript`'s `page` arm reads it
 
   /// Every opaque ground the app ships that `muted` is or could be drawn on, per

--- a/Pastura/PasturaTests/Views/DesignTokensTests+MutedAsContent.swift
+++ b/Pastura/PasturaTests/Views/DesignTokensTests+MutedAsContent.swift
@@ -26,15 +26,11 @@ import Testing
 // one that computes a ground, while this file sits within a few lines of the cap.
 extension DesignTokensTests {
 
-  /// WCAG 1.4.3 normal-text bar. Both #1427 labels are `caption`-class (~12pt),
-  /// under the "large text" threshold, so 3:1 never applies to either.
-  ///
-  /// ⚠️ **Prose, observed by nothing.** ``WashLabelWeight`` made this criterion
-  /// executable for the *wash* fixtures; #1495 tracks this one. The obstacle is
-  /// not the fixture's ground-oriented shape — the two arms using this bar as a
-  /// **floor** speak for named labels and could carry the fields — it is that
-  /// the streak sub-label is `.caption.weight(.medium)`, a weight with no WCAG
-  /// half assigned yet.
+  /// WCAG 1.4.3 normal-text bar. The ceiling arms use it over *grounds*, where
+  /// no label font applies. The two floor arms speak for `PredictionOutcomeBadge`'s
+  /// #1427 labels, and that they are normal text — so this is their bar — is
+  /// asserted per row by `predictionBadgeLabelsAreNormalTextSoTheContentBarApplies`
+  /// in `+MutedTranscript.swift` (#1495).
   static let contentTextBar = 4.5  // internal: `+MutedTranscript`'s `page` arm reads it
 
   /// Every opaque ground the app ships that `muted` is or could be drawn on, per

--- a/Pastura/PasturaTests/Views/DesignTokensTests+MutedTranscript.swift
+++ b/Pastura/PasturaTests/Views/DesignTokensTests+MutedTranscript.swift
@@ -319,18 +319,26 @@ extension DesignTokensTests {
 
   // MARK: - PredictionOutcomeBadge label sites (#1495)
 
-  /// The two labels `bothPredictionBadgeRepointsClearTheBar` and
-  /// `inkSecondaryDoesNotRescueTheStreakOnMossSoftInLight` (both in the sibling
-  /// `DesignTokensTests+MutedAsContent.swift`) speak for: `PredictionOutcomeBadge`'s
-  /// miss arm, on the opaque `bubbleBackground` card ground, and its streak
-  /// sub-label, on the opaque `mossSoft` capsule. Both grounds are opaque —
-  /// neither label sits on a wash — so ``OpaqueLabelSite`` is the right row
-  /// type for them, per its own doc.
+  /// The labels the arms `bothPredictionBadgeRepointsClearTheBar` (both
+  /// labels) and `inkSecondaryDoesNotRescueTheStreakOnMossSoftInLight` (the
+  /// streak's negative control), in the sibling
+  /// `DesignTokensTests+MutedAsContent.swift`, together speak for:
+  /// `PredictionOutcomeBadge`'s miss arm, on the opaque `bubbleBackground` card
+  /// ground, and its streak sub-label, on the opaque `mossSoft` capsule. Both
+  /// grounds are opaque — neither label sits on a wash — so ``OpaqueLabelSite``
+  /// is the right row type for them, per its own doc.
+  ///
+  /// The streak row is also hand-recorded in `+MossSoftGround.swift`'s
+  /// `mossSoftTextSites`, for its mossSoft-ground arm; keep the two in step —
+  /// nothing detects a weight change transcribed into only one.
   ///
   /// Lives here rather than beside those two arms because that file sits at
   /// SwiftLint's `file_length` cap; its header routes a new arm to this
   /// sibling, and that routing covers a row-type pin like this one just as much
-  /// as an arm that computes a ground.
+  /// as an arm that computes a ground. Residual of the split: nothing ties
+  /// these rows to those arms, so a third label joining
+  /// `bothPredictionBadgeRepointsClearTheBar` needs no row here and the
+  /// `count == 2` pin would not notice — a reviewer has to look.
   static let predictionBadgeLabelSites = [
     OpaqueLabelSite(
       "PredictionOutcomeBadge.missArm", pointSize: WashLabelSemanticSize.caption,

--- a/Pastura/PasturaTests/Views/DesignTokensTests+MutedTranscript.swift
+++ b/Pastura/PasturaTests/Views/DesignTokensTests+MutedTranscript.swift
@@ -316,4 +316,39 @@ extension DesignTokensTests {
     let dark = contrastRatio(PasturaPalette.nightInkSecondary, PasturaPalette.nightPage)
     #expect(dark >= Self.contentTextBar, "dark nightPage: \(dark)")
   }
+
+  // MARK: - PredictionOutcomeBadge label sites (#1495)
+
+  /// The two labels `bothPredictionBadgeRepointsClearTheBar` and
+  /// `inkSecondaryDoesNotRescueTheStreakOnMossSoftInLight` (both in the sibling
+  /// `DesignTokensTests+MutedAsContent.swift`) speak for: `PredictionOutcomeBadge`'s
+  /// miss arm, on the opaque `bubbleBackground` card ground, and its streak
+  /// sub-label, on the opaque `mossSoft` capsule. Both grounds are opaque —
+  /// neither label sits on a wash — so ``OpaqueLabelSite`` is the right row
+  /// type for them, per its own doc.
+  ///
+  /// Lives here rather than beside those two arms because that file sits at
+  /// SwiftLint's `file_length` cap; its header routes a new arm to this
+  /// sibling, and that routing covers a row-type pin like this one just as much
+  /// as an arm that computes a ground.
+  static let predictionBadgeLabelSites = [
+    OpaqueLabelSite(
+      "PredictionOutcomeBadge.missArm", pointSize: WashLabelSemanticSize.caption,
+      weight: .semibold),
+    OpaqueLabelSite(
+      "PredictionOutcomeBadge.streak", pointSize: WashLabelSemanticSize.caption, weight: .medium)
+  ]
+
+  /// Makes the 4.5 bar's applicability to the two arms above executable rather
+  /// than prose (#1495; the shape #1466 falsified for the wash fixtures).
+  @Test func predictionBadgeLabelsAreNormalTextSoTheContentBarApplies() {
+    // Anti-vacuity: the loop below iterates this literal, so an emptied array
+    // would pass silently.
+    #expect(Self.predictionBadgeLabelSites.count == 2)
+    for site in Self.predictionBadgeLabelSites {
+      #expect(
+        site.isNormalText,
+        "\(largeTextRejection(site.name, pointSize: site.pointSize, weight: site.weight))")
+    }
+  }
 }

--- a/Pastura/PasturaTests/Views/DesignTokensTests+WashLabelTypeSize.swift
+++ b/Pastura/PasturaTests/Views/DesignTokensTests+WashLabelTypeSize.swift
@@ -146,6 +146,24 @@ extension DesignTokensTests {
         "\(probe.pointSize)pt \(probe.weight): expected isNormalText == \(probe.isNormalText)")
     }
   }
+
+  /// The negative control for ``OpaqueLabelSite/isNormalText``, and
+  /// deliberately a third one rather than a reuse of the two controls above:
+  /// all three row types forward the same fields to the same
+  /// ``WashLabelWeight`` method, so sharing would look sufficient — but what
+  /// each type can get wrong is its own wiring, and a control run through a
+  /// sibling that happens to be correct passes without observing this one at
+  /// all.
+  @Test func opaqueLabelSiteRejectsLargeTextLabels() {
+    #expect(Self.washLabelBoundaryCases.count == 9)
+
+    for probe in Self.washLabelBoundaryCases {
+      let row = OpaqueLabelSite("probe", pointSize: probe.pointSize, weight: probe.weight)
+      #expect(
+        row.isNormalText == probe.isNormalText,
+        "\(probe.pointSize)pt \(probe.weight): expected isNormalText == \(probe.isNormalText)")
+    }
+  }
 }
 
 // MARK: - Helpers
@@ -272,6 +290,55 @@ func largeTextRejection(_ name: String, pointSize: Double, weight: WashLabelWeig
 enum WashLabelSemanticSize {
   static let caption = 12.0
   static let caption2 = 11.0
+}
+
+/// One shipped label on an **opaque** token-filled ground.
+///
+/// **No ground fields, unlike ``MossWashSite``.** That type composites a
+/// translucent wash over a background it must record on the row; this type's
+/// ground is the token itself at full opacity, so nothing behind it can move
+/// the ratio, the fixture measures that token pair directly, and a row only
+/// needs to carry the label's font.
+///
+/// **Lives in this file rather than in a fixture** because two fixtures
+/// share it — `DesignTokensTests+MossSoftGround.swift`'s
+/// `mossSoftTextSites`, and the #1427 label rows
+/// `DesignTokensTests+MutedTranscript.swift` will carry — and a row type
+/// shared by two fixtures is criterion-level, per this file's header
+/// ownership split.
+///
+/// **Speaks for the site's `Text` label only.** A site that also draws an SF
+/// Symbol icon — `PredictionOutcomeBadge`'s hit capsule draws `target` at
+/// `.caption2.weight(.bold)` alongside its label — is not recorded here: an
+/// icon is non-text under WCAG 1.4.11's 3:1 bar, outside a normal-text
+/// fixture's scope. A decorative glyph (`ContradictionBadge`'s 🃏,
+/// `.accessibilityHidden`) is excluded the same way.
+///
+/// Hand-recorded against the view, like the other row types in this suite;
+/// ``WashLabelSemanticSize`` is the reference for what `pointSize` means.
+struct OpaqueLabelSite {
+  let name: String
+
+  /// The label's point size at the default `.large` content size — the two
+  /// regimes it spans, and why a wrong transcription is caught by nothing:
+  /// ``WashLabelSemanticSize``.
+  let pointSize: Double
+
+  /// Which WCAG large-text half the label's weight selects — the `.semibold`
+  /// decision, and the token-derived form: ``WashLabelWeight``.
+  let weight: WashLabelWeight
+
+  init(_ name: String, pointSize: Double, weight: WashLabelWeight) {
+    self.name = name
+    self.pointSize = pointSize
+    self.weight = weight
+  }
+
+  /// Whether this row's label is still WCAG **normal** text, i.e. whether the
+  /// 4.5:1 bar the fixture pins is the bar it actually answers to. Both
+  /// fields are required at construction, so a row cannot join without
+  /// declaring a font.
+  var isNormalText: Bool { weight.admitsAsNormalText(pointSize: pointSize) }
 }
 
 /// One boundary case for the ``WashLabelWeight`` halves: a point size, a

--- a/Pastura/PasturaTests/Views/DesignTokensTests+WashLabelTypeSize.swift
+++ b/Pastura/PasturaTests/Views/DesignTokensTests+WashLabelTypeSize.swift
@@ -4,11 +4,12 @@ import UIKit
 
 @testable import Pastura
 
-// The WCAG large-text admission criterion the wash-contrast fixtures apply,
+// The WCAG large-text admission criterion the contrast fixtures apply,
 // made executable (#1468).
 //
-// `DesignTokensTests+MossOnWash.swift`, `+MossInkAsWashLabel.swift` and
-// `+InkOnWash.swift` each pin a 4.5:1 bar, and each is only the right bar
+// `DesignTokensTests+MossOnWash.swift`, `+MossInkAsWashLabel.swift`,
+// `+InkOnWash.swift`, `+MossSoftGround.swift`, and the #1427 label rows in
+// `+MutedTranscript.swift` each pin a 4.5:1 bar, and each is only the right bar
 // because every label in its fixture is WCAG **normal** text. Until #1468 that
 // was a prose claim over row types storing no font, so no arm observed it and a
 // large-text row would have been admitted silently (#1466).
@@ -18,19 +19,6 @@ import UIKit
 // ``WashLabelWeight`` and each row type's `isNormalText`, which is what lives
 // here, and it keeps the controls off the two fixture files closest to
 // swiftlint's 400-line `file_length` error under `--strict`.
-//
-// **Two sibling fixtures in this suite still carry the unexecuted form, and the
-// class is not closed** (#1495): `DesignTokensTests+MossSoftGround.swift`'s
-// `textBar` pins 4.5 over a `[String]` site list with a superlative on top — the
-// exact state #1466 falsified — and `DesignTokensTests+MutedAsContent.swift`'s
-// `contentTextBar` carries the shorter form. They are excluded deliberately, and
-// **one obstacle is common to both**: `PredictionOutcomeBadge`'s streak
-// sub-label is `.caption.weight(.medium)`, and both speak for it, so either
-// would force a fourth ``WashLabelWeight`` case — a WCAG judgement call this
-// branch had no occasion to make. `+MutedAsContent` has a second obstacle: its
-// remaining claim is entangled with the occupancy question it deferred to #1448
-// (closed; the per-site verdicts are `docs/design/muted-application-audit.md`
-// §5 / §6.4). Do not read the criterion below as covering either.
 //
 // Sibling-file extension of `DesignTokensTests` per `.claude/rules/testing.md`
 // § "Splitting a Suite Across Files" — a fresh `@Suite` would run in parallel
@@ -61,7 +49,9 @@ extension DesignTokensTests {
     WashLabelBoundaryCase(18, .semibold, isNormalText: false),
     WashLabelBoundaryCase(17.9, .semibold, isNormalText: true),
     WashLabelBoundaryCase(18, .regular, isNormalText: false),
-    WashLabelBoundaryCase(17.9, .regular, isNormalText: true)
+    WashLabelBoundaryCase(17.9, .regular, isNormalText: true),
+    WashLabelBoundaryCase(18, .medium, isNormalText: false),
+    WashLabelBoundaryCase(17.9, .medium, isNormalText: true)
   ]
 
   /// The two semantic sizes are the only figures in any wash fixture with no
@@ -81,8 +71,8 @@ extension DesignTokensTests {
   }
 
   /// Coverage over the boundary table, which its own count pin cannot give:
-  /// `count == 7` survives a same-cardinality swap and says nothing about a
-  /// **fourth** ``WashLabelWeight`` case, which would ship with zero control
+  /// `count == 9` survives a same-cardinality swap and says nothing about a
+  /// **fifth** ``WashLabelWeight`` case, which would ship with zero control
   /// rows while both negative controls stayed green.
   ///
   /// Deliberately structural, not value-derived: it asks that each case be
@@ -98,21 +88,25 @@ extension DesignTokensTests {
   }
 
   /// ``WashLabelWeight/init(_:)`` is what lets a token-backed row take its
-  /// weight live instead of transcribing it, so this pins both halves of that
-  /// initializer: the mappings the fixtures rely on, and — through
-  /// `withKnownIssue` — that an unmodelled weight is *recorded* rather than
-  /// quietly folded into `.regular`. The second half is the one that matters:
-  /// silent defaulting is the over-strict direction, so nothing else would ever
-  /// redden to reveal it.
-  @Test func tokenWeightsMapToHalvesAndUnmodelledOnesAreRecorded() {
+  /// weight live instead of transcribing it, so this pins every mapping the
+  /// fixtures rely on. The `.medium` pin is the one doing real work: `.medium`
+  /// and `.regular` share the ≥18pt half, so a mapping that folded `.medium`
+  /// into `.regular` would produce identical results everywhere else in the
+  /// repo — this pin is the only thing that observes the distinction between
+  /// naming `.medium` explicitly and defaulting it there by accident.
+  ///
+  /// This no longer probes the unmodelled-weight path: all nine named
+  /// `Font.Weight` statics are modelled now, and `Font.Weight` has no public
+  /// initializer, so no unmodelled weight can be constructed to drive it. The
+  /// `default:` arm's `Issue.record` in ``WashLabelWeight/init(_:)`` is
+  /// therefore unobservable by test — it stays in place as a guard for a
+  /// future SwiftUI weight, not as something this suite can exercise.
+  @Test func tokenWeightsMapToHalves() {
     #expect(WashLabelWeight(.regular) == .regular)
+    #expect(WashLabelWeight(.medium) == .medium)
     #expect(WashLabelWeight(.semibold) == .semibold)
     #expect(WashLabelWeight(.bold) == .bold)
     #expect(WashLabelWeight(.heavy) == .bold)
-
-    withKnownIssue("an unmodelled weight must record an issue, not default silently") {
-      _ = WashLabelWeight(.medium)
-    }
   }
 
   /// The negative control for ``MossWashSite/isNormalText``.
@@ -123,7 +117,7 @@ extension DesignTokensTests {
   /// case proves nothing. This constructs the rows the guard claims to reject
   /// and confirms it does.
   @Test func mossWashSiteRejectsLargeTextLabels() {
-    #expect(Self.washLabelBoundaryCases.count == 7)
+    #expect(Self.washLabelBoundaryCases.count == 9)
 
     for probe in Self.washLabelBoundaryCases {
       let row = MossWashSite(
@@ -142,7 +136,7 @@ extension DesignTokensTests {
   /// and a control run through a sibling that happens to be correct passes
   /// without observing this one at all.
   @Test func inkWashSiteRejectsLargeTextLabels() {
-    #expect(Self.washLabelBoundaryCases.count == 7)
+    #expect(Self.washLabelBoundaryCases.count == 9)
 
     for probe in Self.washLabelBoundaryCases {
       let row = InkWashSite(
@@ -176,18 +170,25 @@ extension DesignTokensTests {
 /// produce errs toward over-strictness — none routes a label to a *looser* bar,
 /// because no looser bar exists in these files.
 ///
-/// Only the three weights the fixtures use are modelled, and a fourth has to
-/// choose a half rather than being a mechanical addition. Both the
-/// `largeTextThreshold` switch and ``init(_:)`` are written so a new weight
+/// Four weights are modelled now, covering every weight the fixtures in this
+/// suite use. `.medium` (500) takes the ≥18pt half alongside `.regular` and
+/// `.semibold`, decided here rather than per row: WCAG's "bold" is
+/// conventionally ≥700, and `.semibold` (600) already takes the ≥18pt half, so
+/// `.medium` cannot take the bold half either — and as with every case here,
+/// the classification errs toward over-strictness, never the other way. Both
+/// the `largeTextThreshold` switch and ``init(_:)`` are written so a new weight
 /// cannot arrive without that decision — the first by having no `default:`, the
-/// second by recording an issue. The live case waiting on it:
-/// `PredictionOutcomeBadge`'s streak sub-label, `.caption.weight(.medium)`
-/// (#1495).
+/// second by recording an issue.
+///
+/// The live case `.medium` serves: `PredictionOutcomeBadge`'s streak
+/// sub-label, `.caption.weight(.medium)`
+/// (`Views/Components/PredictionOutcomeBadge.swift`).
 ///
 /// File scope per `.claude/rules/testing.md` § "Splitting a Suite Across Files":
 /// helpers in a sibling file live outside the suite struct.
 enum WashLabelWeight: CaseIterable {
   case regular
+  case medium
   case semibold
   case bold
 
@@ -196,12 +197,13 @@ enum WashLabelWeight: CaseIterable {
   /// both of its figures live, the way it already takes `size`.
   ///
   /// Records an issue rather than folding an unmodelled weight into `.regular`:
-  /// silently defaulting is safe in outcome but erases the "a fourth weight is a
+  /// silently defaulting is safe in outcome but erases the "a new weight is a
   /// decision" property this type exists to hold.
   init(_ weight: Font.Weight) {
     switch weight {
     case .bold, .heavy, .black: self = .bold
     case .semibold: self = .semibold
+    case .medium: self = .medium
     case .regular, .light, .thin, .ultraLight: self = .regular
     default:
       Issue.record("unmodelled Font.Weight — decide its WCAG half in WashLabelWeight")
@@ -214,7 +216,7 @@ enum WashLabelWeight: CaseIterable {
   var largeTextThreshold: Double {
     switch self {
     case .bold: 14
-    case .regular, .semibold: 18
+    case .regular, .medium, .semibold: 18
     }
   }
 
@@ -225,10 +227,10 @@ enum WashLabelWeight: CaseIterable {
   func admitsAsNormalText(pointSize: Double) -> Bool { pointSize < largeTextThreshold }
 }
 
-/// The failure message the three wash fixtures share when a row is large text.
+/// The failure message the fixtures share when a row is large text.
 ///
-/// One wording in one place: three byte-identical string literals across files
-/// would be a mirror like any other.
+/// One wording in one place: several byte-identical string literals across
+/// files would be a mirror like any other.
 ///
 /// **It carries the repair direction because the cheapest repair is wrong.**
 /// `#expect` does not short-circuit, so a rejected row reddens twice — here,
@@ -247,8 +249,7 @@ func largeTextRejection(_ name: String, pointSize: Double, weight: WashLabelWeig
 
 /// Point sizes of the semantic SwiftUI text styles the wash fixtures use, at
 /// the default `.large` content size — and the reference for what a row's
-/// `pointSize` means in either regime, for both ``MossWashSite`` and
-/// ``InkWashSite``.
+/// `pointSize` means in either regime, for every row type in this suite.
 ///
 /// **The split is fixed-size vs scaling, not which expression the view wrote.**
 /// *Fixed size* covers every `.system(size:)` label — from a `Typography.*`

--- a/Pastura/PasturaTests/Views/DesignTokensTests+WashLabelTypeSize.swift
+++ b/Pastura/PasturaTests/Views/DesignTokensTests+WashLabelTypeSize.swift
@@ -302,8 +302,8 @@ enum WashLabelSemanticSize {
 ///
 /// **Lives in this file rather than in a fixture** because two fixtures
 /// share it — `DesignTokensTests+MossSoftGround.swift`'s
-/// `mossSoftTextSites`, and the #1427 label rows
-/// `DesignTokensTests+MutedTranscript.swift` will carry — and a row type
+/// `mossSoftTextSites`, and `DesignTokensTests+MutedTranscript.swift`'s
+/// `predictionBadgeLabelSites` (the #1427 labels) — and a row type
 /// shared by two fixtures is criterion-level, per this file's header
 /// ownership split.
 ///


### PR DESCRIPTION
## Summary

#1468 made the WCAG large-text admission criterion executable for the three wash fixtures; two siblings in the same suite still carried the unexecuted form — `+MossSoftGround`'s `textBar` over a `[String]` list with a superlative on top (the shape #1466 falsified), and `+MutedAsContent`'s `contentTextBar`. Both are now executed per row.

- **`WashLabelWeight.medium`** — the obstacle common to both fixtures (`PredictionOutcomeBadge`'s streak sub-label is `.caption.weight(.medium)`). Takes the ≥18pt half: `.semibold` (600) already takes it, so `.medium` (500) cannot take the bold half, and every misclassification stays over-strict. All nine named `Font.Weight` statics are now modelled and the struct has no public initializer, so the `withKnownIssue` probe lost its only input; it is replaced by an explicit `.medium → .medium` pin — the one assertion that can tell a named arm from a fold into `.regular` (both land on 18pt).
- **`OpaqueLabelSite`** — a third row type (`name`, `pointSize`, `weight`, `isNormalText`), with no ground fields because an opaque token fill occludes whatever sits behind it. Declared in `+WashLabelTypeSize` since two fixtures share it; gets its own negative control like the two wash row types.
- **`mossSoftTextSites`** promoted to `[OpaqueLabelSite]` (12pt semibold ×2, 12pt medium, 10pt bold — hand-recorded against the views), asserted per row; superlative and ⚠️ paragraph deleted.
- **`+MutedAsContent`** — the two floor arms' labels (#1427 miss arm / streak) carry rows and an admission arm in `+MutedTranscript`, per `+MutedAsContent`'s own header (it sits at SwiftLint's 400-line cap and routes new arms to that sibling; net −4 lines there). The ceiling arms stay ground-oriented, stated in the doc.

The occupancy dependency the issue named (#1448) closed 2026-08-22, so nothing here is deferred.

## Test plan

- [x] `scripts/xcodebuild.sh test -skip-testing:PasturaUITests` — 3557 tests / 286 suites passed (`DesignTokensTests` grew 141 → 143: `opaqueLabelSiteRejectsLargeTextLabels`, `predictionBadgeLabelsAreNormalTextSoTheContentBarApplies`)
- [x] `swiftlint lint --quiet --strict` — clean; `+MutedAsContent.swift` 397 → 393 lines
- UI tests skipped: test-only change under `PasturaTests/Views/`, no view code touched

## Review

Reviewer: **Opus** (`code-reviewer`) — Verdict PASS, 0 Critical / 2 Warning / 5 Suggestion. All five hand-recorded font rows verified against the views. Follow-ups in `c6806c4c`:

- **Applied** W1 — the rewritten `contentTextBar` doc read as if every floor consumer were executed; it now names the two that are not (`+MutedDirection`'s selected-`ModelRow` arm on a wash, `+MutedTranscript`'s `page` arm = `ViewerPredictionSheet` countdown). Their labels' size is still observed by nothing — a residual this PR states rather than closes; rows would need a wash-type fixture, out of #1495's scope.
- **Applied** W2 — the streak label is hand-recorded in two fixtures; each doc now names the other.
- **Applied** S1 (tense), S2 (arms vs labels wording), S3 (the split's residual documented).
- **Rejected** S4 (header note on where a fourth row type goes) — `+WashLabelTypeSize` has 41 lines of headroom and no fourth type is in sight; naming a home now would be a guess, not a decision.
- **No change** S5 — `WashLabelWeight.init(_:)`'s `default:` arm is undrivable by test (no public `Font.Weight` initializer); the doc already states the guard now rests on review.

## Device QA

実機QA不要 — test-only change; no view, inference, or `#if !targetEnvironment(simulator)` code touched.

Closes #1495
