### PR TITLE
📝 docs: point the worktree pruner's wiring note at USAGE, not a dead bullet

### DIFF
--- a/scripts/prune-stale-worktrees.sh
+++ b/scripts/prune-stale-worktrees.sh
@@ -138,12 +138,17 @@
 #   scripts/prune-stale-worktrees.sh --log FILE   # override the decision log
 #   scripts/prune-stale-worktrees.sh --age-minutes N   # test lever only
 #
+# The wired SessionStart hook needs BOTH flags. `--quiet` alone leaves the
+# default dry run in place, so the hook logs `(dry-run)` decisions forever and
+# removes nothing — silently, because its stdout is discarded (#1543):
+#   ./scripts/prune-stale-worktrees.sh --quiet --apply >/dev/null 2>&1 || true
+#
 # stdout defaults to on when it is a TTY and off otherwise, because the wired
 # caller is a `SessionStart` hook whose stdout is a context-injection channel —
 # printing there would cost every session, every turn. Decisions always go to
-# the log file instead. Nothing in this repository wires that hook: see the
-# "Automated hooks" bullet under CLAUDE.md's "Swift Coding Conventions", which
-# directs it to your own untracked .claude/settings.local.json.
+# the log file instead. Nothing in this repository wires that hook: it belongs
+# in your own untracked .claude/settings.local.json, using the invocation shown
+# under USAGE above.
 #
 # This script exits 0 on every non-fatal path for the same reason: a
 # SessionStart hook that exits non-zero surfaces an error on every session for


### PR DESCRIPTION
## Summary

`scripts/prune-stale-worktrees.sh` のヘッダコメントが、存在しない CLAUDE.md の "Automated hooks" bullet（"Swift Coding Conventions" 配下）を参照していた。この hook をどう配線するかを説明する唯一の箇所が行き止まりになっていた。

- 死んだ参照を削除し、それが運んでいた事実（このリポジトリは hook を配線しない／各自の untracked `.claude/settings.local.json` に書く）だけを残した
- USAGE ブロックに実際の配線例を追記した。**`--apply` 込みで** — その欠落が #1543 の調査で見つかった実害そのもので、`--quiet` のみの hook は既定の dry run のまま `(dry-run)` 判定をログに書き続けて何も削除せず、しかも stdout が捨てられているので気づけない

コメントのみ。挙動の変更なし。

## Test plan

- `bash -n scripts/prune-stale-worktrees.sh` — OK
- pre-commit hook 通過（`scripts/**` の変更なので分類器が `build` を要求 → Xcode ビルド実行・成功。SwiftLint は Swift 未ステージのためスキップ）
- 回帰テスト `scripts/tests/prune-stale-worktrees-test.sh` はコメント文言に依存しないため未実行

## Review

ユーザー指示により `claude-kit:critic`（Step 1b）と `code-reviewer`（Step 4）の両フェーズをスキップし、セルフレビューのみ。実施したセルフチェック: 全文 diff 確認、`bash -n`、旧参照の残存 grep（`Automated hooks` → 0 hit）、周辺コメントとの em dash スタイル一致、他ドキュメントに配線手順のミラーが無いことの確認（`docs/` `CONTRIBUTING.md` `.claude/rules/` で `settings.local.json` は 0 hit）。

## Device QA

実機QA不要 — シェルスクリプトのコメントのみで、アプリのコードパスに触れていない。

Part of #1543

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SZRUkedSidDCG6UqkPtiyc
