### PR TITLE
🐛 fix: add-gallery-entry.sh --update fails opaquely without a usable tty

### DIFF
--- a/docs/gallery/README.md
+++ b/docs/gallery/README.md
@@ -298,7 +298,13 @@ In update mode:
 
 - Fields not overridden by a flag are **preserved** from the existing
   `gallery.json` entry — `--non-interactive` works without forcing
-  every field to be re-supplied.
+  every field to be re-supplied. Any field this script does not
+  manage (ADR-029's `highlight_*`, ADR-020's `min_engine_version` /
+  `featured`) is carried forward unconditionally.
+- Calling this script with no usable tty — CI, or an agent's Bash
+  tool — **requires `--non-interactive`**. Without it, a missing
+  required field or the confirmation prompt tries to read `/dev/tty`
+  and fails.
 - If the candidate entry is byte-identical to the existing one (no
   flag overrides AND unchanged YAML body), the script exits 0 with
   *No change needed* — `updated_at` is **not** bumped, so re-running

--- a/scripts/add-gallery-entry.sh
+++ b/scripts/add-gallery-entry.sh
@@ -432,20 +432,25 @@ fi
 
 # --- Build candidate entry -------------------------------------------------
 
-# ADR-029 highlight fields are derivable from neither the YAML nor any flag of
-# this script, and update mode replaces the entry wholesale — so without this
-# carry-forward, `--update` on a highlighted entry drops them. The post-validate
-# gate then fails on the orphaned highlight file and restores the backup, so
-# nothing is destroyed, but the error names an orphan and never mentions the
-# dropped fields.
+# ADR-029 highlight fields (and any other key this script does not manage —
+# e.g. ADR-020's `min_engine_version`, `featured`) are derivable from neither
+# the YAML nor any flag of this script, and update mode replaces the entry
+# wholesale — so without this carry-forward, `--update` drops them silently.
+# A dropped highlight field trips the post-validate gate (orphaned highlight
+# file) and restores the backup, so nothing is destroyed there — but a
+# dropped `min_engine_version` / `featured` has no such gate and would
+# silently vanish.
 #
-# Selected by `highlight_` prefix rather than by naming the two keys: the
-# fail-safe direction is carrying an unrecognised field, not dropping it, and a
-# field added to the contract later would otherwise vanish unnoticed.
-HIGHLIGHT_FIELDS='{}'
+# Selected by "every key NOT in the fields this script manages" rather than a
+# `highlight_` prefix allowlist: the fail-safe direction is carrying an
+# unrecognised field, not dropping it, so a field added to the contract later
+# is carried forward automatically instead of vanishing unnoticed.
+EXTRA_FIELDS='{}'
 if [ "$MODE" = "update" ]; then
-  HIGHLIGHT_FIELDS=$(printf '%s' "$EXISTING_ENTRY" \
-    | jq -c 'with_entries(select(.key | startswith("highlight_")))')
+  EXTRA_FIELDS=$(printf '%s' "$EXISTING_ENTRY" \
+    | jq -c 'del(.id, .title, .category, .description, .author,
+      .recommended_model, .estimated_inferences, .agent_count, .rounds,
+      .phases, .language, .yaml_url, .yaml_sha256, .added_at)')
 fi
 
 NEW_ENTRY=$(jq -n \
@@ -462,7 +467,7 @@ NEW_ENTRY=$(jq -n \
   --arg language "$YAML_LANGUAGE" \
   --arg yaml_url "$YAML_BASENAME" \
   --arg yaml_sha256 "$YAML_SHA" \
-  --argjson highlight "$HIGHLIGHT_FIELDS" \
+  --argjson extra "$EXTRA_FIELDS" \
   --arg added_at "$ADDED_AT" \
   '{
     id: $id,
@@ -479,7 +484,7 @@ NEW_ENTRY=$(jq -n \
     yaml_url: $yaml_url,
     yaml_sha256: $yaml_sha256
   }
-  + $highlight
+  + $extra
   + {
     added_at: $added_at
   }')

--- a/scripts/add-gallery-entry.sh
+++ b/scripts/add-gallery-entry.sh
@@ -124,8 +124,9 @@ ADD_GALLERY_TTY="${PASTURA_ADD_GALLERY_TTY:-/dev/tty}"
 # Opens $ADD_GALLERY_TTY on fd 3 and reads one line into $1. `[ -e /dev/tty ]`
 # and `[ -t 0 ]` both under/over-detect (the device node can exist but fail
 # to open — ENXIO — or stdin can be a pipe while the tty is fine), so this
-# probes with a real `exec` open and reports the actionable fix on failure
-# instead of the raw shell error ("Device not configured").
+# probes with a real open (in a subshell — see below) and reports the
+# actionable fix on failure instead of the raw shell error ("Device not
+# configured").
 # Locals are `__rft_`-prefixed: `printf -v "$1"` targets a variable by name,
 # and a caller (e.g. prompt_required) that also has a local `value` would
 # otherwise collide with an unprefixed local here — bash resolves `-v`'s
@@ -462,17 +463,17 @@ fi
 # Selected by "every key NOT in the fields this script manages" rather than a
 # `highlight_` prefix allowlist: the fail-safe direction is carrying an
 # unrecognised field, not dropping it, so a field added to the contract later
-# is carried forward automatically instead of vanishing unnoticed. `del(...)`
-# below is a hand-maintained mirror of the managed-key set built into
-# `NEW_ENTRY` just after — merged as `$extra + {managed fields}` (managed
-# fields win) so that if the two lists ever desync, a stale carried-forward
-# value can only be shadowed by a fresh one, never the reverse.
-EXTRA_FIELDS='{}'
+# is carried forward automatically instead of vanishing unnoticed. The
+# managed-key set is named once, inline in the jq filter below, and used
+# both to filter `$extra_raw` down to the truly-unmanaged keys AND to build
+# the object — so there is no second, hand-maintained key list that could
+# desync from it. Managed fields are also emitted first, preserving
+# existing entries' key order (curator-readable diffs;
+# scripts/tests/gallery-highlight-test.sh asserts highlight_url's position
+# relative to yaml_sha256).
+EXTRA_RAW='{}'
 if [ "$MODE" = "update" ]; then
-  EXTRA_FIELDS=$(printf '%s' "$EXISTING_ENTRY" \
-    | jq -c 'del(.id, .title, .category, .description, .author,
-      .recommended_model, .estimated_inferences, .agent_count, .rounds,
-      .phases, .language, .yaml_url, .yaml_sha256, .added_at)')
+  EXTRA_RAW=$(printf '%s' "$EXISTING_ENTRY" | jq -c '.')
 fi
 
 NEW_ENTRY=$(jq -n \
@@ -489,10 +490,9 @@ NEW_ENTRY=$(jq -n \
   --arg language "$YAML_LANGUAGE" \
   --arg yaml_url "$YAML_BASENAME" \
   --arg yaml_sha256 "$YAML_SHA" \
-  --argjson extra "$EXTRA_FIELDS" \
+  --argjson extra_raw "$EXTRA_RAW" \
   --arg added_at "$ADDED_AT" \
-  '$extra
-  + {
+  '{
     id: $id,
     title: $title,
     category: $category,
@@ -505,9 +505,12 @@ NEW_ENTRY=$(jq -n \
     phases: $phases,
     language: $language,
     yaml_url: $yaml_url,
-    yaml_sha256: $yaml_sha256,
-    added_at: $added_at
-  }')
+    yaml_sha256: $yaml_sha256
+  } as $managed
+  | (($managed | keys_unsorted) + ["added_at"]) as $managed_keys
+  | $managed
+  + ($extra_raw | with_entries(select(.key as $k | ($managed_keys | index($k)) | not)))
+  + { added_at: $added_at }')
 
 # --- update-mode no-op short-circuit --------------------------------------
 #

--- a/scripts/add-gallery-entry.sh
+++ b/scripts/add-gallery-entry.sh
@@ -51,9 +51,17 @@
 #                                preserved from existing entry.
 #   --non-interactive           fail if any required field is missing
 #                                (no prompts, no confirmation). In
-#                                update mode, all fields default to
-#                                existing-entry values, so this works
-#                                without overrides.
+#                                update mode, fields not overridden by a
+#                                flag default to the existing entry's
+#                                values (and any field this script does
+#                                not manage — e.g. ADR-029 highlight_*,
+#                                ADR-020 min_engine_version/featured — is
+#                                carried forward unconditionally), so
+#                                this works without overrides. REQUIRED
+#                                for a caller with no usable tty (CI, an
+#                                agent's Bash tool): without it, a
+#                                missing field or the confirmation
+#                                prompt tries to read /dev/tty and fails.
 #
 # Failure modes — chosen behavior:
 #

--- a/scripts/add-gallery-entry.sh
+++ b/scripts/add-gallery-entry.sh
@@ -126,18 +126,28 @@ ADD_GALLERY_TTY="${PASTURA_ADD_GALLERY_TTY:-/dev/tty}"
 # to open — ENXIO — or stdin can be a pipe while the tty is fine), so this
 # probes with a real `exec` open and reports the actionable fix on failure
 # instead of the raw shell error ("Device not configured").
+# Locals are `__rft_`-prefixed: `printf -v "$1"` targets a variable by name,
+# and a caller (e.g. prompt_required) that also has a local `value` would
+# otherwise collide with an unprefixed local here — bash resolves `-v`'s
+# target against the nearest matching scope, silently writing this
+# function's own local instead of the caller's.
 read_from_tty() {
-  local var_name="$1"
-  local prompt="$2"
+  local __rft_var_name="$1"
+  local __rft_prompt="$2"
+  # Probed in a subshell first: `exec 3<file 2>/dev/null` with no command
+  # after it makes bash's redirections PERMANENT for the rest of the
+  # script — a failed open would silently swallow every later `>&2`
+  # prompt/error, not just this one. `(: 3<file) 2>/dev/null` scopes both
+  # the open attempt and the stderr suppression to the subshell.
   if ! (: 3<"$ADD_GALLERY_TTY") 2>/dev/null; then
-    echo "ERROR: cannot read from $ADD_GALLERY_TTY to prompt for $prompt — pass --non-interactive instead" >&2
+    echo "ERROR: cannot read from $ADD_GALLERY_TTY to prompt for $__rft_prompt — pass --non-interactive instead" >&2
     exit 1
   fi
-  local value
+  local __rft_value
   exec 3<"$ADD_GALLERY_TTY"
-  read -r value <&3
+  read -r __rft_value <&3
   exec 3<&-
-  printf -v "$var_name" '%s' "$value"
+  printf -v "$__rft_var_name" '%s' "$__rft_value"
 }
 
 ROOT="$(git rev-parse --show-toplevel)"
@@ -452,7 +462,11 @@ fi
 # Selected by "every key NOT in the fields this script manages" rather than a
 # `highlight_` prefix allowlist: the fail-safe direction is carrying an
 # unrecognised field, not dropping it, so a field added to the contract later
-# is carried forward automatically instead of vanishing unnoticed.
+# is carried forward automatically instead of vanishing unnoticed. `del(...)`
+# below is a hand-maintained mirror of the managed-key set built into
+# `NEW_ENTRY` just after — merged as `$extra + {managed fields}` (managed
+# fields win) so that if the two lists ever desync, a stale carried-forward
+# value can only be shadowed by a fresh one, never the reverse.
 EXTRA_FIELDS='{}'
 if [ "$MODE" = "update" ]; then
   EXTRA_FIELDS=$(printf '%s' "$EXISTING_ENTRY" \
@@ -477,7 +491,8 @@ NEW_ENTRY=$(jq -n \
   --arg yaml_sha256 "$YAML_SHA" \
   --argjson extra "$EXTRA_FIELDS" \
   --arg added_at "$ADDED_AT" \
-  '{
+  '$extra
+  + {
     id: $id,
     title: $title,
     category: $category,
@@ -490,10 +505,7 @@ NEW_ENTRY=$(jq -n \
     phases: $phases,
     language: $language,
     yaml_url: $yaml_url,
-    yaml_sha256: $yaml_sha256
-  }
-  + $extra
-  + {
+    yaml_sha256: $yaml_sha256,
     added_at: $added_at
   }')
 

--- a/scripts/add-gallery-entry.sh
+++ b/scripts/add-gallery-entry.sh
@@ -111,6 +111,27 @@ if ! python3 -c "import yaml" 2>/dev/null; then
   exit 1
 fi
 
+ADD_GALLERY_TTY="${PASTURA_ADD_GALLERY_TTY:-/dev/tty}"
+
+# Opens $ADD_GALLERY_TTY on fd 3 and reads one line into $1. `[ -e /dev/tty ]`
+# and `[ -t 0 ]` both under/over-detect (the device node can exist but fail
+# to open — ENXIO — or stdin can be a pipe while the tty is fine), so this
+# probes with a real `exec` open and reports the actionable fix on failure
+# instead of the raw shell error ("Device not configured").
+read_from_tty() {
+  local var_name="$1"
+  local prompt="$2"
+  if ! (: 3<"$ADD_GALLERY_TTY") 2>/dev/null; then
+    echo "ERROR: cannot read from $ADD_GALLERY_TTY to prompt for $prompt — pass --non-interactive instead" >&2
+    exit 1
+  fi
+  local value
+  exec 3<"$ADD_GALLERY_TTY"
+  read -r value <&3
+  exec 3<&-
+  printf -v "$var_name" '%s' "$value"
+}
+
 ROOT="$(git rev-parse --show-toplevel)"
 GALLERY_DIR="$ROOT/docs/gallery"
 GALLERY_JSON="$GALLERY_DIR/gallery.json"
@@ -340,7 +361,7 @@ prompt_required() {
   fi
   printf "%s: " "$label" >&2
   local value
-  read -r value < /dev/tty
+  read_from_tty value "$label"
   if [ -z "$value" ]; then
     echo "ERROR: $label cannot be empty" >&2
     exit 1
@@ -538,7 +559,8 @@ if [ "$NON_INTERACTIVE" != "1" ]; then
   echo "" >&2
   echo "  updated_at: $UPDATED_AT" >&2
   printf "Proceed? [y/N]: " >&2
-  read -r confirm < /dev/tty
+  confirm=""
+  read_from_tty confirm "confirmation"
   if [ "$confirm" != "y" ] && [ "$confirm" != "Y" ]; then
     echo "Aborted." >&2
     exit 0

--- a/scripts/tests/gallery-scripts-test.sh
+++ b/scripts/tests/gallery-scripts-test.sh
@@ -238,6 +238,40 @@ expect_ok "A10 update exits 0"
 runc "$R" jq -r '.scenarios[0] | "\(.min_engine_version) \(.featured)"' docs/gallery/gallery.json
 expect_out "1.2.0 1" "A10 unmanaged keys carried forward"
 
+# A11 — prompt_required (interactive add mode, missing --category) writes
+# back to the CALLER's variable, not a same-named local inside
+# read_from_tty. Regression for a variable-name collision that made every
+# interactive required-field prompt fail with "cannot be empty" while A8/A9
+# (which use a non-colliding var name, "confirm") stayed green. The tty
+# seam replays the same first line on every read (each call reopens the
+# file at offset 0), so the answer also reaches the confirmation prompt —
+# "creative" != y/Y aborts cleanly. A live bug would instead exit 1 with
+# "category cannot be empty" before ever reaching the confirmation prompt.
+R="$(new_repo)"; mk_gallery_yaml "$R" prompt_v1 4 2
+mkdir -p "$R/Pastura/Pastura/Models"
+printf 'case creative = "creative"\n' > "$R/Pastura/Pastura/Models/GalleryScenario.swift"
+printf 'creative\n' > "$R/fake-tty"
+runc "$R" env PASTURA_ADD_GALLERY_TTY="$R/fake-tty" bash scripts/add-gallery-entry.sh \
+  docs/gallery/prompt_v1.yaml \
+  --recommended-model gemma-4-e2b-q4-k-m --estimated-inferences 8 \
+  --description card --author tester
+expect_ok "A11 prompted category reaches confirmation, not a hard error"
+expect_out "Aborted." "A11 prompted category propagated to caller"
+
+# A12 — a flag override wins over the pre-existing value in update mode,
+# even after widening the carry-forward (--recommended-model must not be
+# shadowed by $extra's unmanaged-field carry-forward).
+R="$(new_repo)"; mk_gallery_yaml "$R" ov_v1 4 2
+runc "$R" bash scripts/add-gallery-entry.sh docs/gallery/ov_v1.yaml \
+  --category creative --recommended-model gemma-4-e2b-q4-k-m \
+  --estimated-inferences 8 --description card --author tester --non-interactive
+expect_ok "A12 add exits 0"
+runc "$R" bash scripts/add-gallery-entry.sh --update ov_v1 \
+  --recommended-model qwen-3-4b-q4-k-m --non-interactive
+expect_ok "A12 update exits 0"
+runc "$R" jq -r '.scenarios[0].recommended_model' docs/gallery/gallery.json
+expect_out "qwen-3-4b-q4-k-m" "A12 flag override wins over existing value"
+
 # A3 — filename stem != YAML id rejected.
 R="$(new_repo)"; mk_gallery_yaml "$R" wrongstem 4 2
 # Rewrite the internal id so stem (wrongstem) != id (otherid).

--- a/scripts/tests/gallery-scripts-test.sh
+++ b/scripts/tests/gallery-scripts-test.sh
@@ -212,6 +212,19 @@ if [ "$SHA_BEFORE" != "$SHA_AFTER" ]; then PASS=$((PASS + 1)); else bad "A4 sha 
 runc "$R" bash scripts/add-gallery-entry.sh --update foo_v1 --non-interactive
 expect_ok "A5 no-op update exits 0"; expect_out "No change needed" "A5 no-op message"
 
+# A8 — without --non-interactive, an unopenable tty seam fails with an
+# actionable message naming --non-interactive (not the raw shell error).
+mk_gallery_yaml "$R" foo_v1 5 3 "a8 body"
+runc "$R" env PASTURA_ADD_GALLERY_TTY="$R/no-such-tty" bash scripts/add-gallery-entry.sh --update foo_v1
+expect_fail "A8 unopenable tty fails"
+expect_out "pass --non-interactive instead" "A8 actionable message"
+
+# A9 — a readable file substituted for the tty seam is consumed normally
+# (positive counterpart to A8 — guards against an always-firing check).
+printf 'y\n' > "$R/fake-tty"
+runc "$R" env PASTURA_ADD_GALLERY_TTY="$R/fake-tty" bash scripts/add-gallery-entry.sh --update foo_v1
+expect_ok "A9 fake-tty confirm exits 0"; expect_out "Updated entry" "A9 fake-tty update message"
+
 # A3 — filename stem != YAML id rejected.
 R="$(new_repo)"; mk_gallery_yaml "$R" wrongstem 4 2
 # Rewrite the internal id so stem (wrongstem) != id (otherid).

--- a/scripts/tests/gallery-scripts-test.sh
+++ b/scripts/tests/gallery-scripts-test.sh
@@ -225,6 +225,19 @@ printf 'y\n' > "$R/fake-tty"
 runc "$R" env PASTURA_ADD_GALLERY_TTY="$R/fake-tty" bash scripts/add-gallery-entry.sh --update foo_v1
 expect_ok "A9 fake-tty confirm exits 0"; expect_out "Updated entry" "A9 fake-tty update message"
 
+# A10 — --update carries forward a key this script does not manage (e.g.
+# ADR-020's min_engine_version / featured), not just highlight_*-prefixed
+# ones — regression for the old highlight_-prefix-only allowlist silently
+# dropping any other unrecognized field.
+jq '.scenarios[0].min_engine_version = "1.2.0" | .scenarios[0].featured = 1' \
+  "$R/docs/gallery/gallery.json" > "$R/docs/gallery/gallery.json.t"
+mv "$R/docs/gallery/gallery.json.t" "$R/docs/gallery/gallery.json"
+mk_gallery_yaml "$R" foo_v1 5 3 "a10 body"
+runc "$R" bash scripts/add-gallery-entry.sh --update foo_v1 --non-interactive
+expect_ok "A10 update exits 0"
+runc "$R" jq -r '.scenarios[0] | "\(.min_engine_version) \(.featured)"' docs/gallery/gallery.json
+expect_out "1.2.0 1" "A10 unmanaged keys carried forward"
+
 # A3 — filename stem != YAML id rejected.
 R="$(new_repo)"; mk_gallery_yaml "$R" wrongstem 4 2
 # Rewrite the internal id so stem (wrongstem) != id (otherid).

--- a/scripts/tests/gallery-scripts-test.sh
+++ b/scripts/tests/gallery-scripts-test.sh
@@ -257,20 +257,41 @@ runc "$R" env PASTURA_ADD_GALLERY_TTY="$R/fake-tty" bash scripts/add-gallery-ent
   --description card --author tester
 expect_ok "A11 prompted category reaches confirmation, not a hard error"
 expect_out "Aborted." "A11 prompted category propagated to caller"
+case "$OUT" in
+  *"cannot be empty"*) bad "A11 category prompt regressed to the shadowing bug" ;;
+  *) PASS=$((PASS + 1)) ;;
+esac
 
-# A12 — a flag override wins over the pre-existing value in update mode,
-# even after widening the carry-forward (--recommended-model must not be
-# shadowed by $extra's unmanaged-field carry-forward).
+# A12 — a flag override wins over an unmanaged carried-forward key of the
+# SAME name colliding with a managed field would be impossible (the
+# managed-key set is derived from the constructed object itself, not a
+# second hand-maintained list, so the two cannot desync by construction).
+# What remains to pin: (1) a flag override still wins over the pre-existing
+# managed value, and (2) an unmanaged field lands AFTER the managed fields
+# and BEFORE added_at in the emitted entry — the ordering
+# scripts/tests/gallery-highlight-test.sh's H35 depends on for the real
+# ADR-029 highlight_* fields (a plain unmanaged key here, not
+# highlight_url/highlight_sha256, to avoid check-gallery-entry.sh's
+# highlight-validator gate, which this sandboxed repo doesn't scaffold).
 R="$(new_repo)"; mk_gallery_yaml "$R" ov_v1 4 2
 runc "$R" bash scripts/add-gallery-entry.sh docs/gallery/ov_v1.yaml \
   --category creative --recommended-model gemma-4-e2b-q4-k-m \
   --estimated-inferences 8 --description card --author tester --non-interactive
 expect_ok "A12 add exits 0"
+jq '.scenarios[0].min_engine_version = "1.2.0"' \
+  "$R/docs/gallery/gallery.json" > "$R/docs/gallery/gallery.json.t"
+mv "$R/docs/gallery/gallery.json.t" "$R/docs/gallery/gallery.json"
 runc "$R" bash scripts/add-gallery-entry.sh --update ov_v1 \
   --recommended-model qwen-3-4b-q4-k-m --non-interactive
 expect_ok "A12 update exits 0"
 runc "$R" jq -r '.scenarios[0].recommended_model' docs/gallery/gallery.json
 expect_out "qwen-3-4b-q4-k-m" "A12 flag override wins over existing value"
+runc "$R" jq -r '.scenarios[0] | keys_unsorted | index("yaml_sha256")' docs/gallery/gallery.json
+YAML_SHA_IDX="$OUT"
+runc "$R" jq -r '.scenarios[0] | keys_unsorted | index("min_engine_version")' docs/gallery/gallery.json
+expect_out "$((YAML_SHA_IDX + 1))" "A12 unmanaged key ordered directly after managed fields"
+runc "$R" jq -r '.scenarios[0] | keys_unsorted | last' docs/gallery/gallery.json
+expect_out "added_at" "A12 added_at stays the last key"
 
 # A3 — filename stem != YAML id rejected.
 R="$(new_repo)"; mk_gallery_yaml "$R" wrongstem 4 2


### PR DESCRIPTION
## Summary

- Investigation on main falsified issue #1546's premise: `--update <id> --non-interactive` already writes non-interactively and passes post-validate (existing tests A4/A5 cover it). The actual PR #1535 blocker was ADR-029's highlight sha pin, unrelated to tty. Scope narrowed to fixing the opaque failure a non-`--non-interactive` caller with no tty hits, plus a latent field-drop bug found while auditing the update-mode carry-forward.
- `scripts/add-gallery-entry.sh --update`'s two `/dev/tty` reads now probe openability first and report an actionable `--non-interactive` hint instead of a raw `Device not configured` error.
- Widened the update-mode field carry-forward from a `highlight_`-prefix allowlist to every key the script doesn't manage, so ADR-020's `min_engine_version` / `featured` (and any future unmanaged field) survive `--update` instead of silently vanishing.
- Documented the `--non-interactive` requirement for non-tty callers (agents, CI) in the README and `--help` text.

## Test plan

- `bash scripts/tests/gallery-scripts-test.sh` — 62 passed, 0 failed (also under `/bin/bash` for bash 3.2 coverage).
- `bash scripts/tests/gallery-highlight-test.sh` — 201 passed, 0 failed (H35 key-ordering regression from the fix round's first attempt is now fixed and covered).
- `scripts/xcodebuild.sh test` — full local suite incl. UI tests: `** TEST SUCCEEDED **`.
- Manual end-to-end sanity against the real `docs/gallery/gallery.json`: `--update asch_conformity_v1 --non-interactive` (a highlighted entry) still no-ops byte-identically; `scripts/check-gallery-entry.sh --all` passes.

## Review

Reviewer: Opus (`code-reviewer`), two rounds (policy max):

- **Round 1** (full branch diff) — FAIL, 1 critical + 2 warnings. Fixed: a variable-name collision in the new `read_from_tty` helper (`local value` inside the helper shadowed `prompt_required`'s identically-named local via `printf -v`) broke every interactive add-mode prompt; an update-mode merge-order hazard where a future desync between the field carry-forward's key list and the managed-field set could let a stale value silently win; added regression tests for both.
- **Round 2** (fix-diff only, since the fix introduced new logic) — FAIL, 1 critical + 1 warning. The round-1 merge-order fix inverted emitted key order, regressing `gallery-highlight-test.sh`'s H35 (`highlight_url` must sit directly after `yaml_sha256`) and would have churned every highlighted entry's key order on its next `--update`. Fixed by deriving the managed-key set inline from the constructed object (retiring the hand-maintained mirror the round-1 fix introduced) so precedence and ordering can no longer desync by construction; reworked a vacuous test into one that actually exercises flag-override-wins + key ordering.

No third review round per policy; final verification (both shell-test suites, bash 3.2, full `xcodebuild.sh test`, real-gallery sanity check) done directly.

## Device QA

実機QA不要 — shell + docs only, no Swift source touched.

Closes #1546
