### PR TITLE
✨ feat: scenario-factory paper tournament + incubation lane (round 3)

### DIFF
--- a/.claude/skills/scenario-factory/SKILL.md
+++ b/.claude/skills/scenario-factory/SKILL.md
@@ -37,6 +37,15 @@ Non-goals:
   stderr lands in a `.stderr.log` sidecar next to each log)
 - Digest: `data/factory/digest.md` (gitignored local log — appended in
   place, never committed; bootstrapped by `append_digest.py` if absent)
+- Sketch seed bank: `data/factory/sketches/<DATE>.md` (gitignored; the
+  paper tournament of Step 2a, read back as seeds by Step 1(d))
+- Incubator queue: `data/factory/incubator.md` (gitignored; one-line
+  header, bootstrapped by the session on first append — same pattern as
+  `lessons-inbox.md`)
+- **Naming**: a factory `_v2` / `_v3` id suffix means an incubated re-author
+  of a FACTORY candidate (Step 2b lane, Step 4 queue); `/scenario-refine`'s
+  `__v2` (double underscore, under `improvements/`) is an A/B candidate for a
+  SHIPPED scenario — different lanes, different journals.
 - Per-run timeout: `600` seconds (not the harness default 1800 — bounds a
   wedged run at 2 attempts × 600 s)
 - Helper scripts: `.claude/skills/scenario-factory/scripts/` (incl.
@@ -52,7 +61,7 @@ Non-goals:
 
 ## Step 1 — Read prior scenarios (dedup)
 
-Read three sources, in order:
+Read four sources, in order:
 
 - **(a) The PLAYBOOK first** — `.claude/skills/scenario-factory/PLAYBOOK.md`
   (repo-tracked), in full. It is the **GENERATION GATE**: every generated
@@ -66,6 +75,11 @@ Read three sources, in order:
   freshest nuance — last nights' comments, lessons, and axis-rotation context.
   **NEVER read the whole digest** (it exceeds the session Read cap, ~39k
   tokens): read with `offset`/`limit`, or stop at the 2nd `## <date>` heading.
+- **(d) The newest 2 files in `data/factory/sketches/`** as a seed bank —
+  **grep the `### S` heading and `paper:` lines only, never Read them whole**
+  (context budget). A runner-up that lost only on axis-distinctness may be
+  selected tonight; a sketch that lost twice on paper is a saturated-family
+  signal — do not re-sketch it.
 
 Dedup semantics (sourced from (a)+(b)+(c)): the new batch must not repeat same
 premise, same persona cast, or a theme judged ≤2 on humor twice in a row.
@@ -126,32 +140,88 @@ semantics, output-field contract, and cost) and tracking issue #906 (the
 interestingness umbrella — design considerations for every recent / planned
 phase).
 
-## Step 2 — Generate 3 scenario YAMLs
+When the incubation lane fires (Step 2b) the distinct-axis requirement covers
+the 2 fresh slots only — the v2 keeps its original axis. A fired tripwire
+**outranks the lane**: skip the lane that night so the batch stays 3 fresh.
 
-Write 3 files to `data/factory/scenarios/<DATE>/<id>.yaml` with
-`id: factory_<DATESTAMP>_<slug>` (snake_case slug, also the filename).
+## Step 2 — Paper tournament, then generate 3 YAMLs
 
-Theme: **driven by the per-scenario axis from Step 1.5**, not a fixed
-focus. The oogiri / comedy family is a strong default *tone* — use
-`Pastura/Pastura/Resources/Presets/bokete.yaml` as the schema/tone
-reference — but the assigned mechanic axis dictates the *format* (e.g.
-`elimination` → knockout bracket, `branching` → `conditional` divergent
-paths, `reactive_event` → `event_inject`, `scoring_free` → observation /
-discussion with no vote), and an assigned **category** axis may rotate the
-premise out of comedy entirely (a `game_theory` cooperation dilemma, an
-`experimental` social-psych setup à la the original asch/trolley seeds). A
-non-comedy scenario is judged on its own terms — see Step 4. Each of the 3
-must differ from the other 2 AND from digest history in premise or
-mechanics, not merely in topic strings.
+Sketching in-session burns no inference; the harness run (~4–10 min each) is
+the bottleneck, so selecting at sketch level buys ~3× candidate diversity per
+inference minute (第1弾 #952/#955 and 第2弾 #956/#960 tuned judging and lessons;
+this round moves selection BEFORE the run).
 
-**Design defaults — subtract by default (#919):** author the SMALLER shape
-unless the assigned axis needs more. Concretely: **2 output fields**
-(`statement` + `inner_thought`), **3–4 agents**, and **no mandatory scoring**
-(a `narrate` score-free ending or `scoring_free` observation is fine — drop
-`vote → score_calc → summarize` when the payoff is the phenomenon). Each
-addition trades against 2B breakdown rate, tokens, and latency — justify it.
-Canonical guidelines (the numbers live here): `PLAYBOOK.md`
-§ "Subtract by default".
+### 2a — Sketch 8–10 candidates
+
+Sketch into `data/factory/sketches/<DATE>.md` (create the dir). One block each,
+**≤6 lines**: `### S<n> <slug>`, premise (1 line), cast (3–4 personas, 1 line),
+`axis:` (a Step 1.5 target), phase spine + inference estimate (2c formula) on
+one line, PLAYBOOK rules relied on + any `[hypothesis]` lever, and a `paper:`
+line. Span ≥3 distinct Step 1.5 axes, including ≥1 comedy sketch (rule 29). If
+8 are out of budget, sketch at least 5 and say so in the Step 6 report — a
+stated shortfall beats a silent one.
+
+**Paper rubric** (0–2 each, max 8), written as
+`paper: N=<n> R=<n> P=<n> B=<n> total=<n>`:
+
+- **N** novelty — vs digest-index ids/themes + PLAYBOOK saturated families; a
+  topic-skin of a saturated family = 0.
+- **R** rule compliance — any `[validated]` violation = **DQ** (not 0); 2 =
+  every rule relied on is cited.
+- **P** payoff mechanism — arc / humor mechanically forced by a phase or an
+  `assign` rotation = 2; merely hoped for from personas = 0.
+- **B** budget fit — ≤50 = 2, ≤80 = 1, 81–100 = 0, >100 = DQ. Ties break
+  toward the rarer axis.
+
+### 2b — Select
+
+Rank by total; take the top 3 (top 2 when the incubation lane fires) subject to:
+distinct axes across the fresh slots, exactly one comedy slot among the fresh
+slots (rule 29), batch inference ≤ ~120. **Precedence when constraints collide:
+census tripwire > rule-29 comedy slot > incubation lane.** Append a
+`## Selection` block to the sketch file (ranking + one-line reason per
+pick/drop) so Step 1(d) can read it back next night.
+
+**Incubation lane** (max 1 slot per night): if `data/factory/incubator.md` has
+an open entry (line starts with `- open`, `attempts: <2`), the 3rd slot is that
+scenario's v2 — take the OLDEST open entry. Copy its original YAML from
+`data/factory/scenarios/<orig date>/` to
+`data/factory/scenarios/<DATE>/<slug>_v2.yaml` (`_v3` on the second attempt),
+set `id: factory_<DATESTAMP>_<slug>_v2`, and apply ONLY the entry's recorded
+`fix:` — single-lever discipline, so the score delta is attributable (same rule
+as `/scenario-refine`'s A/B). If the original YAML is missing (pruned /
+different checkout), rewrite the entry's leading `- open` to `- retired` with
+` retired: <DATE> source-missing` and skip the lane tonight (all 3 fresh). The
+v2 never counts as the comedy slot even when it is comedy; the lane is skipped
+when the incubator is absent, empty, or all-closed.
+
+### 2c — Author the full YAMLs
+
+For the selected sketches only. Write 3 files to
+`data/factory/scenarios/<DATE>/<id>.yaml` with
+`id: factory_<DATESTAMP>_<slug>` (snake_case slug, also the filename). The
+v2's Step 5 results row: `axis` = `incubator / <original axis>`, and `theme`
+begins `v2 of <original id> — <fix applied>`.
+
+Theme: **driven by the per-scenario axis from Step 1.5**, not a fixed focus. The
+oogiri / comedy family is a strong default *tone* — use
+`Pastura/Pastura/Resources/Presets/bokete.yaml` as the schema/tone reference —
+but the assigned mechanic axis dictates the *format* (e.g. `elimination` →
+knockout bracket, `branching` → `conditional` divergent paths, `reactive_event`
+→ `event_inject`, `scoring_free` → observation / discussion with no vote), and
+an assigned **category** axis may rotate the premise out of comedy entirely (a
+`game_theory` cooperation dilemma, an `experimental` social-psych setup à la the
+original asch/trolley seeds). A non-comedy scenario is judged on its own terms —
+see Step 4. Each of the 3 must differ from the other 2 AND from digest history
+in premise or mechanics, not merely in topic strings.
+
+**Design defaults — subtract by default (#919):** author the SMALLER shape unless
+the assigned axis needs more. Concretely: **2 output fields** (`statement` +
+`inner_thought`), **3–4 agents**, and **no mandatory scoring** (a `narrate`
+score-free ending or `scoring_free` observation is fine — drop
+`vote → score_calc → summarize` when the payoff is the phenomenon). Each addition
+trades against 2B breakdown rate, tokens, and latency — justify it. Canonical
+guidelines (the numbers live here): `PLAYBOOK.md` § "Subtract by default".
 
 Schema requirements (ScenarioLoader — all required):
 
@@ -282,6 +352,32 @@ Failed runs get **no scores** — record the status and the wrapper's
 `error` (skim the partial transcript only to classify the failure for
 the comment). The judge is a quality filter, not a safety screen.
 
+### Incubator (near-miss queue)
+
+After scoring, append to `data/factory/incubator.md` (create with a one-line
+header if absent) when a run is a **near miss**: status `ok`, total ≥ **60% of
+the available max** (15/25; 12/20 when humor is null; 9/15 when humor and
+development both are), AND the judge comment names ONE concrete promotion
+blocker with a mechanical fix mapped to a PLAYBOOK rule or lever (rule 5
+`vote_winner` leak; rule 27 one-note by R3 → rounds cap + `assign` rotation;
+rule 1 field-name drift → guard). A `failed` run whose crash is design-caused
+with a known fix (rules 2/3) also qualifies. NOT a near miss: a vague blocker
+("not funny enough") or a model-limit one (rules 19/28 territory) — those are
+lessons-inbox material. Entry shape (status token line-initial so grep anchors),
+**grep-before-append** so one id is never queued twice:
+
+```
+- open <DATE> <id> total=<n>/<max> blocker: <one line> fix: <one line, single lever> attempts: 0
+```
+
+**v2 outcome** (when tonight ran an incubated v2): update its entry in place —
+blocker cleared AND total ≥ original → change `- open` to `- resolved`, append
+` resolved: <DATE> Δ+<n>`; it is now a **promotion suggestion** (Step 6 reports
+both YAML paths; never auto-promoted — § Promotion). Otherwise bump `attempts:`
+and append ` <DATE>: <why still blocked>`; at 2 attempts change it to
+`- retired` and append ` retired: <DATE>`, so the lane never sinks a third
+night into it.
+
 ## Step 5 — Append the digest
 
 1. Write the results JSON (schema documented in `append_digest.py`'s
@@ -289,7 +385,11 @@ the comment). The judge is a quality filter, not a safety screen.
    yaml, run_log, status, attempts, duration_sec, scores (5 axes: coherence /
    interaction / breakdown_free / humor / development), comment, error) to
    a temp file. Set `axis` to the Step 1.5 axis this scenario targeted (e.g.
-   `"elimination / creative"`) so cross-night rotation can read it back.
+   `"elimination / creative"`) so cross-night rotation can read it back. Keep
+   `notes` a **single line** (a line-initial `## ` or `|` would split the digest
+   section on re-parse): `tournament: <N> sketched → <selected ids>; sketches:
+   data/factory/sketches/<DATE>.md; incubator: <none | v2 of <id> →
+   resolved/blocked/retired>`.
 2. ```bash
    python3 .claude/skills/scenario-factory/scripts/append_digest.py \
      --results /tmp/factory_results_<DATE>.json \
@@ -322,9 +422,11 @@ The inbox is a **PROPOSAL queue only** — the nightly cycle NEVER edits
 Summarize for the user: per-scenario status + scores + best line of the
 night, failures with one-line causes, and where the artifacts live
 (`scenarios/<DATE>/`, `runs/<DATE>/`, the appended digest section; the
-`lessons-inbox.md` entries if any were proposed in Step 5.5). If the index was
-missing (Step 1 fallback), surface the degraded-dedup notice with the
-`--rebuild-index` command.
+`lessons-inbox.md` entries if any were proposed in Step 5.5). Add the tournament
+summary (N sketched, picks with one-line reasons, any shortfall) and the
+incubator outcomes (`resolved` → "ready for promotion" with both YAML paths;
+any `retired` entries). If the index was missing (Step 1 fallback), surface the
+degraded-dedup notice with the `--rebuild-index` command.
 `data/factory/digest.md` is a gitignored local log — the new section is
 appended in place and is NOT committed or pushed. Only *promoting* a
 winning scenario (bundled preset or shared-scenario gallery; see
@@ -343,7 +445,9 @@ via an `/orchestrate` PR either way:
 - **Shared-scenario gallery** (remote — served from `main` via
   `raw.githubusercontent.com`, so **merge is the deploy**): copy to
   `docs/gallery/<slug>_v1.yaml` (rename the YAML's `id:` from
-  `factory_<date>_<slug>` to `<slug>_v1`), then run
+  `factory_<date>_<slug>` to `<slug>_v1`; an incubated `..._v2` / `_v3` drops
+  that suffix too and ships as `<slug>_v1` — it is a generation marker, not a
+  gallery version), then run
   `scripts/add-gallery-entry.sh`. The gallery does **not** pass through the
   blocklist gate — curate by the judge scores yourself (hold back
   low-coherence / low-humor runs). Full bridge: `docs/gallery/README.md`
@@ -365,8 +469,9 @@ human-driven `/orchestrate` PR — same pattern as scenario promotion. The PR:
   (invariant + why + evidence pointer; see the PLAYBOOK header discipline,
   soft cap ~150 lines) — never paste inbox prose verbatim.
 - After merge, an **operator step** CLEARS promoted / duplicate / stale entries
-  from the local inbox. The PR itself can't do this — the inbox is a gitignored
-  local file, invisible to the merge — mirroring how the gitignored digest is
+  from the local inbox, and clears `resolved` / `retired` lines from the local
+  `incubator.md`. The PR itself can't do this — both are gitignored local
+  files, invisible to the merge — mirroring how the gitignored digest is
   maintained locally rather than by the PR.
 
 ## Scheduling (how the unattended run works)
@@ -383,7 +488,8 @@ human-driven `/orchestrate` PR — same pattern as scenario promotion. The PR:
   scenario is a separate `/orchestrate` PR — see § Promotion.)
 - **Run in the user's main checkout — not a throwaway worktree.** The
   gitignored digest, its `digest-index.jsonl` sidecar, `scenarios/<DATE>/`,
-  and `runs/<DATE>/` must persist between nights so the full history stays
+  `runs/<DATE>/`, `sketches/<DATE>.md`, and `incubator.md` (the cross-night
+  near-miss queue) must persist between nights so the full history stays
   available — Step 1 dedup reads the index (rebuilt from the digest); a fresh
   per-run worktree would start with an empty bootstrapped digest and lose that
   history. The digest being gitignored is what keeps the main working tree

--- a/.claude/skills/scenario-factory/SKILL.md
+++ b/.claude/skills/scenario-factory/SKILL.md
@@ -79,7 +79,8 @@ Read four sources, in order:
   **grep the `### S` heading and `paper:` lines only, never Read them whole**
   (context budget). A runner-up that lost only on axis-distinctness may be
   selected tonight; a sketch that lost twice on paper is a saturated-family
-  signal — do not re-sketch it.
+  signal — do not re-sketch it. Also `grep '^- open' data/factory/incubator.md`
+  here, so Step 1.5 already knows whether the incubation lane fires tonight.
 
 Dedup semantics (sourced from (a)+(b)+(c)): the new batch must not repeat same
 premise, same persona cast, or a theme judged ≤2 on humor twice in a row.
@@ -148,13 +149,13 @@ the 2 fresh slots only — the v2 keeps its original axis. A fired tripwire
 
 Sketching in-session burns no inference; the harness run (~4–10 min each) is
 the bottleneck, so selecting at sketch level buys ~3× candidate diversity per
-inference minute (第1弾 #952/#955 and 第2弾 #956/#960 tuned judging and lessons;
-this round moves selection BEFORE the run).
+inference minute (rounds 1–2 tuned judging and lessons; this round moves
+selection BEFORE the run).
 
 ### 2a — Sketch 8–10 candidates
 
 Sketch into `data/factory/sketches/<DATE>.md` (create the dir). One block each,
-**≤6 lines**: `### S<n> <slug>`, premise (1 line), cast (3–4 personas, 1 line),
+**≤7 lines**: `### S<n> <slug>`, premise (1 line), cast (3–4 personas, 1 line),
 `axis:` (a Step 1.5 target), phase spine + inference estimate (2c formula) on
 one line, PLAYBOOK rules relied on + any `[hypothesis]` lever, and a `paper:`
 line. Span ≥3 distinct Step 1.5 axes, including ≥1 comedy sketch (rule 29). If
@@ -176,8 +177,9 @@ stated shortfall beats a silent one.
 ### 2b — Select
 
 Rank by total; take the top 3 (top 2 when the incubation lane fires) subject to:
-distinct axes across the fresh slots, exactly one comedy slot among the fresh
-slots (rule 29), batch inference ≤ ~120. **Precedence when constraints collide:
+distinct axes across the fresh slots, at least one comedy slot among the
+fresh slots (rule 29 is a floor — the humor datapoint), batch inference
+≤ ~120. **Precedence when constraints collide:
 census tripwire > rule-29 comedy slot > incubation lane.** Append a
 `## Selection` block to the sketch file (ranking + one-line reason per
 pick/drop) so Step 1(d) can read it back next night.
@@ -186,8 +188,9 @@ pick/drop) so Step 1(d) can read it back next night.
 an open entry (line starts with `- open`, `attempts: <2`), the 3rd slot is that
 scenario's v2 — take the OLDEST open entry. Copy its original YAML from
 `data/factory/scenarios/<orig date>/` to
-`data/factory/scenarios/<DATE>/<slug>_v2.yaml` (`_v3` on the second attempt),
-set `id: factory_<DATESTAMP>_<slug>_v2`, and apply ONLY the entry's recorded
+`data/factory/scenarios/<DATE>/<id>.yaml` with
+`id: factory_<DATESTAMP>_<slug>_v2` (`_v3` on the second attempt — the file
+follows the id, same as a fresh slot), and apply ONLY the entry's recorded
 `fix:` — single-lever discipline, so the score delta is attributable (same rule
 as `/scenario-refine`'s A/B). If the original YAML is missing (pruned /
 different checkout), rewrite the entry's leading `- open` to `- retired` with
@@ -197,11 +200,12 @@ when the incubator is absent, empty, or all-closed.
 
 ### 2c — Author the full YAMLs
 
-For the selected sketches only. Write 3 files to
-`data/factory/scenarios/<DATE>/<id>.yaml` with
-`id: factory_<DATESTAMP>_<slug>` (snake_case slug, also the filename). The
-v2's Step 5 results row: `axis` = `incubator / <original axis>`, and `theme`
-begins `v2 of <original id> — <fix applied>`.
+For the selected sketches only — write the FRESH files (3, or 2 when the lane
+fired; the v2 already exists from 2b) to `data/factory/scenarios/<DATE>/<id>.yaml`
+with `id: factory_<DATESTAMP>_<slug>` (snake_case slug, also the filename). The
+v2's Step 5 results row keeps `axis` as the original two-part axis (the
+rotation scan reads that column against the census vocabulary) and marks the
+lane in `theme`, which begins `v2 of <original id> — <fix applied>`.
 
 Theme: **driven by the per-scenario axis from Step 1.5**, not a fixed focus. The
 oogiri / comedy family is a strong default *tone* — use
@@ -355,7 +359,10 @@ the comment). The judge is a quality filter, not a safety screen.
 ### Incubator (near-miss queue)
 
 After scoring, append to `data/factory/incubator.md` (create with a one-line
-header if absent) when a run is a **near miss**: status `ok`, total ≥ **60% of
+header if absent) when a **fresh-slot** run is a **near miss** — an incubated
+v2 is never queued as a new entry; its result goes ONLY into the v2-outcome
+update below, or each `_vN` id would restart at `attempts: 0` and defeat the
+cap: status `ok`, total ≥ **60% of
 the available max** (15/25; 12/20 when humor is null; 9/15 when humor and
 development both are), AND the judge comment names ONE concrete promotion
 blocker with a mechanical fix mapped to a PLAYBOOK rule or lever (rule 5
@@ -363,8 +370,9 @@ blocker with a mechanical fix mapped to a PLAYBOOK rule or lever (rule 5
 rule 1 field-name drift → guard). A `failed` run whose crash is design-caused
 with a known fix (rules 2/3) also qualifies. NOT a near miss: a vague blocker
 ("not funny enough") or a model-limit one (rules 19/28 territory) — those are
-lessons-inbox material. Entry shape (status token line-initial so grep anchors),
-**grep-before-append** so one id is never queued twice:
+lessons-inbox material. Entry shape (status token line-initial so grep anchors);
+**grep-before-append on the base `<slug>`**, not the exact id, so a scenario
+family is never queued twice:
 
 ```
 - open <DATE> <id> total=<n>/<max> blocker: <one line> fix: <one line, single lever> attempts: 0
@@ -374,9 +382,9 @@ lessons-inbox material. Entry shape (status token line-initial so grep anchors),
 blocker cleared AND total ≥ original → change `- open` to `- resolved`, append
 ` resolved: <DATE> Δ+<n>`; it is now a **promotion suggestion** (Step 6 reports
 both YAML paths; never auto-promoted — § Promotion). Otherwise bump `attempts:`
-and append ` <DATE>: <why still blocked>`; at 2 attempts change it to
-`- retired` and append ` retired: <DATE>`, so the lane never sinks a third
-night into it.
+and append ` <DATE>: <why still blocked>`; if it now reads `attempts: 2`,
+change `- open` to `- retired` and append ` retired: <DATE>`, so the lane
+never sinks a third night into it.
 
 ## Step 5 — Append the digest
 

--- a/.claude/skills/scenario-factory/scripts/append_digest.py
+++ b/.claude/skills/scenario-factory/scripts/append_digest.py
@@ -39,6 +39,7 @@ Results JSON schema (composed by the /scenario-factory session):
       "axis": "branching / roleplay",   // optional: the under-represented
                                         // gallery axis this scenario targeted
                                         // (SKILL.md Step 1.5); omitted → em-dash
+                                        // an incubated v2 prefixes it: "incubator / <original axis>"
       "yaml": "data/factory/scenarios/2026-06-13/....yaml",
       "run_log": "data/factory/runs/2026-06-13/....jsonl",
       "status": "ok|failed|config_error",

--- a/.claude/skills/scenario-factory/scripts/append_digest.py
+++ b/.claude/skills/scenario-factory/scripts/append_digest.py
@@ -39,7 +39,6 @@ Results JSON schema (composed by the /scenario-factory session):
       "axis": "branching / roleplay",   // optional: the under-represented
                                         // gallery axis this scenario targeted
                                         // (SKILL.md Step 1.5); omitted → em-dash
-                                        // an incubated v2 prefixes it: "incubator / <original axis>"
       "yaml": "data/factory/scenarios/2026-06-13/....yaml",
       "run_log": "data/factory/runs/2026-06-13/....jsonl",
       "status": "ok|failed|config_error",

--- a/.claude/skills/scenario-factory/tests/run_tests.sh
+++ b/.claude/skills/scenario-factory/tests/run_tests.sh
@@ -273,4 +273,15 @@ REAL=$(python3 "$SCRIPTS/gallery_census.py" fixtures/gallery_census_sample.json 
 echo "$REAL" | grep -q "NEW ENGINE MECHANICS" \
   && fail "census: unexpected drift against real PhaseType.swift (new phase needs a census axis)"
 
+# --- SKILL.md ↔ .gitignore contract (#1541) ---------------------------------
+# The paper-tournament seed bank and the incubator queue are local-only files
+# the skill writes every night; if either path drops out of .gitignore the
+# nightly Routine dirties the main checkout, and if SKILL.md stops naming them
+# the prose and the ignore list have drifted apart.
+for P in data/factory/sketches/x.md data/factory/incubator.md; do
+  git -C "$REPO_ROOT" check-ignore -q "$P" || fail "gitignore: $P is not ignored"
+done
+grep -q "data/factory/sketches/" ../SKILL.md || fail "SKILL.md: sketch seed bank path missing"
+grep -q "data/factory/incubator.md" ../SKILL.md || fail "SKILL.md: incubator queue path missing"
+
 echo "ALL TESTS PASSED"

--- a/.claude/skills/scenario-factory/tests/run_tests.sh
+++ b/.claude/skills/scenario-factory/tests/run_tests.sh
@@ -278,8 +278,11 @@ echo "$REAL" | grep -q "NEW ENGINE MECHANICS" \
 # the skill writes every night; if either path drops out of .gitignore the
 # nightly Routine dirties the main checkout, and if SKILL.md stops naming them
 # the prose and the ignore list have drifted apart.
+# check-ignore -v names the SOURCE rule, so a match coming from
+# .git/info/exclude or a global excludesfile (the tracked entry deleted) fails.
 for P in data/factory/sketches/x.md data/factory/incubator.md; do
-  git -C "$REPO_ROOT" check-ignore -q "$P" || fail "gitignore: $P is not ignored"
+  SRC=$(git -C "$REPO_ROOT" check-ignore -v "$P" | cut -f1 | cut -d: -f1 || true)
+  [ "$SRC" = ".gitignore" ] || fail "gitignore: $P not ignored by tracked .gitignore (source: ${SRC:-none})"
 done
 grep -q "data/factory/sketches/" ../SKILL.md || fail "SKILL.md: sketch seed bank path missing"
 grep -q "data/factory/incubator.md" ../SKILL.md || fail "SKILL.md: incubator queue path missing"

--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,8 @@ __pycache__/
 # #515 / #521) — local-only.
 data/factory/runs/
 data/factory/scenarios/
+# Paper-tournament sketch seed bank (#1541) — same local-only channel.
+data/factory/sketches/
 
 # Scenario-refine (/scenario-refine #730) raw run logs and A/B improvement
 # candidate YAMLs — local-only. The skill's hard safety boundary is that it
@@ -83,6 +85,7 @@ data/factory/digest-index.jsonl
 data/factory/audit-digest.md
 data/queue/digest.md
 data/factory/lessons-inbox.md
+data/factory/incubator.md
 
 # Harness transcripts backing gallery highlights (ADR-029) — local-only by
 # decision: the pre-commit human sign-off is the sole durable record of a


### PR DESCRIPTION
## Summary

Round 3 of the scenario-factory interestingness ladder (Part of #1541). Docs/skill-spec change only — no Swift, no results-schema change.

- **Paper tournament (Step 2a/2b/2c)** — sketch 8–10 candidates (≤7 lines each) into a gitignored seed bank, score them on a PLAYBOOK-derived paper rubric (novelty / rule compliance / payoff mechanism / budget fit, 0–2 each, validated-rule violation = DQ), and author only the top 3. In-session sketching burns no inference; the ~4–10 min harness run is the bottleneck, so selection moves before the run. Losing sketches are read back next night by grep (Step 1(d)) as seeds / saturation signals.
- **Incubation lane (Step 2b + Step 4)** — the judge appends a fresh-slot near miss (≥60% of available max + ONE concrete blocker mapped to a PLAYBOOK rule) to `data/factory/incubator.md`; one nightly slot re-authors the oldest open entry as a single-lever v2, capped at 2 attempts (`- open` → `- resolved` / `- retired`, line-initial status token for anchored grep). A resolved entry is a promotion suggestion, never auto-promoted.
- Precedence when constraints collide: census tripwire > rule-29 comedy slot > lane. Step 1.5 / § Promotion / § Lessons promotion / § Scheduling get the matching clauses.
- `.gitignore`: `data/factory/sketches/`, `data/factory/incubator.md`. `run_tests.sh` pins the SKILL.md ↔ tracked-.gitignore contract for both paths.

Out of scope (tracked on #1541): the digest concurrent-append race; the 未評価在庫 half is an operational `/scenario-refine` run.

## Test plan

- [x] `bash .claude/skills/scenario-factory/tests/run_tests.sh` → ALL TESTS PASSED
- [x] `scripts/precommit-gate-classify.sh` on the changeset emits no `build` / `lint` token → xcodebuild test suite and SwiftLint skipped (no Swift touched); CI path-gating matches.

## Review

Reviewer: Opus (`code-reviewer`). Plan critique: Opus `critic` (7 warnings, all folded into the plan — Step 1.5/§ Promotion coverage, incubator edge states, budget band 81–100, single-line `notes`, sketch size cap).

Code review: FAIL → all 10 findings applied in `🐛 fix:` — Critical: an incubated v2 could re-enter the queue under its new id and restart the attempt cap (append rule now fresh-slot-only, slug-level grep). Warnings: 2c "write 3 files" vs the v2 already existing; `<slug>_v2.yaml` vs `<id>.yaml`; `incubator / <axis>` three-part axis broke the rotation scan (axis now stays two-part, lane marked in `theme`); ≤6-line cap vs 7 enumerated items; retirement trigger ambiguity. Suggestions: `check-ignore -v` source assertion; Japanese round names dropped; rule 29 stated as a floor; incubator probed in Step 1(d). No findings rejected.

## Device QA

実機QA不要 — skill prose, `.gitignore`, and a shell test only.

Part of #1541

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VNfnGpvafcAKWDtftoos3m
