### PR TITLE
📝 docs: memory 棚卸しからの非導出知識の昇格

### DIFF
--- a/.claude/skills/queue-consumer/SKILL.md
+++ b/.claude/skills/queue-consumer/SKILL.md
@@ -38,7 +38,9 @@ Non-goals:
   pre-start skips do not count)
 - Branch: `agent/issue-<N>`; collision fallback `agent/issue-<N>-<YYYYMMDD>`
 - Labels: `agent-ready` (input — human-assigned only), `needs-detail`,
-  `agent-blocked`
+  `agent-blocked`. The write permission needed to assign `agent-ready` is the
+  **sole** security wall; there is deliberately no issue-author gate, so
+  external reports on this public repo stay processable — don't add one.
 - Digest: `data/queue/digest.md` — a gitignored **local log** in the main
   checkout (the helper script resolves it; the worktree's copy would die
   with the worktree, and it bootstraps the file if absent)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -11,7 +11,8 @@
 Pastura is deliberately a スルメ (surume / dried-squid) app: the more you chew,
 the more flavor comes out. Value accrues through repeated experimentation, not
 first-launch wow. Phase 0 showed the on-device LLM's output quality cannot carry
-an entertainment-first proposition; the v0.3 pivot reframed Pastura as an
+an entertainment-first proposition (`docs/phase0/pastura-phase0-assessment.md`);
+the v0.3 pivot (`docs/specs/pastura-mvp-spec-v0_3.md`) reframed Pastura as an
 experiment platform where value comes from the user's own curiosity,
 hypothesis-building, and comparison across runs.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,8 +1,31 @@
 # Pastura — Product Roadmap
 
-> Last updated: 2026-07-10
+> Last updated: 2026-08-25
 > This document defines phase boundaries and scope. When in doubt whether a feature
 > belongs in the current phase, check here first.
+
+---
+
+## Product principles — a "surume" app
+
+Pastura is deliberately a スルメ (surume / dried-squid) app: the more you chew,
+the more flavor comes out. Value accrues through repeated experimentation, not
+first-launch wow. Phase 0 showed the on-device LLM's output quality cannot carry
+an entertainment-first proposition; the v0.3 pivot reframed Pastura as an
+experiment platform where value comes from the user's own curiosity,
+hypothesis-building, and comparison across runs.
+
+When judging a feature proposal:
+
+- **Prefer depth hooks over polish** — features that reward curiosity
+  (inner-thought reveal, run-to-run comparison, export for external analysis)
+  beat features that polish first impressions.
+- **Don't optimize for "wow on first run"** — a single run is a sample of one;
+  favor making many varied runs easy.
+- **Let users build their own hypotheses** (e.g. "why did this LLM conform in
+  Trolley but not Asch?") rather than consuming pre-packaged conclusions.
+- **Keep persona/scenario variation frictionless** (duplicate-and-edit, scenario
+  export) — iterate-and-compare is the core loop.
 
 ---
 

--- a/docs/gallery/README.md
+++ b/docs/gallery/README.md
@@ -207,6 +207,12 @@ non-factory source YAML, e.g. an improved variant). **Step 4 (curation)
 is still yours** — the script promotes the id you name and never picks
 by score.
 
+Promoting from an `/orchestrate` worktree: the factory sources are gitignored
+and exist only in the **main checkout**, while the script writes under the
+current tree (`git rev-parse --show-toplevel` = the worktree). Pass
+`--scenario` / `--run-log` as absolute main-checkout paths — source=main /
+dest=worktree is the working combination.
+
 Then verify the scenario end-to-end (§3 below) and open a PR (§4) — the
 script has already done §1's drafting and §2's registration.
 

--- a/docs/release-setup.md
+++ b/docs/release-setup.md
@@ -99,7 +99,11 @@ distribution (the flag authenticates via that session).
 > Apple's servers, not the Mac's keychain, so there is nothing to export as a
 > `.p12` and a new machine needs no cert of its own — just the signed-in Apple
 > ID + `-allowProvisioningUpdates`. (The `.p12` export route applies only to a
-> traditional, non-cloud "Apple Distribution" certificate.)
+> traditional, non-cloud "Apple Distribution" certificate.) Consequently
+> `security find-identity -v -p codesigning` listing **no** distribution
+> identity on this machine is normal, not a broken setup. If releases ever move
+> to unattended CI, the signed-in-Apple-ID session is unavailable there — pass
+> an ASC API key (App Manager role) to `xcodebuild` instead.
 
 ### 5. Install fastlane
 
@@ -109,6 +113,10 @@ bundle install            # generates Gemfile.lock (recommend committing it)
 
 If `bundle install` fails on the system Ruby (2.6.x), install a newer Ruby
 (`brew install ruby`) and re-run.
+
+Non-interactive shells (scripts, agents) don't read `~/.zshrc`, so the Homebrew
+Ruby silently loses to the system 2.6.x there — prefix `bundle` / `fastlane`
+invocations with an explicit `PATH="/opt/homebrew/opt/ruby/bin:$PATH"`.
 
 ### 6. Verify
 

--- a/docs/release-setup.md
+++ b/docs/release-setup.md
@@ -116,7 +116,9 @@ If `bundle install` fails on the system Ruby (2.6.x), install a newer Ruby
 
 Non-interactive shells (scripts, agents) don't read `~/.zshrc`, so the Homebrew
 Ruby silently loses to the system 2.6.x there — prefix `bundle` / `fastlane`
-invocations with an explicit `PATH="/opt/homebrew/opt/ruby/bin:$PATH"`.
+invocations with an explicit `PATH="/opt/homebrew/opt/ruby/bin:$PATH"`
+(Apple Silicon; on Intel it is `/usr/local/opt/ruby/bin` — `brew --prefix ruby`
+resolves either).
 
 ### 6. Verify
 

--- a/docs/store/README.md
+++ b/docs/store/README.md
@@ -23,7 +23,7 @@ the copy that a human pastes into App Store Connect.
 - **Primary locale**: en (Go criterion = English submission Approved)
 - **URLs** (Support/Marketing are per-locale — despite Apple's canonical
   "required-localizable-and-editable-properties" table claiming app-wide; the
-  real UI wins. Privacy Policy is set in App Information):
+  real UI wins, observed 2026-07. Privacy Policy is set in App Information):
   - en — Support `https://pastura.app/support/` · Marketing `https://pastura.app/`
   - ja — Support `https://pastura.app/ja/support/` · Marketing `https://pastura.app/ja/`
   - Privacy Policy `https://pastura.app/legal/privacy-policy/` (ja: `https://pastura.app/ja/legal/privacy-policy/`)
@@ -32,17 +32,17 @@ the copy that a human pastes into App Store Connect.
 
 Copy is ready; these are the gates around it. Not all are in this repo's scope.
 
-### Hard blockers (ADR-005 §9.2 + #233)
+### Hard blockers (ADR-005 §9.2 + #233) — all cleared for the 1.0 release (2026-07-23)
 
-- [ ] `OllamaService` wrapped out of the release binary; `nm` audit clean (#148)
-- [ ] `PrivacyInfo.xcprivacy` present, required-reason APIs declared (#149)
-- [ ] Support URL landing page live at `https://pastura.app/support/` (#182)
-- [ ] Privacy Policy URL registered in ASC → App Information (#233)
-- [ ] App Privacy questionnaire answered "Data Not Collected" (#233)
+- [x] `OllamaService` wrapped out of the release binary; `nm` audit clean (#148)
+- [x] `PrivacyInfo.xcprivacy` present, required-reason APIs declared (#149)
+- [x] Support URL landing page live at `https://pastura.app/support/` (#182)
+- [x] Privacy Policy URL registered in ASC → App Information (#233)
+- [x] App Privacy questionnaire answered "Data Not Collected" (#233)
 - [x] EU DSA: declare **non-trader** status in ASC → Business (free app, hobby dev) (#233)
       — done for 1.0. The form lives at Business → Agreements → Compliance →
       **Digital Services Act** (account-level, not per-app)
-- [ ] `ITSAppUsesNonExemptEncryption = NO` declared (#159)
+- [x] `ITSAppUsesNonExemptEncryption = NO` declared (#159)
 
 ### Ordering / verification gates (this task surfaced these)
 

--- a/docs/store/README.md
+++ b/docs/store/README.md
@@ -21,7 +21,9 @@ the copy that a human pastes into App Store Connect.
 - **Primary category**: Developer Tools · **Secondary**: Entertainment (per-version editable, not a one-way door)
 - **Age rating**: 13+ (ADR-005 §3.2; 16+ pre-planned fallback)
 - **Primary locale**: en (Go criterion = English submission Approved)
-- **URLs** (Support/Marketing are per-locale; Privacy Policy is set in App Information):
+- **URLs** (Support/Marketing are per-locale — despite Apple's canonical
+  "required-localizable-and-editable-properties" table claiming app-wide; the
+  real UI wins. Privacy Policy is set in App Information):
   - en — Support `https://pastura.app/support/` · Marketing `https://pastura.app/`
   - ja — Support `https://pastura.app/ja/support/` · Marketing `https://pastura.app/ja/`
   - Privacy Policy `https://pastura.app/legal/privacy-policy/` (ja: `https://pastura.app/ja/legal/privacy-policy/`)
@@ -37,7 +39,9 @@ Copy is ready; these are the gates around it. Not all are in this repo's scope.
 - [ ] Support URL landing page live at `https://pastura.app/support/` (#182)
 - [ ] Privacy Policy URL registered in ASC → App Information (#233)
 - [ ] App Privacy questionnaire answered "Data Not Collected" (#233)
-- [ ] EU DSA: declare **non-trader** status in ASC → Business (free app, hobby dev) (#233)
+- [x] EU DSA: declare **non-trader** status in ASC → Business (free app, hobby dev) (#233)
+      — done for 1.0. The form lives at Business → Agreements → Compliance →
+      **Digital Services Act** (account-level, not per-app)
 - [ ] `ITSAppUsesNonExemptEncryption = NO` declared (#159)
 
 ### Ordering / verification gates (this task surfaced these)
@@ -61,3 +65,20 @@ Copy is ready; these are the gates around it. Not all are in this repo's scope.
 | Promotional Text | 170 | 164 | 93 |
 
 (Counts are Unicode code points; ja full-width = 1 each, matching ASC.)
+
+## ASC field locations (observed 2026-07 in the real UI)
+
+Fields whose location the ASC docs don't make findable:
+
+- **Copyright** is a per-version field on the version page, not App Information.
+- **Device requirements** (the ASC-computed compatible-device list): TestFlight
+  → select the build → build metadata → Device requirements.
+
+## Review history (operator notes — never pasted into ASC)
+
+- **1.0 (2026-07): rejected once under 5.1.1(i)/5.1.2(i)**, on the reviewer's
+  false premise that Pastura sends user data to a third-party AI (it is 100%
+  on-device). Approved after rebuttal; the rebuttal is kept permanently in
+  `review-notes.md` § "No third-party AI service" so every later submission
+  pre-empts it. If Phase 3 ever adds a real Cloud API, that posture must be
+  re-derived, not patched (ADR-005 §7.5; ADR-006 when written).


### PR DESCRIPTION
## Summary

auto memory 廃止に伴う棚卸しで、per-user memory にだけ存在した非導出知識をリポの正本へ昇格する（docs-only）。採用基準は #1519 の 2 条件（機械が守るものは書かない / 残すのは違反が黙るものだけ）。

- `docs/store/README.md` — ASC フィールドの実 UI 上の場所（Copyright はバージョンページ / デバイス要件の場所 / Apple 正典テーブルの URL スコープ誤記）、EU DSA フォームの正確な場所、1.0 の 5.1.1(i)/5.1.2(i) リジェクト履歴と Phase 3 時の再導出ポインタ（ADR-005 §7.5）。Hard blockers チェックリストは 1.0 出荷済みの状態に更新。
- `docs/release-setup.md` — cloud-managed 署名では `security find-identity` が空で正常であること、将来 CI 化時の ASC API キー要件、非対話シェルの ruby PATH 罠。
- `docs/ROADMAP.md` — スルメアプリの製品原則（機能提案の判断基準4点、Phase 0 評価と v0.3 spec への参照付き）。
- `docs/gallery/README.md` — worktree からの factory 昇格は source=main 絶対パス / dest=worktree になる仕組み。
- `.claude/skills/queue-consumer/SKILL.md` — `agent-ready` ラベル付与権限が唯一のセキュリティ壁であり、author ゲートを意図的に置かない設計根拠。

計画からの逸脱 2 点: (1) リジェクト履歴の置き場を `review-notes.md` から store README に変更 — `review-notes.md` は ASC にそのまま貼る文書のため、運用ノートを混ぜると Apple に貼られる。(2) 計画項目5の「factory モードは命名不一致で落ちる」はメモリの古い主張で、現行 SKILL は `<factory-id>.yaml` 命名に修正済み（スクリプトの導出パスと一致）のため書かず、worktree パスの罠だけ残した。

## Test plan

docs-only。`precommit-gate-classify.sh` により build / lint とも対象外（pre-commit がスキップを報告）。

## Review

Opus code-reviewer、**PASS**（Critical 0 / Warning 2 / Suggestion 2）。4 件すべて適用:

- Hard blockers の DSA だけ `[x]` にすると他 6 行が「未了」に読める → 全行 `[x]` + 見出しに「1.0 で全クリア」を明記
- Apple 正典テーブル誤記の主張に観測日付なし → `observed 2026-07` を付記
- ROADMAP 製品原則に Phase 0 評価 / v0.3 spec へのポインタを追加
- ruby PATH の Homebrew prefix が Apple Silicon 決め打ち → Intel prefix と `brew --prefix ruby` を併記

未適用 1 件（レビュアー提案の一部）: ADR-017 から製品原則への逆参照追加 — 出荷済み ADR の修正は別 Amendment が要るため本 PR のスコープ外。

## Device QA

実機QA不要 — docs-only、アプリコードに変更なし。

Closes #1547

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A8316HCHQM8Jh3BwHTTBT2
