### PR TITLE
✨ feat: ADR-023 Stage 3 — ScenarioValidator run-gate port (PR B1)

### DIFF
--- a/.claude/rules/kmp-interop.md
+++ b/.claude/rules/kmp-interop.md
@@ -70,8 +70,9 @@ lowercase path work locally and fail the gate.
 **A new `PhaseType` must be dispositioned in TWO Kotlin maps, neither compiler-caught.**
 `PhaseDispatcher.defaultHandlers()` decides whether the phase runs at all; `ConditionalHandler`'s
 `subHandlers` decides whether it may run *inside a conditional branch*. Both are `Map` literals, so
-an omission compiles and fails as a mid-run throw. With no `ScenarioValidator` here, `subHandlers`
-is the sole enforcement, not a backstop.
+an omission compiles and fails as a mid-run throw. `ScenarioValidator.kt` exists but is not wired
+into `SimulationEngine` (it waits for the linter port, ADR-023 §4), so `subHandlers` is the sole
+run-path enforcement, not a backstop.
 
 **A Models change can break `shared/engine`**, and `:shared:models:jvmTest` alone is blind to it —
 run the CI pair `:shared:models:jvmTest :shared:engine:jvmTest` before pushing. Likewise every

--- a/Pastura/Pastura/Engine/ScenarioValidator+EventInject.swift
+++ b/Pastura/Pastura/Engine/ScenarioValidator+EventInject.swift
@@ -7,6 +7,13 @@ import Foundation
 /// `nonisolated` Engine type, and a plain sibling-file `extension` would
 /// inherit default-MainActor isolation and break the nonisolated callers in
 /// the main file (see `.claude/rules/swift-isolation.md` Pattern 3).
+///
+/// **Dual-landed with
+/// `shared/engine/src/commonMain/kotlin/com/pastura/engine/ScenarioValidator.kt`**
+/// (spelled out so a move leaves a greppable string behind) — change both
+/// (ADR-023). The Kotlin twin folds this extension into its single file; no
+/// checker verifies that an edit here was mirrored, so the pairing is yours to
+/// honour. See the base type's doc in `ScenarioValidator.swift`.
 nonisolated extension ScenarioValidator {
 
   /// Shared shape-check for event_inject phases, callable from both the

--- a/Pastura/Pastura/Engine/ScenarioValidator+OutputFieldNames.swift
+++ b/Pastura/Pastura/Engine/ScenarioValidator+OutputFieldNames.swift
@@ -5,6 +5,13 @@ import Foundation
 // the project's default MainActor isolation — breaking `nonisolated` callers in
 // the main file (`validatePhases` / `validateBranch`). See
 // `.claude/rules/swift-isolation.md` Pattern 3.
+//
+// Dual-landed with
+// `shared/engine/src/commonMain/kotlin/com/pastura/engine/ScenarioValidator.kt`
+// (spelled out so a move leaves a greppable string behind) — change both
+// (ADR-023). The Kotlin twin folds this extension into its single file; no
+// checker verifies that an edit here was mirrored, so the pairing is yours to
+// honour. See the base type's doc in `ScenarioValidator.swift`.
 nonisolated extension ScenarioValidator {
   /// Rejects any `output:` field name that is not an ASCII identifier
   /// (``ScenarioConventions/isValidFieldName(_:)``).

--- a/Pastura/Pastura/Engine/ScenarioValidator.swift
+++ b/Pastura/Pastura/Engine/ScenarioValidator.swift
@@ -6,6 +6,15 @@ import Foundation
 /// count (warn >50, error >100), and phase-field semantics (e.g.,
 /// assign-phase target/source compatibility) to prevent runaway or
 /// misconfigured simulations.
+///
+/// **Dual-landed with
+/// `shared/engine/src/commonMain/kotlin/com/pastura/engine/ScenarioValidator.kt`**
+/// (spelled out so a move leaves a greppable string behind) — change both
+/// (ADR-023). The Kotlin twin carries the run gate (`validate`) from this file,
+/// `+EventInject` and `+OutputFieldNames`; `validateForCommit` /
+/// `+CanonicalFields` are not ported yet (#1552 B2). The ledger row is `PORT`,
+/// so no checker verifies an edit here was mirrored — the pairing is yours to
+/// honour, and `.claude/rules/kmp-interop.md` does not load for `Pastura/**`.
 nonisolated public struct ScenarioValidator: Sendable {
 
   /// Creates a validator.

--- a/Pastura/Pastura/Engine/ScenarioValidator.swift
+++ b/Pastura/Pastura/Engine/ScenarioValidator.swift
@@ -12,9 +12,10 @@ import Foundation
 /// (spelled out so a move leaves a greppable string behind) — change both
 /// (ADR-023). The Kotlin twin carries the run gate (`validate`) from this file,
 /// `+EventInject` and `+OutputFieldNames`; `validateForCommit` /
-/// `+CanonicalFields` are not ported yet (#1552 B2). The ledger row is `PORT`,
-/// so no checker verifies an edit here was mirrored — the pairing is yours to
-/// honour, and `.claude/rules/kmp-interop.md` does not load for `Pastura/**`.
+/// `+CanonicalFields` are not ported yet (#1552 B2). No checker verifies that
+/// an edit here was mirrored — for any ledger disposition — so the pairing is
+/// yours to honour; `.claude/rules/kmp-interop.md` does not load for
+/// `Pastura/**`, `engine.md` does.
 nonisolated public struct ScenarioValidator: Sendable {
 
   /// Creates a validator.

--- a/docs/kmp-migration-status.md
+++ b/docs/kmp-migration-status.md
@@ -22,7 +22,7 @@ At-a-glance progress for the KMP Engine migration (ADR-023 / [#501](https://gith
 > other section is hand-maintained; refresh it when a KMP PR merges (see
 > [`.claude/rules/kmp-interop.md`](../.claude/rules/kmp-interop.md)).
 
-_Last updated: 2026-08-14._
+_Last updated: 2026-08-26._
 
 ## Stages
 
@@ -45,7 +45,7 @@ Legend: ✅ done · 🔄 in progress · 🟡 partial · ⬜ not started.
 | Wave A — non-handler run-path (scoring, mechanisms, prompt/LLM glue) | ✅ done | #1207 #1212 #1217 |
 | Wave B — 14 phase handlers | ✅ 14/14 | checklist ↓ |
 | code-phase track | ✅ done | CP1 #1226 · CP2 #1230 · CP3 #1232 |
-| Loader / validator port + `detector`·`logger` wiring | 🟡 partial | validator prerequisites in ([#1464](https://github.com/tyabu12/pastura/issues/1464)); validator / loader / linter / wiring left · [ADR-023](decisions/ADR-023.md) §4 · #501 |
+| Loader / validator port + `detector`·`logger` wiring | 🟡 partial | validator prerequisites in ([#1464](https://github.com/tyabu12/pastura/issues/1464)); validator run gate in ([#1552](https://github.com/tyabu12/pastura/issues/1552) B1); commit gate (B2) / loader / linter / wiring left · [ADR-023](decisions/ADR-023.md) §4 · #501 |
 
 ### Wave B handler checklist
 

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/InferenceEstimator.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/InferenceEstimator.kt
@@ -23,9 +23,9 @@ import com.pastura.models.Scenario
  * `estimatedInferencesExceedsMaximum` / `highInferenceCount` limits are
  * `ScenarioValidator`'s, not the loader's.
  *
- * Landed as infra for the ADR-023 §6 Stage-3 Engine migration (#501): there is
- * **no Kotlin consumer yet**, because `ScenarioValidator` itself is unported
- * (`DivergenceLedger.DivergenceClass.VALIDATOR_UNPORTED`).
+ * Landed as infra for the ADR-023 §6 Stage-3 Engine migration (#501, #1464);
+ * its consumer is [ScenarioValidator.validate] (#1552). Neither is wired into
+ * [SimulationEngine] yet (`DivergenceLedger.DivergenceClass.VALIDATOR_UNPORTED`).
  */
 internal object InferenceEstimator {
 
@@ -40,9 +40,9 @@ internal object InferenceEstimator {
      * 30 *before* calling this, but nothing caps a phase's `sub_rounds`. A
      * `speak_each` with `sub_rounds: 300000000` overflows 32 bits, and the wrapped
      * value is small or negative — so a ported validator would **accept** a
-     * scenario Swift rejects via `estimatedInferencesExceedsMaximum`. Latent while
-     * nothing consumes this, and live the moment the validator lands, which is
-     * this file's whole purpose.
+     * scenario Swift rejects via `estimatedInferencesExceedsMaximum`. Live since
+     * [ScenarioValidator.validate] landed (#1552) — it compares this value
+     * against the caps as `Long` and only clamps to `Int` for the message text.
      *
      * Per-phase formula (per round):
      * - `speak_all` / `vote` / `reflect`: agent count

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/LanguageDispatch.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/LanguageDispatch.kt
@@ -15,8 +15,11 @@ package com.pastura.engine
  * falls to **ja**, not en.
  *
  * That consequence is load-bearing here in a way it is not in Swift: Swift's
- * `ScenarioValidator` gates the input, but that validator is a Stage-3 port
- * (ADR-023 §4), so **no Kotlin gate enforces `{"ja", "en"}` yet**. Until it
+ * `ScenarioValidator` gates the input at the run preflight. Kotlin's
+ * [ScenarioValidator] ports the run gate (`validate`) but is **not wired into
+ * [SimulationEngine]** — ADR-023 §4 gates the preflight on the validator and
+ * `ScenarioSemanticLinter` together, and the linter is unported — so **no
+ * Kotlin gate enforces `{"ja", "en"}` on the run path yet**. Until the wiring
  * lands, an unvalidated scenario reaches this function directly and silently
  * renders ja. Preserved as-is rather than "hardened" — a divergence here would
  * make Stage-4 transcript parity fail for exactly the inputs the validator is

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/PromptBuilder.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/PromptBuilder.kt
@@ -143,8 +143,10 @@ internal class PromptBuilder {
      *
      *   Swift's doc reasons that "for any `window >= 1` (the validator's floor) the
      *   trimmed slice is non-empty whenever `entries` is". **That floor does not
-     *   hold in Kotlin yet** — `ScenarioValidator` is a Stage-3 port, so nothing
-     *   rejects `log_window: 0`. `takeLast(0)` returns empty, which would render
+     *   hold in Kotlin yet** — [ScenarioValidator] ports the run gate but is not
+     *   wired into [SimulationEngine] (ADR-023 §4: the preflight waits for the
+     *   linter port), so nothing on the run path rejects `log_window: 0`.
+     *   `takeLast(0)` returns empty, which would render
      *   the empty-log placeholder on a *non-empty* log — silently telling the model
      *   "no conversation yet" mid-round. Guarded explicitly below rather than
      *   inherited by assumption; see [Phase.maxSentences] for the same
@@ -158,8 +160,9 @@ internal class PromptBuilder {
         if (entries.isEmpty()) {
             return pickLanguage(language, ja = "（まだなし）", en = "(none yet)")
         }
-        // coerceAtLeast(1): see the `window` doc — the Swift-side validator floor
-        // is not yet portable, and a 0 window must not masquerade as an empty log.
+        // coerceAtLeast(1): see the `window` doc — the validator floor is not yet
+        // enforced on this run path, and a 0 window must not masquerade as an
+        // empty log.
         val windowed = window?.let { entries.takeLast(it.coerceAtLeast(1)) } ?: entries
         return windowed.joinToString(separator = "\n") { "  ${it.agentName}: ${it.content}" }
     }

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/ScenarioValidator.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/ScenarioValidator.kt
@@ -1,0 +1,645 @@
+package com.pastura.engine
+
+import com.pastura.models.AnyCodableValue
+import com.pastura.models.AssignTarget
+import com.pastura.models.Phase
+import com.pastura.models.PhaseType
+import com.pastura.models.Scenario
+import com.pastura.models.ScenarioConventions
+import com.pastura.models.ScenarioValidationMessage
+import com.pastura.models.SimulationError
+
+/**
+ * Validates a [Scenario] against execution limits before running.
+ *
+ * Enforces agent count (2–10), round count (≤30), estimated inference count
+ * (warn >50, error >100), and phase-field semantics (e.g. assign-phase
+ * target/source compatibility) to prevent runaway or misconfigured simulations.
+ *
+ * Kotlin port of `Pastura/Pastura/Engine/ScenarioValidator.swift` plus its two
+ * sibling extensions `ScenarioValidator+EventInject.swift` and
+ * `ScenarioValidator+OutputFieldNames.swift` (ADR-023 §4, the "Load + validate"
+ * row). The Swift originals split across three files only to stay under
+ * SwiftLint's file/type length caps and to dodge a default-MainActor isolation
+ * trap on sibling extensions; Kotlin has neither constraint, so the whole gate
+ * lives here.
+ *
+ * ## Scope: the RUN gate only
+ *
+ * `validateForCommit` and the canonical primary-field checks
+ * (`ScenarioValidator+CanonicalFields.swift`) are **not** ported yet — they land
+ * in a follow-up PR. Everything `validate(_:)` runs is here.
+ *
+ * ## Not wired into the engine
+ *
+ * Nothing in `shared/engine` calls this yet, deliberately. ADR-023 §4 has the
+ * preflight gate on the validator **and** `ScenarioSemanticLinter` (ADR-024)
+ * together — the linter's `.error` findings block a run just as this gate's
+ * throws do. The linter is unported, so wiring this half into
+ * [SimulationEngine] now would split one preflight across two languages, which
+ * is exactly the shape ADR-023 §4 rejects. Wiring happens once both halves
+ * exist.
+ *
+ * ## Known rendering divergences from Swift
+ *
+ * All four are **documented, not ledgered**. They are the same family as
+ * `DivergenceLedger.DivergenceClass.NUMBER_LITERAL_FORMATTING` and
+ * `SCOREBOARD_ORDERING` — cross-language differences in how a value becomes
+ * text — but none is a ledger entry, because validation errors never reach a
+ * parity transcript at all: a scenario this gate rejects produces no run to
+ * compare (the standing reason recorded on
+ * `DivergenceClass.VALIDATOR_UNPORTED`).
+ *
+ * 1. **Probability rendering.** Swift `String(probability)` and Kotlin
+ *    `Double.toString()` switch to exponent notation at different magnitudes and
+ *    spell the exponent differently: `1e-7` renders `"1e-07"` in Swift and
+ *    `"1.0E-7"` in Kotlin. Message text only — both sides reject the same
+ *    values.
+ * 2. **NaN / infinity rendering.** Swift renders `"nan"` / `"inf"` / `"-inf"`,
+ *    Kotlin `"NaN"` / `"Infinity"` / `"-Infinity"`. Control flow agrees (both
+ *    fall outside `0.0..1.0` and throw); only the message text differs. Unlike
+ *    (1) this **is** reachable from authored YAML — `probability: .nan` and
+ *    `probability: .inf` are legal YAML floats.
+ * 3. **Whitespace trimming.** Swift trims `.whitespacesAndNewlines` (a Unicode
+ *    character set); Kotlin `trim()` trims `Char.isWhitespace()`. The two sets
+ *    disagree on a handful of exotic code points, so a source key or `if:`
+ *    padded with one of them could trim on one side and not the other.
+ * 4. **Output-key ordering.** `schema.keys.sorted()` is Unicode-scalar order in
+ *    Swift and UTF-16 code-unit order in Kotlin. Only *which* invalid key is
+ *    reported first can differ, and only when a schema has ≥2 invalid keys
+ *    straddling the BMP boundary — accept/reject is identical either way.
+ */
+public class ScenarioValidator {
+
+    /** The result of scenario validation. */
+    public data class ValidationResult(
+        /** Non-fatal warnings (e.g. high inference count). */
+        public val warnings: List<String>,
+        /** The estimated total number of LLM inferences. */
+        public val estimatedInferences: Long,
+    )
+
+    /**
+     * Validates [scenario] against execution limits.
+     *
+     * `@Throws` is load-bearing at the K/N boundary, not decoration: Kotlin
+     * exceptions from an **un-annotated** function are not surfaced to Swift as
+     * catchable errors — they terminate the process. Stage-5 iOS consumers call
+     * this across that boundary, so the annotation is what makes a validation
+     * failure a `catch`-able Swift error instead of a crash. This is the first
+     * `@Throws` in commonMain; `ConditionEvaluator.parse` has the same gap and
+     * is a follow-up, not this PR.
+     *
+     * @return a [ValidationResult] with any warnings and the inference estimate.
+     * @throws SimulationException carrying
+     *   [SimulationError.ScenarioValidationFailed] if a limit is exceeded.
+     */
+    @Throws(SimulationException::class)
+    public fun validate(scenario: Scenario): ValidationResult {
+        // Language values (ADR-010 D1 / D5 — programmatic-construction path
+        // gate, mirrors `ScenarioLoader`'s YAML-parse path).
+        if (scenario.language !in Scenario.ACCEPTED_LANGUAGES) {
+            throw validationError(
+                ScenarioValidationMessage.LanguageNotAccepted(
+                    allowed = acceptedLanguagesList(),
+                    got = scenario.language,
+                ),
+            )
+        }
+        val simulationLanguage = scenario.simulationLanguage
+        if (simulationLanguage != null && simulationLanguage !in Scenario.ACCEPTED_LANGUAGES) {
+            throw validationError(
+                ScenarioValidationMessage.SimulationLanguageNotAccepted(
+                    allowed = acceptedLanguagesList(),
+                    got = simulationLanguage,
+                ),
+            )
+        }
+
+        // Agent count limits (checked first for clearer error messages)
+        if (scenario.agentCount < 2) {
+            throw validationError(
+                ScenarioValidationMessage.AgentCountBelowMinimum(scenario.agentCount),
+            )
+        }
+        if (scenario.agentCount > 10) {
+            throw validationError(
+                ScenarioValidationMessage.AgentCountExceedsMaximum(scenario.agentCount),
+            )
+        }
+
+        // Persona count must match agentCount
+        if (scenario.personas.size != scenario.agentCount) {
+            throw validationError(
+                ScenarioValidationMessage.PersonaCountMismatch(
+                    personaCount = scenario.personas.size,
+                    agentCount = scenario.agentCount,
+                ),
+            )
+        }
+
+        // Round count limit
+        if (scenario.rounds > 30) {
+            throw validationError(
+                ScenarioValidationMessage.RoundCountExceedsMaximum(scenario.rounds),
+            )
+        }
+
+        // Conversation-log window (#907): a prompt-side cap that must keep at
+        // least one entry when set. `null` means "no window" (full log); `0` or
+        // negative would silently strip the whole log, so reject it as a
+        // misconfiguration.
+        val logWindow = scenario.logWindow
+        if (logWindow != null && logWindow < 1) {
+            throw validationError(ScenarioValidationMessage.LogWindowBelowMinimum(logWindow))
+        }
+
+        // Inference count estimation
+        val estimated = InferenceEstimator.estimateInferenceCount(scenario)
+
+        if (estimated > 100) {
+            // The clamp only affects the *displayed* number, and only above
+            // `Int.MAX_VALUE` — the throw already fired on `> 100`. The Models
+            // message mirror is 1:1 with the 53 Swift cases (#1464) and is
+            // deliberately not widened to `Long` for this one arg, so a
+            // scenario whose estimate overflows an `Int` reports a clamped
+            // count in a message that already says "too many".
+            throw validationError(
+                ScenarioValidationMessage.EstimatedInferencesExceedsMaximum(estimated.clampToInt()),
+            )
+        }
+
+        validatePhases(scenario)
+
+        val warnings = mutableListOf<String>()
+        if (estimated > 50) {
+            // Unreachable clamp, kept purely defensively: this branch fires only
+            // for 51…100, so the value always fits an `Int`. It exists so the
+            // call shape matches the sibling above and cannot start truncating
+            // if the band ever widens.
+            warnings.add(
+                ScenarioValidationMessage.HighInferenceCount(estimated.clampToInt()).render(),
+            )
+        }
+
+        return ValidationResult(warnings = warnings, estimatedInferences = estimated)
+    }
+
+    /**
+     * Per-phase semantic checks beyond execution-limit validation.
+     *
+     * Covers `assign` target/source shape compatibility and `conditional` branch
+     * well-formedness. Unknown `target` values are caught earlier by
+     * `ScenarioLoader` (compile-time enforced via [AssignTarget]).
+     *
+     * The `when` is deliberately `else`-free so a new [PhaseType] fails to
+     * compile here rather than silently skipping its shape check.
+     */
+    private fun validatePhases(scenario: Scenario) {
+        scenario.phases.forEachIndexed { index, phase ->
+            val label = "Phase ${index + 1}"
+            validateOutputFieldNames(phase, label)
+            validateMaxSentences(phase, label)
+            when (phase.type) {
+                PhaseType.ASSIGN ->
+                    validateAssignPhaseShape(phase, "$label (assign)", scenario)
+                PhaseType.CONDITIONAL ->
+                    validateConditionalPhase(phase, index, scenario, depth = 0)
+                PhaseType.REFLECT -> validateReflectShape(phase, label)
+                PhaseType.WHISPER -> validateWhisperShape(phase, label)
+                // `NARRATE` needs no shape check: its output schema is
+                // Engine-fixed (`{ commentary }`, built by `NarrateHandler`),
+                // not author-declared, so there is no `output:` block or
+                // `logic`/`source`/`target` to validate.
+                PhaseType.SPEAK_ALL,
+                PhaseType.SPEAK_EACH,
+                PhaseType.VOTE,
+                PhaseType.CHOOSE,
+                PhaseType.SCORE_CALC,
+                PhaseType.ELIMINATE,
+                PhaseType.SUMMARIZE,
+                PhaseType.NARRATE,
+                -> Unit
+                PhaseType.RELATIONSHIP_UPDATE -> validateRelationshipUpdateShape(phase, label)
+                PhaseType.EVENT_INJECT ->
+                    validateEventInjectShape(phase, "$label (event_inject)", scenario)
+            }
+        }
+    }
+
+    /**
+     * Enforces the accepted range (1…6) for a phase's `max_sentences` override
+     * (#881). Called at both traversal sites ([validatePhases] and
+     * [validateBranch]) so a nested `then:` / `else:` sub-phase is checked too.
+     * A `null` override (the common case) is a no-op. The upper bound doubles as
+     * a latency / JSON-stability guard — the model tops out ~3–4 sentences even
+     * at cap 6 (#881 Stage-0 spike), so higher values are meaningless.
+     */
+    private fun validateMaxSentences(phase: Phase, label: String) {
+        val value = phase.maxSentences ?: return
+        if (value !in 1..6) {
+            throw validationError(
+                ScenarioValidationMessage.MaxSentencesOutOfRange(label = label, value = value),
+            )
+        }
+    }
+
+    /**
+     * Enforces the conditional-phase invariants that the construction-time
+     * [Phase] constructor cannot express:
+     * - `condition` must be non-empty (an empty expression would throw at
+     *   evaluator parse time anyway, but failing fast here is clearer).
+     * - At least one of `thenPhases` / `elsePhases` must be non-empty (otherwise
+     *   the phase is a no-op with extra overhead).
+     * - `depth > 0` blocks nested `conditional` — the loader has the same check
+     *   on the YAML path, and this covers non-YAML construction (tests, editors,
+     *   future migrations).
+     */
+    private fun validateConditionalPhase(
+        phase: Phase,
+        index: Int,
+        scenario: Scenario,
+        depth: Int,
+    ) {
+        val phaseLabel = "Phase ${index + 1} (conditional)"
+        val trimmedCondition = (phase.condition ?: "").trim()
+        if (trimmedCondition.isEmpty()) {
+            throw validationError(ScenarioValidationMessage.ConditionalMissingIf(phaseLabel))
+        }
+
+        // Parse-only pre-flight: malformed `if:` (mismatched parens, dangling
+        // combinator, empty operand) surfaces here at scenario-load time rather
+        // than mid-simulation when the handler dispatches. Critical for gallery
+        // curation — a bad `if:` in a curated scenario would otherwise only fail
+        // when a user runs it.
+        try {
+            ConditionEvaluator().parse(trimmedCondition)
+        } catch (e: SimulationException) {
+            val error = e.error
+            if (error is SimulationError.ScenarioValidationFailed) {
+                // Raw interpolation is deliberate here (not a
+                // `ScenarioValidationMessage` case): this only prefixes the
+                // phase locator onto a string `ConditionEvaluator.parse` has
+                // already rendered. There is no new translatable literal to
+                // extract, so a future i18n sweep skips it.
+                throw SimulationException(
+                    SimulationError.ScenarioValidationFailed("$phaseLabel: ${error.message}"),
+                )
+            }
+            throw e
+        }
+
+        val thenCount = phase.thenPhases?.size ?: 0
+        val elseCount = phase.elsePhases?.size ?: 0
+        if (thenCount == 0 && elseCount == 0) {
+            throw validationError(ScenarioValidationMessage.ConditionalEmptyBranches(phaseLabel))
+        }
+
+        if (depth > 0) {
+            throw validationError(
+                ScenarioValidationMessage.NestedConditionalNotAllowed(phaseLabel),
+            )
+        }
+
+        validateBranch(phase.thenPhases.orEmpty(), phaseLabel, "then", scenario)
+        validateBranch(phase.elsePhases.orEmpty(), phaseLabel, "else", scenario)
+    }
+
+    /**
+     * Recursively validates each sub-phase in a conditional branch.
+     *
+     * Rejects nested `conditional` (depth-1 rule), `reflect`, `whisper`,
+     * `relationship_update`, and `narrate` (none supported inside a branch in
+     * v1), and applies the same semantic checks we run at the top level — e.g.
+     * an `assign` phase with mismatched target/source shape still errors when
+     * buried inside a `then:` or `else:` branch. `event_inject` is allowed
+     * inside a branch (consistent with assign / score_calc) and gets the same
+     * shape-check it would receive at the top level.
+     */
+    private fun validateBranch(
+        phases: List<Phase>,
+        parentLabel: String,
+        branchLabel: String,
+        scenario: Scenario,
+    ) {
+        phases.forEachIndexed { subIndex, subPhase ->
+            val subLabel = "$parentLabel $branchLabel[${subIndex + 1}]"
+            validateOutputFieldNames(subPhase, subLabel)
+            validateMaxSentences(subPhase, subLabel)
+            when (subPhase.type) {
+                PhaseType.CONDITIONAL ->
+                    throw validationError(
+                        ScenarioValidationMessage.BranchNestedConditional(subLabel),
+                    )
+                // `reflect` is not supported inside a conditional branch in v1.
+                // Reject at load-time validation (mirroring the
+                // nested-conditional rule above) so it fails here rather than at
+                // `ConditionalHandler` dispatch.
+                PhaseType.REFLECT ->
+                    throw validationError(
+                        ScenarioValidationMessage.BranchReflectNotAllowed(subLabel),
+                    )
+                // `whisper` is likewise not supported inside a conditional
+                // branch in v1 (mirrors the reflect rejection above).
+                PhaseType.WHISPER ->
+                    throw validationError(
+                        ScenarioValidationMessage.BranchWhisperNotAllowed(subLabel),
+                    )
+                // `relationship_update` is likewise not supported inside a
+                // conditional branch in v1; it is also omitted from
+                // `ConditionalHandler.subHandlers` as a structural backstop.
+                PhaseType.RELATIONSHIP_UPDATE ->
+                    throw validationError(
+                        ScenarioValidationMessage.BranchRelationshipUpdateNotAllowed(subLabel),
+                    )
+                // `narrate` is likewise not supported inside a conditional
+                // branch in v1 (#909): it is omitted from
+                // `ConditionalHandler.subHandlers`, so without this load-gate
+                // rejection a branch-nested narrate would pass all validation
+                // and then throw mid-run at dispatch (deferred failure).
+                PhaseType.NARRATE ->
+                    throw validationError(
+                        ScenarioValidationMessage.BranchNarrateNotAllowed(subLabel),
+                    )
+                PhaseType.ASSIGN -> validateAssignPhaseShape(subPhase, subLabel, scenario)
+                PhaseType.EVENT_INJECT -> validateEventInjectShape(subPhase, subLabel, scenario)
+                PhaseType.SPEAK_ALL,
+                PhaseType.SPEAK_EACH,
+                PhaseType.VOTE,
+                PhaseType.CHOOSE,
+                PhaseType.SCORE_CALC,
+                PhaseType.ELIMINATE,
+                PhaseType.SUMMARIZE,
+                -> Unit
+            }
+        }
+    }
+
+    /**
+     * Requires reflect phases to declare the canonical `note` output at the RUN
+     * gate ([validate]), not just the commit gate.
+     *
+     * Other LLM phases run schema-less in degraded-but-visible form (their
+     * primary text lands in the conversation log as empty prose), but a reflect
+     * phase without `note` is a pure no-op inference — it burns one call per
+     * agent per round and stores nothing, with no user-visible symptom to debug
+     * from. Failing fast at the run gate is friendlier. Reuses the commit-gate
+     * message so both gates read identically.
+     */
+    private fun validateReflectShape(phase: Phase, label: String) {
+        if (phase.outputSchema.orEmpty()["note"] == null) {
+            throw validationError(
+                ScenarioValidationMessage.RequiresOutputField(
+                    label = label,
+                    type = phase.type.serialName(),
+                    field = "note",
+                ),
+            )
+        }
+    }
+
+    /**
+     * Requires whisper phases to declare the canonical `statement` output at the
+     * RUN gate ([validate]), mirroring [validateReflectShape]'s rationale.
+     *
+     * A whisper without `statement` burns one inference per participant per pair
+     * per round and stores nothing user-visible — the same no-op-inference
+     * failure mode reflect guards against, so it fails fast here at the run gate
+     * rather than degrading silently. Reuses the shared missing-field message.
+     */
+    private fun validateWhisperShape(phase: Phase, label: String) {
+        if (phase.outputSchema.orEmpty()["statement"] == null) {
+            throw validationError(
+                ScenarioValidationMessage.RequiresOutputField(
+                    label = label,
+                    type = phase.type.serialName(),
+                    field = "statement",
+                ),
+            )
+        }
+    }
+
+    /**
+     * Requires relationship_update phases to declare at least one affinity rule
+     * (`vote_against` and/or a non-empty `action_deltas`) at the RUN gate.
+     *
+     * A phase with neither rule is a pure no-op: it reads its vote / choose
+     * signals, applies zero deltas, and injects an empty summary — burning a
+     * phase slot with no user-visible effect (the same no-op failure mode
+     * [validateReflectShape] guards against). Failing fast here surfaces the
+     * authoring mistake instead of a silently inert phase (#910).
+     */
+    private fun validateRelationshipUpdateShape(phase: Phase, label: String) {
+        val hasVoteRule = phase.voteAgainst != null
+        val hasActionRule = phase.actionDeltas.orEmpty().isNotEmpty()
+        if (!hasVoteRule && !hasActionRule) {
+            throw validationError(
+                ScenarioValidationMessage.RelationshipUpdateMissingRule(
+                    label = label,
+                    type = phase.type.serialName(),
+                ),
+            )
+        }
+    }
+
+    /**
+     * Shared shape-check for assign phases, callable from both the top-level and
+     * the nested branch paths.
+     *
+     * The `when`s over [AnyCodableValue] are `else`-free so a new shape has to
+     * be dispositioned here rather than silently accepted.
+     */
+    private fun validateAssignPhaseShape(phase: Phase, label: String, scenario: Scenario) {
+        // Phases without a `source` reference persona indices instead of
+        // extraData — nothing to shape-check.
+        val sourceKey = phase.source ?: return
+
+        // The Visual Editor round-trips extraData (#129), so a missing key here
+        // means the scenario YAML genuinely lacks the referenced field — the
+        // assign would silently no-op at runtime. Surface it early.
+        val sourceValue = scenario.extraData[sourceKey]
+            ?: throw validationError(
+                ScenarioValidationMessage.SourceNotFound(label = label, source = sourceKey),
+            )
+        when (phase.target ?: AssignTarget.ALL) {
+            AssignTarget.ALL -> when (sourceValue) {
+                is AnyCodableValue.ArrayValue, is AnyCodableValue.StringValue -> Unit
+                is AnyCodableValue.ArrayOfDictionariesValue,
+                is AnyCodableValue.DictionaryValue,
+                -> throw validationError(
+                    ScenarioValidationMessage.AssignSourceGroupedForAll(
+                        label = label,
+                        source = sourceKey,
+                    ),
+                )
+            }
+            AssignTarget.RANDOM_ONE -> when (sourceValue) {
+                is AnyCodableValue.ArrayOfDictionariesValue -> Unit
+                is AnyCodableValue.ArrayValue,
+                is AnyCodableValue.StringValue,
+                is AnyCodableValue.DictionaryValue,
+                -> throw validationError(
+                    ScenarioValidationMessage.AssignSourceNotGroupedForRandomOne(
+                        label = label,
+                        source = sourceKey,
+                    ),
+                )
+            }
+        }
+    }
+
+    /**
+     * Shared shape-check for event_inject phases, callable from both the
+     * top-level path and from inside a conditional branch.
+     *
+     * Enforces:
+     * - `source` must be present and non-empty (the handler's no-op fallback
+     *   exists for the case where extraData lookup fails at runtime, but a
+     *   curator who wrote `event_inject` clearly meant to fire — failing fast at
+     *   validation is friendlier).
+     * - `extraData[source]` must be [AnyCodableValue.ArrayValue] (a list of
+     *   strings) or [AnyCodableValue.ArrayOfDictionariesValue] (a list of
+     *   `{ text, favors }` mappings, #931 — each entry needs a non-empty `text`;
+     *   `favors` is optional). String / dictionary shapes are rejected; the
+     *   error message points at the workaround so curators don't get stuck.
+     * - `probability` (when set) must lie in `[0.0, 1.0]`. The handler would
+     *   still produce well-defined behavior outside this range (`< 0` never
+     *   fires, `>= 1.0` always fires), but a curator who wrote
+     *   `probability: 1.5` almost certainly mistyped — surfacing it early is
+     *   friendlier than silent over-fire.
+     */
+    private fun validateEventInjectShape(phase: Phase, label: String, scenario: Scenario) {
+        val sourceKey = (phase.source ?: "").trim()
+        if (sourceKey.isEmpty()) {
+            throw validationError(ScenarioValidationMessage.EventInjectMissingSource(label))
+        }
+        val sourceValue = scenario.extraData[sourceKey]
+            ?: throw validationError(
+                ScenarioValidationMessage.SourceNotFound(label = label, source = sourceKey),
+            )
+        when (sourceValue) {
+            is AnyCodableValue.ArrayValue ->
+                // An empty array silently produces probability-miss-equivalent
+                // output at runtime (the handler writes "" and emits
+                // `EventInjected(null)`), which a curator cannot distinguish
+                // from a string of unlucky rolls. Reject early so the
+                // misconfiguration surfaces at scenario load.
+                if (sourceValue.value.isEmpty()) {
+                    throw validationError(
+                        ScenarioValidationMessage.EventInjectSourceEmptyStrings(
+                            label = label,
+                            source = sourceKey,
+                        ),
+                    )
+                }
+            is AnyCodableValue.ArrayOfDictionariesValue ->
+                validateDictEventEntries(sourceValue.value, sourceKey, label)
+            is AnyCodableValue.StringValue, is AnyCodableValue.DictionaryValue ->
+                throw validationError(
+                    ScenarioValidationMessage.EventInjectSourceWrongShape(
+                        label = label,
+                        source = sourceKey,
+                    ),
+                )
+        }
+        validateEventProbability(phase.probability, label)
+    }
+
+    /**
+     * Dict-shaped events (`{ text, favors }`, #931). Same empty-list rejection
+     * as the string shape, plus each entry must carry a non-empty `text` — an
+     * entry without it injects "" (a silent no-op). `favors` is optional (an
+     * untagged entry simply scores no reward).
+     */
+    private fun validateDictEventEntries(
+        entries: List<Map<String, String>>,
+        sourceKey: String,
+        label: String,
+    ) {
+        if (entries.isEmpty()) {
+            throw validationError(
+                ScenarioValidationMessage.EventInjectSourceEmptyEvents(
+                    label = label,
+                    source = sourceKey,
+                ),
+            )
+        }
+        if (entries.any { (it["text"] ?: "").trim().isEmpty() }) {
+            throw validationError(
+                ScenarioValidationMessage.EventInjectEntryMissingText(
+                    label = label,
+                    source = sourceKey,
+                ),
+            )
+        }
+    }
+
+    /**
+     * `probability` (when set) must lie in `[0.0, 1.0]` — see the rationale on
+     * [validateEventInjectShape].
+     *
+     * `!in 0.0..1.0` is a [ClosedFloatingPointRange] membership test, so NaN
+     * falls outside and throws, matching Swift's `(0.0...1.0).contains`.
+     */
+    private fun validateEventProbability(probability: Double?, label: String) {
+        val value = probability ?: return
+        if (value !in 0.0..1.0) {
+            throw validationError(
+                ScenarioValidationMessage.EventInjectProbabilityOutOfRange(
+                    label = label,
+                    probability = value.toString(),
+                ),
+            )
+        }
+    }
+
+    /**
+     * Rejects any `output:` field name that is not an ASCII identifier
+     * ([ScenarioConventions.isValidFieldName]).
+     *
+     * Every output key is emitted verbatim as a JSON-key literal into the
+     * LLM-phase GBNF grammar by `GBNFGrammarBuilder`. A non-ASCII / multi-byte
+     * key reaches llama.cpp's sampler as a literal and crashes it at accept-time
+     * on-device — an uncatchable SIGABRT, the same mechanism that forced CJK
+     * choose-option *values* out of the grammar in #599 (#607). Surfacing it
+     * here (run gate + editor) gives a clear load-time error instead of a
+     * mid-run grammar failure; the builder's own check stays as the
+     * unconditional backstop for paths that skip this gate.
+     *
+     * Validates **every** key, not just the canonical primary — all output keys
+     * reach the grammar, so a CJK *secondary* key (`inner_thought` / `reason`)
+     * is just as dangerous as the primary. Keys are sorted so the surfaced error
+     * is deterministic across runs.
+     */
+    private fun validateOutputFieldNames(phase: Phase, label: String) {
+        val schema = phase.outputSchema ?: return
+        val invalid = schema.keys.sorted().firstOrNull { !ScenarioConventions.isValidFieldName(it) }
+            ?: return
+        throw validationError(
+            ScenarioValidationMessage.OutputFieldNameInvalid(label = label, name = invalid),
+        )
+    }
+
+    private fun acceptedLanguagesList(): String =
+        Scenario.ACCEPTED_LANGUAGES.sorted().joinToString(", ")
+}
+
+/**
+ * Wraps a [ScenarioValidationMessage] in
+ * [SimulationError.ScenarioValidationFailed], rendering it at the Models layer
+ * so the Engine run path carries no string formatting of its own.
+ *
+ * File-scope rather than a method, mirroring the Swift original — which is
+ * file-scope so it stays out of `ScenarioValidator`'s SwiftLint
+ * `type_body_length` budget and does not collide with `ScenarioLoader`'s
+ * same-named helper at module scope.
+ */
+private fun validationError(message: ScenarioValidationMessage): SimulationException =
+    SimulationException(SimulationError.ScenarioValidationFailed(message.render()))
+
+/**
+ * Narrows a `Long` inference estimate to the `Int` the Models message mirror
+ * carries. See the two call sites in [ScenarioValidator.validate] for what the
+ * clamp does and does not affect in each case.
+ */
+private fun Long.clampToInt(): Int = coerceAtMost(Int.MAX_VALUE.toLong()).toInt()

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/ScenarioValidator.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/ScenarioValidator.kt
@@ -42,7 +42,7 @@ import com.pastura.models.SimulationError
  *
  * ## Known rendering divergences from Swift
  *
- * All four are **documented, not ledgered**. They are the same family as
+ * All five are **documented, not ledgered**. They are the same family as
  * `DivergenceLedger.DivergenceClass.NUMBER_LITERAL_FORMATTING` and
  * `SCOREBOARD_ORDERING` — cross-language differences in how a value becomes
  * text — but none is a ledger entry, because validation errors never reach a
@@ -63,11 +63,22 @@ import com.pastura.models.SimulationError
  * 3. **Whitespace trimming.** Swift trims `.whitespacesAndNewlines` (a Unicode
  *    character set); Kotlin `trim()` trims `Char.isWhitespace()`. The two sets
  *    disagree on a handful of exotic code points, so a source key or `if:`
- *    padded with one of them could trim on one side and not the other.
+ *    padded with one of them could trim on one side and not the other. Unlike
+ *    (1), (2) and (4) this is **not** message-text only: the trimmed value
+ *    feeds the `extraData[sourceKey]` lookup and the empty-`if` guard, so one
+ *    engine can reject (`SourceNotFound` / `EventInjectMissingSource` /
+ *    `ConditionalMissingIf`) a scenario the other accepts. Still unledgered
+ *    for the same reason — the rejecting side produces no transcript.
  * 4. **Output-key ordering.** `schema.keys.sorted()` is Unicode-scalar order in
  *    Swift and UTF-16 code-unit order in Kotlin. Only *which* invalid key is
  *    reported first can differ, and only when a schema has ≥2 invalid keys
  *    straddling the BMP boundary — accept/reject is identical either way.
+ * 5. **Estimate rendering above `Int.MAX_VALUE`.** Swift `Int` is 64-bit, so
+ *    `estimatedInferencesExceedsMaximum` prints the true estimate; the Kotlin
+ *    message mirror takes `Int` (#1464's 1:1 mirror is deliberately not widened
+ *    for one arg), so [validate] clamps to `2147483647` before rendering. The
+ *    `> 100` throw has already fired, so accept/reject agrees. See the clamp
+ *    site in [validate].
  */
 public class ScenarioValidator {
 

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/SimulationEngine.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/SimulationEngine.kt
@@ -42,7 +42,7 @@ import kotlinx.coroutines.launch
  *
  * | Absent | Why |
  * |---|---|
- * | `ScenarioValidator` preflight + `ScenarioSemanticLinter` (ADR-024) | Stage-3 ports — §4's `Load + validate` row, which the linter joined on 2026-07-19 (before that, §4 did not mention it and this row's `(§4)` citation pointed at nothing). Nothing gates a scenario on this side yet, which is why the ported code must not assume validator floors — see `PromptBuilder`. |
+ * | `ScenarioValidator` preflight + `ScenarioSemanticLinter` (ADR-024) | §4's `Load + validate` row, which the linter joined on 2026-07-19 (before that, §4 did not mention it and this row's `(§4)` citation pointed at nothing). [ScenarioValidator] ports the **run gate only** (`validate`; the commit gate `validateForCommit` is #1552 B2) and the linter is unported; neither is wired here, because §4 gates the preflight on both together and wiring one side would split it across languages. Nothing gates a scenario on this side yet, which is why the ported code must not assume validator floors — see `PromptBuilder`. |
  * | Resume (`resumingFrom` seed / `startRound`) | needs the Data layer's persisted state; D2 keeps Data in Swift |
  * | `LanguageDetector` / `EngineLogger` injection | injection is Stage-3 freight — absent from `PhaseContext`. §4 ports both **seams only** (`LanguageDetector` in PR-3, `EngineLogger` in PR-2); the concrete `OSLogEngineLogger` / `NLLanguageDetector` stay in Swift App/ |
  *

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/ConditionalValidatorTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/ConditionalValidatorTests.kt
@@ -18,7 +18,11 @@ import kotlin.test.assertTrue
  * `ConditionalValidatorTests+Reflect.swift`,
  * `ConditionalValidatorTests+RelationshipUpdate.swift`, and
  * `ConditionalValidatorTests+Whisper.swift`
- * (`Pastura/PasturaTests/Engine/`) — 24 tests, 1:1 by name with those six files.
+ * (`Pastura/PasturaTests/Engine/`) — 26 tests: 24 are 1:1 by name with those
+ * six files; two (`rejectsMalformedConditionWithPhaseLabelPrefix`,
+ * `rejectsEmptyConditionWithMissingIfMessage`) are Kotlin-only mechanism pins
+ * with no Swift twin — see their own comments and the §12 condition-4 record
+ * in `ScenarioValidatorTests.kt`.
  *
  * The parse-time tests (`rejectsMalformedConditionAtValidateTime`,
  * `rejectsDanglingCombinatorAtValidateTime`) exercise
@@ -381,6 +385,9 @@ class ConditionalValidatorTests {
     // critical for gallery curation where curated scenarios must fail before
     // shipping.
 
+    // Deliberately loose (type-only), 1:1 with Swift; the "$phaseLabel: " rewrap
+    // is pinned by `rejectsMalformedConditionWithPhaseLabelPrefix` on the same
+    // fixture — do not de-duplicate the pair.
     @Test
     fun rejectsMalformedConditionAtValidateTime() {
         val scenario = makeScenario(

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/ConditionalValidatorTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/ConditionalValidatorTests.kt
@@ -27,6 +27,11 @@ import kotlin.test.assertTrue
  * `SimulationError.ScenarioValidationFailed`, rewraps the message as
  * `"$phaseLabel: ..."` before rethrowing — so these tests pin the wrapped
  * validator-level message, not `ConditionEvaluator.parse`'s own rendering.
+ *
+ * The ADR-023 §12 condition-4 perturbation record for `ScenarioValidator` lives in
+ * [ScenarioValidatorTests]' class KDoc and covers this file's claimants too — both
+ * suites were run together for every mutation, and three of its rows name tests
+ * added here.
  */
 class ConditionalValidatorTests {
 
@@ -389,6 +394,49 @@ class ConditionalValidatorTests {
         )
         val caught = assertFailsWith<SimulationException> { validator.validate(scenario) }
         assertTrue(caught.error is SimulationError.ScenarioValidationFailed)
+    }
+
+    @Test
+    fun rejectsMalformedConditionWithPhaseLabelPrefix() {
+        // No Swift sibling: neither side asserted the `"$phaseLabel: "` rewrap, so
+        // the condition-4 sweep found dropping the prefix green across all 86 tests
+        // (#1552). The two tests above accept any `ScenarioValidationFailed`, which
+        // `ConditionEvaluator.parse` throws on its own — only this one can tell the
+        // validator's rewrap from the evaluator's raw rendering.
+        val scenario = makeScenario(
+            phases = listOf(
+                Phase(
+                    type = PhaseType.CONDITIONAL,
+                    condition = "(current_round == 1 && max_score > 0",
+                    thenPhases = listOf(Phase(type = PhaseType.SUMMARIZE, template = "t")),
+                ),
+            ),
+        )
+        val caught = assertFailsWith<SimulationException> { validator.validate(scenario) }
+        val error = caught.error
+        assertTrue(error is SimulationError.ScenarioValidationFailed)
+        assertTrue(error.message.startsWith("Phase 1 (conditional): "))
+    }
+
+    @Test
+    fun rejectsEmptyConditionWithMissingIfMessage() {
+        // No Swift sibling: [rejectsEmptyCondition] and friends accept any
+        // `ScenarioValidationFailed`, and `ConditionEvaluator.parse("")` throws one
+        // too — so deleting the fail-fast empty-`if` guard stayed green in the
+        // condition-4 sweep (#1552). Only the message tells the two apart.
+        val scenario = makeScenario(
+            phases = listOf(
+                Phase(
+                    type = PhaseType.CONDITIONAL,
+                    condition = "",
+                    thenPhases = listOf(Phase(type = PhaseType.SUMMARIZE, template = "t")),
+                ),
+            ),
+        )
+        val caught = assertFailsWith<SimulationException> { validator.validate(scenario) }
+        val error = caught.error
+        assertTrue(error is SimulationError.ScenarioValidationFailed)
+        assertTrue(error.message.contains("missing or empty 'if' expression"))
     }
 
     @Test

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/ConditionalValidatorTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/ConditionalValidatorTests.kt
@@ -1,0 +1,565 @@
+package com.pastura.engine
+
+import com.pastura.models.AnyCodableValue
+import com.pastura.models.AssignTarget
+import com.pastura.models.Persona
+import com.pastura.models.Phase
+import com.pastura.models.PhaseType
+import com.pastura.models.Scenario
+import com.pastura.models.SimulationError
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+/**
+ * commonTest sibling of Swift's `ConditionalValidatorTests.swift`,
+ * `ConditionalValidatorTests+Narrate.swift`,
+ * `ConditionalValidatorTests+ParseTime.swift`,
+ * `ConditionalValidatorTests+Reflect.swift`,
+ * `ConditionalValidatorTests+RelationshipUpdate.swift`, and
+ * `ConditionalValidatorTests+Whisper.swift`
+ * (`Pastura/PasturaTests/Engine/`) — 24 tests, 1:1 by name with those six files.
+ *
+ * The parse-time tests (`rejectsMalformedConditionAtValidateTime`,
+ * `rejectsDanglingCombinatorAtValidateTime`) exercise
+ * `ConditionEvaluator.parse` indirectly: `ScenarioValidator.validateConditionalPhase`
+ * calls it as a pre-flight check and, on a
+ * `SimulationError.ScenarioValidationFailed`, rewraps the message as
+ * `"$phaseLabel: ..."` before rethrowing — so these tests pin the wrapped
+ * validator-level message, not `ConditionEvaluator.parse`'s own rendering.
+ */
+class ConditionalValidatorTests {
+
+    private val validator = ScenarioValidator()
+
+    /**
+     * Kotlin counterpart of Swift's `ConditionalValidatorTests.makeScenario`.
+     * Two agents, one round, `ja` scenario language — shared by every sibling
+     * test group below via the same suite-scoped helper Swift uses.
+     */
+    private fun makeScenario(phases: List<Phase>): Scenario = Scenario(
+        id = "t",
+        name = "T",
+        description = "t",
+        language = "ja",
+        agentCount = 2,
+        rounds = 1,
+        context = "c",
+        personas = listOf(Persona(name = "A", description = "a"), Persona(name = "B", description = "b")),
+        phases = phases,
+    )
+
+    // region ConditionalValidatorTests.swift
+
+    @Test
+    fun acceptsValidConditional() {
+        val scenario = makeScenario(
+            phases = listOf(
+                Phase(
+                    type = PhaseType.CONDITIONAL,
+                    condition = "current_round == 1",
+                    thenPhases = listOf(Phase(type = PhaseType.SUMMARIZE, template = "t")),
+                ),
+            ),
+        )
+        validator.validate(scenario)
+    }
+
+    @Test
+    fun rejectsEmptyCondition() {
+        val scenario = makeScenario(
+            phases = listOf(
+                Phase(
+                    type = PhaseType.CONDITIONAL,
+                    condition = "",
+                    thenPhases = listOf(Phase(type = PhaseType.SUMMARIZE, template = "t")),
+                ),
+            ),
+        )
+        val caught = assertFailsWith<SimulationException> { validator.validate(scenario) }
+        assertTrue(caught.error is SimulationError.ScenarioValidationFailed)
+    }
+
+    @Test
+    fun rejectsMissingCondition() {
+        val scenario = makeScenario(
+            phases = listOf(
+                Phase(
+                    type = PhaseType.CONDITIONAL,
+                    thenPhases = listOf(Phase(type = PhaseType.SUMMARIZE, template = "t")),
+                ),
+            ),
+        )
+        val caught = assertFailsWith<SimulationException> { validator.validate(scenario) }
+        assertTrue(caught.error is SimulationError.ScenarioValidationFailed)
+    }
+
+    @Test
+    fun rejectsWhitespaceOnlyCondition() {
+        val scenario = makeScenario(
+            phases = listOf(
+                Phase(
+                    type = PhaseType.CONDITIONAL,
+                    condition = "   \n  ",
+                    thenPhases = listOf(Phase(type = PhaseType.SUMMARIZE, template = "t")),
+                ),
+            ),
+        )
+        val caught = assertFailsWith<SimulationException> { validator.validate(scenario) }
+        assertTrue(caught.error is SimulationError.ScenarioValidationFailed)
+    }
+
+    @Test
+    fun rejectsBothBranchesEmpty() {
+        val scenario = makeScenario(
+            phases = listOf(
+                Phase(
+                    type = PhaseType.CONDITIONAL,
+                    condition = "current_round == 1",
+                    thenPhases = emptyList(),
+                    elsePhases = emptyList(),
+                ),
+            ),
+        )
+        val caught = assertFailsWith<SimulationException> { validator.validate(scenario) }
+        assertTrue(caught.error is SimulationError.ScenarioValidationFailed)
+    }
+
+    @Test
+    fun rejectsBothBranchesNil() {
+        val scenario = makeScenario(
+            phases = listOf(Phase(type = PhaseType.CONDITIONAL, condition = "current_round == 1")),
+        )
+        val caught = assertFailsWith<SimulationException> { validator.validate(scenario) }
+        assertTrue(caught.error is SimulationError.ScenarioValidationFailed)
+    }
+
+    @Test
+    fun acceptsOnlyThenBranch() {
+        val scenario = makeScenario(
+            phases = listOf(
+                Phase(
+                    type = PhaseType.CONDITIONAL,
+                    condition = "current_round == 1",
+                    thenPhases = listOf(Phase(type = PhaseType.SUMMARIZE, template = "t")),
+                ),
+            ),
+        )
+        validator.validate(scenario)
+    }
+
+    @Test
+    fun acceptsOnlyElseBranch() {
+        val scenario = makeScenario(
+            phases = listOf(
+                Phase(
+                    type = PhaseType.CONDITIONAL,
+                    condition = "current_round == 1",
+                    elsePhases = listOf(Phase(type = PhaseType.SUMMARIZE, template = "t")),
+                ),
+            ),
+        )
+        validator.validate(scenario)
+    }
+
+    @Test
+    fun rejectsNestedConditionalInThenBranch() {
+        // Non-YAML construction path — the loader covers the YAML side. This
+        // validator check catches scenarios built programmatically (tests,
+        // future editors, migrations).
+        val scenario = makeScenario(
+            phases = listOf(
+                Phase(
+                    type = PhaseType.CONDITIONAL,
+                    condition = "current_round == 1",
+                    thenPhases = listOf(Phase(type = PhaseType.CONDITIONAL, condition = "max_score > 0")),
+                ),
+            ),
+        )
+        val caught = assertFailsWith<SimulationException> { validator.validate(scenario) }
+        assertTrue(caught.error is SimulationError.ScenarioValidationFailed)
+    }
+
+    @Test
+    fun rejectsNestedConditionalInElseBranch() {
+        val scenario = makeScenario(
+            phases = listOf(
+                Phase(
+                    type = PhaseType.CONDITIONAL,
+                    condition = "current_round == 1",
+                    thenPhases = listOf(Phase(type = PhaseType.SUMMARIZE, template = "ok")),
+                    elsePhases = listOf(Phase(type = PhaseType.CONDITIONAL, condition = "max_score > 0")),
+                ),
+            ),
+        )
+        val caught = assertFailsWith<SimulationException> { validator.validate(scenario) }
+        assertTrue(caught.error is SimulationError.ScenarioValidationFailed)
+    }
+
+    // Regression: sub-phase semantic checks (e.g. assign target/source shape)
+    // must run inside conditional branches, not only at the top level.
+    @Test
+    fun rejectsAssignShapeMismatchInThenBranch() {
+        val scenario = Scenario(
+            id = "t",
+            name = "T",
+            description = "t",
+            language = "ja",
+            agentCount = 2,
+            rounds = 1,
+            context = "c",
+            personas = listOf(Persona(name = "A", description = "a"), Persona(name = "B", description = "b")),
+            phases = listOf(
+                Phase(
+                    type = PhaseType.CONDITIONAL,
+                    condition = "current_round == 1",
+                    thenPhases = listOf(
+                        // target .all with arrayOfDictionaries source is the exact
+                        // shape bug `validateAssignPhaseShape` exists to catch.
+                        Phase(type = PhaseType.ASSIGN, source = "topics", target = AssignTarget.ALL),
+                    ),
+                ),
+            ),
+            extraData = mapOf(
+                "topics" to AnyCodableValue.ArrayOfDictionariesValue(
+                    listOf(mapOf("majority" to "cat", "minority" to "dog")),
+                ),
+            ),
+        )
+        val caught = assertFailsWith<SimulationException> { validator.validate(scenario) }
+        assertTrue(caught.error is SimulationError.ScenarioValidationFailed)
+    }
+
+    // event_inject is allowed inside a conditional branch (consistent with
+    // assign / score_calc nesting). The validator applies the same
+    // shape-check it does at the top level.
+
+    @Test
+    fun acceptsEventInjectInThenBranch() {
+        val scenario = Scenario(
+            id = "t",
+            name = "T",
+            description = "t",
+            language = "ja",
+            agentCount = 2,
+            rounds = 1,
+            context = "c",
+            personas = listOf(Persona(name = "A", description = "a"), Persona(name = "B", description = "b")),
+            phases = listOf(
+                Phase(
+                    type = PhaseType.CONDITIONAL,
+                    condition = "current_round == 1",
+                    thenPhases = listOf(
+                        Phase(type = PhaseType.EVENT_INJECT, source = "events", probability = 0.5),
+                    ),
+                ),
+            ),
+            extraData = mapOf("events" to AnyCodableValue.ArrayValue(listOf("x", "y"))),
+        )
+        validator.validate(scenario)
+    }
+
+    @Test
+    fun rejectsEventInjectInThenBranchWithMissingSource() {
+        val scenario = Scenario(
+            id = "t",
+            name = "T",
+            description = "t",
+            language = "ja",
+            agentCount = 2,
+            rounds = 1,
+            context = "c",
+            personas = listOf(Persona(name = "A", description = "a"), Persona(name = "B", description = "b")),
+            phases = listOf(
+                Phase(
+                    type = PhaseType.CONDITIONAL,
+                    condition = "current_round == 1",
+                    thenPhases = listOf(
+                        // source key absent from extraData — should fail with the same
+                        // "not found" message we'd see at the top level, prefixed with
+                        // the branch label.
+                        Phase(type = PhaseType.EVENT_INJECT, source = "missing_events", probability = 1.0),
+                    ),
+                ),
+            ),
+        )
+        val caught = assertFailsWith<SimulationException> { validator.validate(scenario) }
+        val error = caught.error
+        assertTrue(error is SimulationError.ScenarioValidationFailed)
+        val message = error.message
+        assertTrue(message.contains("then[1]"))
+        assertTrue(message.contains("'missing_events'"))
+        assertTrue(message.contains("not found"))
+    }
+
+    @Test
+    fun rejectsEventInjectInElseBranchWithProbabilityOutOfRange() {
+        val scenario = Scenario(
+            id = "t",
+            name = "T",
+            description = "t",
+            language = "ja",
+            agentCount = 2,
+            rounds = 1,
+            context = "c",
+            personas = listOf(Persona(name = "A", description = "a"), Persona(name = "B", description = "b")),
+            phases = listOf(
+                Phase(
+                    type = PhaseType.CONDITIONAL,
+                    condition = "current_round == 99",
+                    thenPhases = listOf(Phase(type = PhaseType.SUMMARIZE, template = "ok")),
+                    elsePhases = listOf(
+                        Phase(type = PhaseType.EVENT_INJECT, source = "events", probability = 2.0),
+                    ),
+                ),
+            ),
+            extraData = mapOf("events" to AnyCodableValue.ArrayValue(listOf("x"))),
+        )
+        val caught = assertFailsWith<SimulationException> { validator.validate(scenario) }
+        val error = caught.error
+        assertTrue(error is SimulationError.ScenarioValidationFailed)
+        val message = error.message
+        assertTrue(message.contains("else[1]"))
+        assertTrue(message.contains("out of range"))
+    }
+
+    // endregion
+
+    // region ConditionalValidatorTests+Narrate.swift
+    // narrate is NOT allowed inside a conditional branch in v1 (#909). The
+    // validator rejects it at load-time (mirroring the reflect / whisper /
+    // relationship_update rejections) so it fails at the load gate rather than
+    // mid-run at `ConditionalHandler` dispatch (which omits narrate from its
+    // sub-handler map).
+
+    @Test
+    fun rejectsNarrateInThenBranch() {
+        val scenario = makeScenario(
+            phases = listOf(
+                Phase(
+                    type = PhaseType.CONDITIONAL,
+                    condition = "current_round == 1",
+                    thenPhases = listOf(Phase(type = PhaseType.NARRATE, prompt = "Narrate.")),
+                ),
+            ),
+        )
+        val caught = assertFailsWith<SimulationException> { validator.validate(scenario) }
+        assertTrue(caught.error is SimulationError.ScenarioValidationFailed)
+    }
+
+    @Test
+    fun rejectsNarrateInElseBranch() {
+        val scenario = makeScenario(
+            phases = listOf(
+                Phase(
+                    type = PhaseType.CONDITIONAL,
+                    condition = "current_round == 1",
+                    thenPhases = listOf(Phase(type = PhaseType.SUMMARIZE, template = "ok")),
+                    elsePhases = listOf(Phase(type = PhaseType.NARRATE, prompt = "Narrate.")),
+                ),
+            ),
+        )
+        val caught = assertFailsWith<SimulationException> { validator.validate(scenario) }
+        val error = caught.error
+        assertTrue(error is SimulationError.ScenarioValidationFailed)
+        val message = error.message
+        assertTrue(message.contains("else[1]"))
+        assertTrue(message.contains("narrate"))
+    }
+
+    // endregion
+
+    // region ConditionalValidatorTests+ParseTime.swift
+    // Pre-flight parse-time validation for conditional `if:` expressions.
+    // These cases ensure that malformed expressions surface at scenario-load
+    // time (validator), not mid-simulation when the handler dispatches —
+    // critical for gallery curation where curated scenarios must fail before
+    // shipping.
+
+    @Test
+    fun rejectsMalformedConditionAtValidateTime() {
+        val scenario = makeScenario(
+            phases = listOf(
+                Phase(
+                    type = PhaseType.CONDITIONAL,
+                    condition = "(current_round == 1 && max_score > 0",
+                    thenPhases = listOf(Phase(type = PhaseType.SUMMARIZE, template = "t")),
+                ),
+            ),
+        )
+        val caught = assertFailsWith<SimulationException> { validator.validate(scenario) }
+        assertTrue(caught.error is SimulationError.ScenarioValidationFailed)
+    }
+
+    @Test
+    fun rejectsDanglingCombinatorAtValidateTime() {
+        val scenario = makeScenario(
+            phases = listOf(
+                Phase(
+                    type = PhaseType.CONDITIONAL,
+                    condition = "current_round == 1 &&",
+                    thenPhases = listOf(Phase(type = PhaseType.SUMMARIZE, template = "t")),
+                ),
+            ),
+        )
+        val caught = assertFailsWith<SimulationException> { validator.validate(scenario) }
+        assertTrue(caught.error is SimulationError.ScenarioValidationFailed)
+    }
+
+    // endregion
+
+    // region ConditionalValidatorTests+Reflect.swift
+    // reflect is NOT allowed inside a conditional branch in v1. The validator
+    // rejects it at load-time (mirroring the nested-conditional rejection) so
+    // it fails here rather than at `ConditionalHandler` dispatch.
+
+    @Test
+    fun rejectsReflectInThenBranch() {
+        val scenario = makeScenario(
+            phases = listOf(
+                Phase(
+                    type = PhaseType.CONDITIONAL,
+                    condition = "current_round == 1",
+                    thenPhases = listOf(
+                        Phase(
+                            type = PhaseType.REFLECT,
+                            prompt = "Reflect.",
+                            outputSchema = mapOf("note" to "string"),
+                        ),
+                    ),
+                ),
+            ),
+        )
+        val caught = assertFailsWith<SimulationException> { validator.validate(scenario) }
+        assertTrue(caught.error is SimulationError.ScenarioValidationFailed)
+    }
+
+    @Test
+    fun rejectsReflectInElseBranch() {
+        val scenario = makeScenario(
+            phases = listOf(
+                Phase(
+                    type = PhaseType.CONDITIONAL,
+                    condition = "current_round == 1",
+                    thenPhases = listOf(Phase(type = PhaseType.SUMMARIZE, template = "ok")),
+                    elsePhases = listOf(
+                        Phase(
+                            type = PhaseType.REFLECT,
+                            prompt = "Reflect.",
+                            outputSchema = mapOf("note" to "string"),
+                        ),
+                    ),
+                ),
+            ),
+        )
+        val caught = assertFailsWith<SimulationException> { validator.validate(scenario) }
+        val error = caught.error
+        assertTrue(error is SimulationError.ScenarioValidationFailed)
+        val message = error.message
+        assertTrue(message.contains("else[1]"))
+        assertTrue(message.contains("reflect"))
+    }
+
+    // endregion
+
+    // region ConditionalValidatorTests+RelationshipUpdate.swift
+    // relationship_update is NOT allowed inside a conditional branch in v1.
+    // The validator rejects it at load-time (mirroring the nested-conditional,
+    // reflect, and whisper rejections) so it fails here rather than at
+    // `ConditionalHandler` dispatch — where it is also absent from
+    // `subHandlers` as a structural backstop.
+
+    @Test
+    fun rejectsRelationshipUpdateInThenBranch() {
+        val scenario = makeScenario(
+            phases = listOf(
+                Phase(
+                    type = PhaseType.CONDITIONAL,
+                    condition = "current_round == 1",
+                    thenPhases = listOf(Phase(type = PhaseType.RELATIONSHIP_UPDATE, voteAgainst = -1)),
+                ),
+            ),
+        )
+        val caught = assertFailsWith<SimulationException> { validator.validate(scenario) }
+        assertTrue(caught.error is SimulationError.ScenarioValidationFailed)
+    }
+
+    @Test
+    fun rejectsRelationshipUpdateInElseBranch() {
+        val scenario = makeScenario(
+            phases = listOf(
+                Phase(
+                    type = PhaseType.CONDITIONAL,
+                    condition = "current_round == 1",
+                    thenPhases = listOf(Phase(type = PhaseType.SUMMARIZE, template = "ok")),
+                    elsePhases = listOf(
+                        Phase(type = PhaseType.RELATIONSHIP_UPDATE, actionDeltas = mapOf("cooperate" to 1)),
+                    ),
+                ),
+            ),
+        )
+        val caught = assertFailsWith<SimulationException> { validator.validate(scenario) }
+        val error = caught.error
+        assertTrue(error is SimulationError.ScenarioValidationFailed)
+        val message = error.message
+        assertTrue(message.contains("else[1]"))
+        assertTrue(message.contains("relationship_update"))
+    }
+
+    // endregion
+
+    // region ConditionalValidatorTests+Whisper.swift
+    // whisper is NOT allowed inside a conditional branch in v1. The validator
+    // rejects it at load-time (mirroring the nested-conditional and reflect
+    // rejections) so it fails here rather than at `ConditionalHandler`
+    // dispatch.
+
+    @Test
+    fun rejectsWhisperInThenBranch() {
+        val scenario = makeScenario(
+            phases = listOf(
+                Phase(
+                    type = PhaseType.CONDITIONAL,
+                    condition = "current_round == 1",
+                    thenPhases = listOf(
+                        Phase(
+                            type = PhaseType.WHISPER,
+                            prompt = "Whisper.",
+                            outputSchema = mapOf("statement" to "string"),
+                        ),
+                    ),
+                ),
+            ),
+        )
+        val caught = assertFailsWith<SimulationException> { validator.validate(scenario) }
+        assertTrue(caught.error is SimulationError.ScenarioValidationFailed)
+    }
+
+    @Test
+    fun rejectsWhisperInElseBranch() {
+        val scenario = makeScenario(
+            phases = listOf(
+                Phase(
+                    type = PhaseType.CONDITIONAL,
+                    condition = "current_round == 1",
+                    thenPhases = listOf(Phase(type = PhaseType.SUMMARIZE, template = "ok")),
+                    elsePhases = listOf(
+                        Phase(
+                            type = PhaseType.WHISPER,
+                            prompt = "Whisper.",
+                            outputSchema = mapOf("statement" to "string"),
+                        ),
+                    ),
+                ),
+            ),
+        )
+        val caught = assertFailsWith<SimulationException> { validator.validate(scenario) }
+        val error = caught.error
+        assertTrue(error is SimulationError.ScenarioValidationFailed)
+        val message = error.message
+        assertTrue(message.contains("else[1]"))
+        assertTrue(message.contains("whisper"))
+    }
+
+    // endregion
+}

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/DivergenceLedger.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/DivergenceLedger.kt
@@ -90,8 +90,13 @@ internal object DivergenceLedger {
         DETECTOR_UNWIRED("SimulationEngine.kt class KDoc; ADR-023 §4"),
 
         /**
-         * Kotlin has no `ScenarioValidator` / `ScenarioSemanticLinter` port, so
-         * the preflight gate behaves differently for scenarios Swift rejects.
+         * Kotlin's `SimulationEngine` runs no preflight gate, so it behaves
+         * differently for scenarios Swift rejects. `ScenarioValidator.validate`
+         * is ported (run gate only — `validateForCommit` is #1552 B2) but
+         * deliberately unwired: ADR-023 §4 gates the preflight on the validator
+         * and `ScenarioSemanticLinter` together, and the linter is unported. The
+         * class name stays until the wiring lands — it names the gate, not the
+         * port.
          */
         VALIDATOR_UNPORTED("LanguageDispatch.kt KDoc; ADR-023 §4"),
 

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/ScenarioValidatorTestSupport.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/ScenarioValidatorTestSupport.kt
@@ -17,9 +17,11 @@ import com.pastura.models.Scenario
  * in which optional field they thread through, so this port collapses them into
  * one builder with defaults plus the thin wrappers below.
  *
- * Shared by `ScenarioValidatorTests.kt` and `ConditionalValidatorTests.kt` (the
- * latter lands with the rest of the 63-test port), which is why it is a
- * top-level file rather than a private helper on one suite. It is named
+ * Consumed by `ScenarioValidatorTests.kt` (63 of the port's 89 tests);
+ * `ConditionalValidatorTests.kt` (the other 26) keeps its own file-private
+ * `makeScenario`, mirroring the Swift suite's local helper. Top-level rather
+ * than private so the conditional suite can adopt it if the two ever
+ * converge. It is named
  * `makeValidatorScenario` rather than `makeScenario` because
  * `ConditionEvaluatorTestSupport.kt` already owns `makeTestScenario` in this
  * same package.
@@ -31,7 +33,9 @@ internal fun makeValidatorScenario(
     rounds: Int,
     phases: List<Phase>,
     logWindow: Int? = null,
-    language: String = "en",
+    // "ja" matches every Swift helper's default, so a future language-conditional
+    // rule exercises the same path on both sides.
+    language: String = "ja",
     simulationLanguage: String? = null,
     extraData: Map<String, AnyCodableValue> = emptyMap(),
 ): Scenario = Scenario(

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/ScenarioValidatorTestSupport.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/ScenarioValidatorTestSupport.kt
@@ -1,0 +1,84 @@
+package com.pastura.engine
+
+import com.pastura.models.AnyCodableValue
+import com.pastura.models.AssignTarget
+import com.pastura.models.Persona
+import com.pastura.models.Phase
+import com.pastura.models.PhaseType
+import com.pastura.models.Scenario
+
+/**
+ * Scenario builder for the [ScenarioValidator] test surface.
+ *
+ * Kotlin counterpart of the four private helpers on Swift's
+ * `ScenarioValidatorTests` (`makeScenario` / `makeLogWindowScenario` /
+ * `makeAssignScenario` / `makeEventInjectScenario`,
+ * `Pastura/PasturaTests/Engine/ScenarioValidatorTests.swift`). They differ only
+ * in which optional field they thread through, so this port collapses them into
+ * one builder with defaults plus the thin wrappers below.
+ *
+ * Shared by `ScenarioValidatorTests.kt` and `ConditionalValidatorTests.kt` (the
+ * latter lands with the rest of the 63-test port), which is why it is a
+ * top-level file rather than a private helper on one suite. It is named
+ * `makeValidatorScenario` rather than `makeScenario` because
+ * `ConditionEvaluatorTestSupport.kt` already owns `makeTestScenario` in this
+ * same package.
+ *
+ * Only the fields the validator reads carry meaning; the rest are placeholders.
+ */
+internal fun makeValidatorScenario(
+    agents: Int,
+    rounds: Int,
+    phases: List<Phase>,
+    logWindow: Int? = null,
+    language: String = "en",
+    simulationLanguage: String? = null,
+    extraData: Map<String, AnyCodableValue> = emptyMap(),
+): Scenario = Scenario(
+    id = "test",
+    name = "Test",
+    description = "Test",
+    language = language,
+    simulationLanguage = simulationLanguage,
+    agentCount = agents,
+    rounds = rounds,
+    logWindow = logWindow,
+    context = "Context",
+    personas = (1..agents).map { Persona(name = "Agent $it", description = "D") },
+    phases = phases,
+    extraData = extraData,
+)
+
+/** Two agents, one `speak_all` phase, and the `log_window` under test (#907). */
+internal fun makeLogWindowScenario(logWindow: Int?): Scenario = makeValidatorScenario(
+    agents = 2,
+    rounds = 1,
+    phases = listOf(Phase(type = PhaseType.SPEAK_ALL)),
+    logWindow = logWindow,
+)
+
+/** Two agents, a single `assign` phase with the target/source shape under test. */
+internal fun makeAssignScenario(
+    target: AssignTarget?,
+    source: String?,
+    extraData: Map<String, AnyCodableValue>,
+): Scenario = makeValidatorScenario(
+    agents = 2,
+    rounds = 1,
+    phases = listOf(Phase(type = PhaseType.ASSIGN, source = source, target = target)),
+    extraData = extraData,
+)
+
+/** Two agents, a single `event_inject` phase with the shape under test. */
+internal fun makeEventInjectScenario(
+    source: String?,
+    probability: Double?,
+    extraData: Map<String, AnyCodableValue>,
+): Scenario = makeValidatorScenario(
+    agents = 2,
+    rounds = 1,
+    phases = listOf(
+        Phase(type = PhaseType.EVENT_INJECT, source = source, probability = probability),
+    ),
+    extraData = extraData,
+)

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/ScenarioValidatorTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/ScenarioValidatorTests.kt
@@ -18,7 +18,131 @@ import kotlin.test.assertTrue
  * and `ScenarioValidatorTests+OutputFieldNames.swift`
  * (`Pastura/PasturaTests/Engine/`) — 62 tests, 1:1 by name with those four files.
  *
- * The ADR-023 §12 condition-4 perturbation record is added in a later commit.
+ * Three tests here and in [ConditionalValidatorTests] have **no Swift sibling** —
+ * [rejectsEventInjectWithEmptyDictSource],
+ * [ConditionalValidatorTests.rejectsMalformedConditionWithPhaseLabelPrefix], and
+ * [ConditionalValidatorTests.rejectsEmptyConditionWithMissingIfMessage]. They were
+ * added because the sweep below found their mechanisms uncovered on **both** sides;
+ * see note 3.
+ *
+ * ## ADR-023 §12 condition-4 perturbation record
+ *
+ * Each mechanism of
+ * `shared/engine/src/commonMain/kotlin/com/pastura/engine/ScenarioValidator.kt` was
+ * broken in isolation and the named **dedicated claimant** — a test that detects the
+ * break through **its own** assertion — confirmed to redden. Every mutation's anchor
+ * count was asserted before applying (all 50 matched **exactly once**) and the
+ * mutated text re-read to confirm it landed; a `replace` that silently no-ops leaves
+ * the original behaviour and reads as verified. The file was restored byte-identically
+ * after each run. The unmutated baseline was measured green (89 tests, both suites)
+ * immediately before the first mutation and again after the last revert, so every
+ * reddening below is signal rather than pre-existing noise. Counts are measured, not
+ * derived — re-measure rather than reason if you change a fixture. Measured
+ * 2026-08-26, #1552.
+ *
+ * The sweep ran **only** these two suites. That is sufficient rather than a shortcut:
+ * `grep` confirms no other `shared/engine` code constructs [ScenarioValidator] — the
+ * gate is deliberately not wired into the engine yet (see the class KDoc on
+ * [ScenarioValidator]), so no other suite could redden.
+ *
+ * | Mechanism broken | Mutation | Dedicated claimant | Incidental |
+ * |---|---|---|---|
+ * | `language` gate | `scenario.language !in ACCEPTED_LANGUAGES` → `in` | [rejectsInvalidLanguage] | 52 — every valid-language fixture then throws |
+ * | `simulationLanguage` null-accept arm | `val simulationLanguage = scenario.simulationLanguage` → `… ?: "fr"` | [acceptsNilSimulationLanguage] | 50 — every fixture leaves it null; see note 2 |
+ * | …membership polarity | `simulationLanguage !in …` → `in` | [rejectsInvalidSimulationLanguage] | none |
+ * | `agentCount` ≥ 2 | `if (scenario.agentCount < 2)` → `if (false)` | [rejectsZeroAgents], [rejectsSingleAgent] | none |
+ * | `agentCount` ≤ 10 | `if (scenario.agentCount > 10)` → `if (false)` | [rejectsMoreThan10Agents] | none |
+ * | persona count matches `agentCount` | `!=` → `==` | [rejectsPersonaCountMismatch] | 51 — every matched-persona fixture then throws |
+ * | `rounds` ≤ 30 | `if (scenario.rounds > 30)` → `if (false)` | [rejectsMoreThan30Rounds] | none |
+ * | `logWindow` ≥ 1 | `logWindow < 1` → `logWindow < 0` (not `if (false)`; see note 2) | [rejectsZeroLogWindow] | none |
+ * | Estimate > 100 is an error | `if (estimated > 100)` → `if (false)` | [errorsWhenInferencesExceed100] | none |
+ * | Estimate > 50 is a warning | `if (estimated > 50)` → `if (false)` | [warnsWhenInferencesExceed50] | none |
+ * | `validatePhases` ASSIGN arm | → `Unit` | all 7 top-level assign cases, e.g. [rejectsAssignAllWithDictionarySource] | none |
+ * | `validatePhases` CONDITIONAL arm | → `Unit` | all 22 rejecting [ConditionalValidatorTests] cases, plus [rejectsOutOfRangeInNestedBranch], [rejectsCjkOutputKeyInsideConditionalBranch], [rejectsEventInjectWithEmptyArraySourceInsideConditional] | none — all 25 fail on their own assertion |
+ * | `validatePhases` REFLECT arm | → `Unit` | [rejectsReflectWithoutNoteOutputAtRunGate] | none |
+ * | `validatePhases` WHISPER arm | → `Unit` | [rejectsWhisperWithoutStatementOutputAtRunGate] | none |
+ * | `validatePhases` RELATIONSHIP_UPDATE arm | → `Unit` | [rejectsRelationshipUpdateWithNoRuleAtRunGate], [rejectsRelationshipUpdateWithEmptyActionDeltas] | none |
+ * | `validatePhases` EVENT_INJECT arm | → `Unit` | all 9 top-level event_inject cases, e.g. [rejectsEventInjectWithStringSource] | none |
+ * | `max_sentences` range | `value !in 1..6` → `!in 0..7` | [rejectsMaxSentencesBelowRange], [rejectsMaxSentencesAboveRange], [rejectsOutOfRangeInNestedBranch] | none |
+ * | …checked at the **branch** site too | the `validateMaxSentences(subPhase, subLabel)` call deleted (branch site only) | [rejectsOutOfRangeInNestedBranch] | none |
+ * | Empty-`if` guard | `if (trimmedCondition.isEmpty())` → `if (false)` | [ConditionalValidatorTests.rejectsEmptyConditionWithMissingIfMessage] — **added**, note 3 | none |
+ * | Conditional parse pre-flight | the `ConditionEvaluator().parse(…)` call removed | [ConditionalValidatorTests.rejectsMalformedConditionAtValidateTime], [ConditionalValidatorTests.rejectsDanglingCombinatorAtValidateTime], [ConditionalValidatorTests.rejectsMalformedConditionWithPhaseLabelPrefix] | none |
+ * | `"$phaseLabel: "` rewrap of a parse error | the prefix dropped | [ConditionalValidatorTests.rejectsMalformedConditionWithPhaseLabelPrefix] — **added**, note 3 | none |
+ * | Empty-branches guard | `if (thenCount == 0 && elseCount == 0)` → `if (false)` | [ConditionalValidatorTests.rejectsBothBranchesEmpty], [ConditionalValidatorTests.rejectsBothBranchesNil] | none |
+ * | Depth guard | `if (depth > 0)` → `if (false)` | *(none — expected green, note 4)* | none |
+ * | Branch rejects CONDITIONAL | arm → `Unit` | [ConditionalValidatorTests.rejectsNestedConditionalInThenBranch], [ConditionalValidatorTests.rejectsNestedConditionalInElseBranch] | none |
+ * | Branch rejects REFLECT | arm → `Unit` | [ConditionalValidatorTests.rejectsReflectInThenBranch], [ConditionalValidatorTests.rejectsReflectInElseBranch] | none |
+ * | Branch rejects WHISPER | arm → `Unit` | [ConditionalValidatorTests.rejectsWhisperInThenBranch], [ConditionalValidatorTests.rejectsWhisperInElseBranch] | none |
+ * | Branch rejects RELATIONSHIP_UPDATE | arm → `Unit` | [ConditionalValidatorTests.rejectsRelationshipUpdateInThenBranch], [ConditionalValidatorTests.rejectsRelationshipUpdateInElseBranch] | none |
+ * | Branch rejects NARRATE | arm → `Unit` | [ConditionalValidatorTests.rejectsNarrateInThenBranch], [ConditionalValidatorTests.rejectsNarrateInElseBranch] | none |
+ * | Branch ASSIGN shape check | arm → `Unit` | [ConditionalValidatorTests.rejectsAssignShapeMismatchInThenBranch] | none |
+ * | Branch EVENT_INJECT shape check | arm → `Unit` | [ConditionalValidatorTests.rejectsEventInjectInThenBranchWithMissingSource], [ConditionalValidatorTests.rejectsEventInjectInElseBranchWithProbabilityOutOfRange], [rejectsEventInjectWithEmptyArraySourceInsideConditional] | none |
+ * | reflect `note` guard | `outputSchema["note"] == null` → `false` | [rejectsReflectWithoutNoteOutputAtRunGate] | none |
+ * | whisper `statement` guard | `outputSchema["statement"] == null` → `false` | [rejectsWhisperWithoutStatementOutputAtRunGate] | none |
+ * | relationship_update no-rule guard | `!hasVoteRule && !hasActionRule` → `false` | [rejectsRelationshipUpdateWithNoRuleAtRunGate], [rejectsRelationshipUpdateWithEmptyActionDeltas] | none |
+ * | assign source-missing guard | the `?: throw …SourceNotFound` → `?: return` | [rejectsAssignAllWhenSourceKeyMissingFromExtraData], [rejectsAssignRandomOneWhenSourceKeyMissingFromExtraData] | none |
+ * | assign ALL-arm rejection | grouped-shape arm → `Unit` | [rejectsAssignAllWithArrayOfDictionariesSource], [rejectsAssignAllWithDictionarySource], [rejectAssignAllWithBadShapeIncludesPhaseIndexAndSourceKey], [ConditionalValidatorTests.rejectsAssignShapeMismatchInThenBranch] | none |
+ * | assign RANDOM_ONE-arm rejection | ungrouped-shape arm → `Unit` | [rejectsAssignRandomOneWithArraySource], [rejectsAssignRandomOneWithStringSource] | none |
+ * | event_inject missing-`source` guard | `if (sourceKey.isEmpty())` → `if (false)` | [rejectsEventInjectWithMissingSource] | none — see note 5 |
+ * | event_inject source-not-found guard | the `?: throw …SourceNotFound` → `?: return` | [rejectsEventInjectWhenSourceKeyAbsentFromExtraData], [ConditionalValidatorTests.rejectsEventInjectInThenBranchWithMissingSource] | none |
+ * | event_inject empty-string-list guard | `if (sourceValue.value.isEmpty())` → `if (false)` | [rejectsEventInjectWithEmptyArraySource], [rejectsEventInjectWithEmptyArraySourceInsideConditional] | none |
+ * | event_inject wrong-shape arm | string / dictionary arm → `Unit` | [rejectsEventInjectWithStringSource], [rejectsEventInjectWithDictionarySource] | none |
+ * | event_inject empty-**events** guard (dict shape) | `if (entries.isEmpty())` → `if (false)` | [rejectsEventInjectWithEmptyDictSource] — **added**, note 3 | none |
+ * | event_inject entry-missing-`text` guard | `if (entries.any { … })` → `if (false)` | [rejectsEventInjectDictEntryMissingText] | none |
+ * | `probability` range | `value !in 0.0..1.0` → `!in -1.0..2.0` | [rejectsEventInjectWithProbabilityAboveOne], [rejectsEventInjectWithNegativeProbability], [ConditionalValidatorTests.rejectsEventInjectInElseBranchWithProbabilityOutOfRange] | none |
+ * | Output-field-name check at the **top-level** site | the `validateOutputFieldNames(phase, label)` call deleted | [rejectsCjkPrimaryOutputKey], [rejectsCjkSecondaryOutputKey], [rejectsNonAsciiLatinAndEmojiOutputKeys] | none |
+ * | …at the **branch** site | the `validateOutputFieldNames(subPhase, subLabel)` call deleted | [rejectsCjkOutputKeyInsideConditionalBranch] | none |
+ * | The field-name predicate itself | `firstOrNull { !isValidFieldName(it) }` → `firstOrNull { false }` | all four of the above | none |
+ * | `Long.clampToInt` narrowing | `coerceAtMost(Int.MAX_VALUE.toLong())` dropped | *(none — expected green, note 6)* | none |
+ * | reflect message `type` arg | `type = phase.type.serialName()` → `"x"` | *(none — expected green, note 7)* | none |
+ * | whisper message `type` arg | same, whisper site | *(none — expected green, note 7)* | none |
+ * | relationship_update message `type` arg | same, relationship_update site | *(none — expected green, note 7)* | none |
+ *
+ * Seven things this table encodes that are easy to misread:
+ *
+ * 1. ⚠️ **Re-measure the whole table when you add a fixture, not the row you were
+ *    thinking about** (the lesson [InferenceEstimatorTests]' record was corrected
+ *    for). This record is the second sweep: adding the three tests in note 3 moved
+ *    three `Incidental` / claimant cells that had nothing to do with them
+ *    (`validatePhases` CONDITIONAL 23 → 25 red, EVENT_INJECT 8 → 9, parse pre-flight
+ *    2 → 3). Every row above was re-measured after they landed.
+ * 2. **Two mutations do not compile in their obvious form, and the substitutes are
+ *    not equivalent.** `if (false)` on the `logWindow` and `simulationLanguage`
+ *    guards drops the smart cast their `!= null &&` left arm provides, so the throw
+ *    argument stops type-checking — the run then reddens *nothing* because no test
+ *    executes, which is a measurement defect, not a green. Both were re-run with
+ *    compiling substitutes (`< 0`, and an `?: "fr"` on the binding) that break the
+ *    same arm. A row that reports zero failures is only evidence when the suite
+ *    actually ran; the driver asserts a non-zero test count for that reason.
+ * 3. **Three mechanisms had no claimant on the first sweep, and the Swift suite has
+ *    none either** — verified by grep, not assumed. Rather than paper over them:
+ *    [rejectsEventInjectWithEmptyDictSource] (the dict-shaped source's own
+ *    empty-list guard — only the string shape was covered),
+ *    [ConditionalValidatorTests.rejectsMalformedConditionWithPhaseLabelPrefix], and
+ *    [ConditionalValidatorTests.rejectsEmptyConditionWithMissingIfMessage]. The last
+ *    two share one cause worth stating: `ConditionEvaluator.parse` throws the *same*
+ *    `SimulationError.ScenarioValidationFailed` the validator's own guards throw, so
+ *    every pre-existing test that asserts only the error **type** is blind to which
+ *    layer produced it. Only a message assertion separates them.
+ * 4. **The depth guard is unreachable, and that is the finding.** `validateBranch`
+ *    rejects a nested `conditional` outright, so `validateConditionalPhase` is only
+ *    ever entered with `depth = 0` and no fixture can reach `depth > 0`. It is
+ *    defensive parity with the Swift original, not dead code to delete — but nothing
+ *    here watches it.
+ * 5. **The event_inject missing-`source` row is a claimant only because its test
+ *    asserts the message.** With the guard disabled, the empty key falls through to
+ *    the source-not-found lookup and still throws, so an error-type-only assertion
+ *    would have stayed green; [rejectsEventInjectWithMissingSource] reddens on its
+ *    `contains("missing 'source'")` line. Same mechanism as note 3, caught in time.
+ * 6. **`clampToInt` is expected green.** Both call sites are documented as
+ *    display-only (the `> 100` throw has already fired, and the `> 50` band cannot
+ *    exceed `Int.MAX_VALUE`), so no reachable input distinguishes the clamp from a
+ *    bare `toInt()`.
+ * 7. **The three `serialName()` rows are an acknowledged gap, not a covered
+ *    mechanism.** Only a message-inspecting test could see the phase-type token, and
+ *    the reflect / whisper / relationship_update rejection tests assert the phase
+ *    label and the missing field name but never the type. A swapped or hardcoded
+ *    `type` argument would ship silently.
  */
 class ScenarioValidatorTests {
 
@@ -594,6 +718,26 @@ class ScenarioValidatorTests {
         )
         // Must NOT throw.
         validator.validate(scenario)
+    }
+
+    @Test
+    fun rejectsEventInjectWithEmptyDictSource() {
+        // No Swift sibling: the string-shaped empty-source case is covered on both
+        // sides, but nothing exercised `validateDictEventEntries`' own empty-list
+        // guard — the condition-4 sweep found it green under mutation. Added here
+        // because the guard is a distinct site from the string-shape one (#1552).
+        val scenario = makeEventInjectScenario(
+            source = "events",
+            probability = 1.0,
+            extraData = mapOf("events" to AnyCodableValue.ArrayOfDictionariesValue(emptyList())),
+        )
+        val caught = assertFailsWith<SimulationException> { validator.validate(scenario) }
+        val error = caught.error
+        assertTrue(error is SimulationError.ScenarioValidationFailed)
+        val message = error.message
+        assertTrue(message.contains("Phase 1 (event_inject)"))
+        assertTrue(message.contains("'events'"))
+        assertTrue(message.contains("empty"))
     }
 
     @Test

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/ScenarioValidatorTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/ScenarioValidatorTests.kt
@@ -16,7 +16,8 @@ import kotlin.test.assertTrue
  * commonTest sibling of Swift's `ScenarioValidatorTests.swift`,
  * `ScenarioValidatorTests+Language.swift`, `ScenarioValidatorTests+MaxSentences.swift`,
  * and `ScenarioValidatorTests+OutputFieldNames.swift`
- * (`Pastura/PasturaTests/Engine/`) — 62 tests, 1:1 by name with those four files.
+ * (`Pastura/PasturaTests/Engine/`) — 63 tests: 62 are 1:1 by name with those four
+ * files, plus one Kotlin-only pin (next paragraph).
  *
  * Three tests here and in [ConditionalValidatorTests] have **no Swift sibling** —
  * [rejectsEventInjectWithEmptyDictSource],
@@ -142,7 +143,9 @@ import kotlin.test.assertTrue
  *    mechanism.** Only a message-inspecting test could see the phase-type token, and
  *    the reflect / whisper / relationship_update rejection tests assert the phase
  *    label and the missing field name but never the type. A swapped or hardcoded
- *    `type` argument would ship silently.
+ *    `type` argument would ship silently. Closing it (one `contains("reflect")`
+ *    per test) was declined for Swift parity — the siblings assert type only —
+ *    not overlooked.
  */
 class ScenarioValidatorTests {
 
@@ -738,6 +741,10 @@ class ScenarioValidatorTests {
         assertTrue(message.contains("Phase 1 (event_inject)"))
         assertTrue(message.contains("'events'"))
         assertTrue(message.contains("empty"))
+        // Distinguishes the dict-shaped site from the string-shaped one — both
+        // render the three fragments above. Fragment sourced from
+        // `ScenarioValidationMessage.swift` (`eventInjectSourceEmptyEvents`).
+        assertTrue(message.contains("at least one event"), message)
     }
 
     @Test

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/ScenarioValidatorTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/ScenarioValidatorTests.kt
@@ -1,0 +1,55 @@
+package com.pastura.engine
+
+import com.pastura.models.AnyCodableValue
+import com.pastura.models.Phase
+import com.pastura.models.PhaseType
+import com.pastura.models.SimulationError
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+/**
+ * Smoke coverage for [ScenarioValidator]'s run gate — one accept, one limit
+ * rejection, one shape rejection. The remaining 60 siblings of Swift's
+ * `ScenarioValidatorTests` land in a follow-up commit, so three is the current
+ * count, not the intended coverage.
+ */
+class ScenarioValidatorTests {
+
+    private val validator = ScenarioValidator()
+
+    @Test
+    fun acceptsValidScenario() {
+        val scenario = makeValidatorScenario(
+            agents = 5,
+            rounds = 3,
+            phases = listOf(Phase(type = PhaseType.SPEAK_ALL)),
+        )
+        val result = validator.validate(scenario)
+        assertTrue(result.warnings.isEmpty())
+        assertEquals(15L, result.estimatedInferences)
+    }
+
+    @Test
+    fun rejectsZeroAgents() {
+        val scenario = makeValidatorScenario(
+            agents = 0,
+            rounds = 1,
+            phases = listOf(Phase(type = PhaseType.SPEAK_ALL)),
+        )
+        val caught = assertFailsWith<SimulationException> { validator.validate(scenario) }
+        assertTrue(caught.error is SimulationError.ScenarioValidationFailed)
+    }
+
+    @Test
+    fun rejectsEventInjectWithProbabilityAboveOne() {
+        val scenario = makeEventInjectScenario(
+            source = "events",
+            probability = 1.5,
+            extraData = mapOf("events" to AnyCodableValue.ArrayValue(listOf("A meteor lands."))),
+        )
+        val caught = assertFailsWith<SimulationException> { validator.validate(scenario) }
+        assertTrue(caught.error is SimulationError.ScenarioValidationFailed)
+    }
+}

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/ScenarioValidatorTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/ScenarioValidatorTests.kt
@@ -1,8 +1,11 @@
 package com.pastura.engine
 
 import com.pastura.models.AnyCodableValue
+import com.pastura.models.AssignTarget
+import com.pastura.models.Persona
 import com.pastura.models.Phase
 import com.pastura.models.PhaseType
+import com.pastura.models.Scenario
 import com.pastura.models.SimulationError
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -10,14 +13,18 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
 /**
- * Smoke coverage for [ScenarioValidator]'s run gate — one accept, one limit
- * rejection, one shape rejection. The remaining 60 siblings of Swift's
- * `ScenarioValidatorTests` land in a follow-up commit, so three is the current
- * count, not the intended coverage.
+ * commonTest sibling of Swift's `ScenarioValidatorTests.swift`,
+ * `ScenarioValidatorTests+Language.swift`, `ScenarioValidatorTests+MaxSentences.swift`,
+ * and `ScenarioValidatorTests+OutputFieldNames.swift`
+ * (`Pastura/PasturaTests/Engine/`) — 62 tests, 1:1 by name with those four files.
+ *
+ * The ADR-023 §12 condition-4 perturbation record is added in a later commit.
  */
 class ScenarioValidatorTests {
 
     private val validator = ScenarioValidator()
+
+    // region Core: agent count / round count / smoke
 
     @Test
     fun acceptsValidScenario() {
@@ -43,13 +50,830 @@ class ScenarioValidatorTests {
     }
 
     @Test
-    fun rejectsEventInjectWithProbabilityAboveOne() {
-        val scenario = makeEventInjectScenario(
-            source = "events",
-            probability = 1.5,
-            extraData = mapOf("events" to AnyCodableValue.ArrayValue(listOf("A meteor lands."))),
+    fun rejectsSingleAgent() {
+        val scenario = makeValidatorScenario(
+            agents = 1,
+            rounds = 1,
+            phases = listOf(Phase(type = PhaseType.SPEAK_ALL)),
         )
         val caught = assertFailsWith<SimulationException> { validator.validate(scenario) }
         assertTrue(caught.error is SimulationError.ScenarioValidationFailed)
     }
+
+    @Test
+    fun acceptsExactlyTwoAgents() {
+        val scenario = makeValidatorScenario(
+            agents = 2,
+            rounds = 1,
+            phases = listOf(Phase(type = PhaseType.SPEAK_ALL)),
+        )
+        val result = validator.validate(scenario)
+        assertTrue(result.warnings.isEmpty())
+    }
+
+    @Test
+    fun rejectsMoreThan10Agents() {
+        val scenario = makeValidatorScenario(
+            agents = 11,
+            rounds = 1,
+            phases = listOf(Phase(type = PhaseType.SPEAK_ALL)),
+        )
+        val caught = assertFailsWith<SimulationException> { validator.validate(scenario) }
+        assertTrue(caught.error is SimulationError.ScenarioValidationFailed)
+    }
+
+    @Test
+    fun rejectsMoreThan30Rounds() {
+        val scenario = makeValidatorScenario(
+            agents = 2,
+            rounds = 31,
+            phases = listOf(Phase(type = PhaseType.SPEAK_ALL)),
+        )
+        val caught = assertFailsWith<SimulationException> { validator.validate(scenario) }
+        assertTrue(caught.error is SimulationError.ScenarioValidationFailed)
+    }
+
+    // endregion
+
+    // region log_window (#907)
+
+    @Test
+    fun rejectsZeroLogWindow() {
+        val scenario = makeLogWindowScenario(logWindow = 0)
+        val caught = assertFailsWith<SimulationException> { validator.validate(scenario) }
+        assertTrue(caught.error is SimulationError.ScenarioValidationFailed)
+    }
+
+    @Test
+    fun acceptsLogWindowOfOne() {
+        val scenario = makeLogWindowScenario(logWindow = 1)
+        val result = validator.validate(scenario)
+        assertTrue(result.warnings.isEmpty())
+    }
+
+    @Test
+    fun acceptsNilLogWindow() {
+        val scenario = makeLogWindowScenario(logWindow = null)
+        val result = validator.validate(scenario)
+        assertTrue(result.warnings.isEmpty())
+    }
+
+    @Test
+    fun warnsWhenInferencesExceed50() {
+        // 10 agents × (speak_all + vote) × 3 rounds = 60
+        val scenario = makeValidatorScenario(
+            agents = 10,
+            rounds = 3,
+            phases = listOf(Phase(type = PhaseType.SPEAK_ALL), Phase(type = PhaseType.VOTE)),
+        )
+        val result = validator.validate(scenario)
+        assertTrue(result.warnings.isNotEmpty())
+        assertEquals(60L, result.estimatedInferences)
+    }
+
+    @Test
+    fun errorsWhenInferencesExceed100() {
+        // 10 agents × (speak_all + speak_each(3) + vote) × 3 rounds = 150
+        val scenario = makeValidatorScenario(
+            agents = 10,
+            rounds = 3,
+            phases = listOf(
+                Phase(type = PhaseType.SPEAK_ALL),
+                Phase(type = PhaseType.SPEAK_EACH, subRounds = 3),
+                Phase(type = PhaseType.VOTE),
+            ),
+        )
+        val caught = assertFailsWith<SimulationException> { validator.validate(scenario) }
+        assertTrue(caught.error is SimulationError.ScenarioValidationFailed)
+    }
+
+    @Test
+    fun returnsEstimatedInferences() {
+        val scenario = makeValidatorScenario(
+            agents = 5,
+            rounds = 2,
+            phases = listOf(Phase(type = PhaseType.SPEAK_ALL), Phase(type = PhaseType.VOTE)),
+        )
+        val result = validator.validate(scenario)
+        assertEquals(20L, result.estimatedInferences)
+    }
+
+    @Test
+    fun reflectPhaseAddsAgentCountPerRound() {
+        // reflect costs one inference per agent per round (like speak_all / vote).
+        // 5 agents × (speak_all + reflect) × 2 rounds = 20.
+        val scenario = makeValidatorScenario(
+            agents = 5,
+            rounds = 2,
+            phases = listOf(
+                Phase(type = PhaseType.SPEAK_ALL),
+                Phase(type = PhaseType.REFLECT, outputSchema = mapOf("note" to "string")),
+            ),
+        )
+        val result = validator.validate(scenario)
+        assertEquals(20L, result.estimatedInferences)
+    }
+
+    @Test
+    fun rejectsReflectWithoutNoteOutputAtRunGate() {
+        // Run-gate strictness beyond sibling LLM phases: a schema-less reflect is
+        // a pure no-op inference (nothing stored, no visible symptom), so
+        // `validate` — not just `validateForCommit` — requires the `note` field.
+        val scenario = makeValidatorScenario(
+            agents = 2,
+            rounds = 1,
+            phases = listOf(Phase(type = PhaseType.REFLECT)),
+        )
+        val caught = assertFailsWith<SimulationException> { validator.validate(scenario) }
+        assertTrue(caught.error is SimulationError.ScenarioValidationFailed)
+    }
+
+    @Test
+    fun acceptsReflectWithExtraOutputFieldAlongsideNote() {
+        // Only `note` presence is required at the run gate; additional fields
+        // (unusual but legal) do not trip it.
+        val scenario = makeValidatorScenario(
+            agents = 2,
+            rounds = 1,
+            phases = listOf(
+                Phase(
+                    type = PhaseType.REFLECT,
+                    outputSchema = mapOf("note" to "string", "mood" to "string"),
+                ),
+            ),
+        )
+        validator.validate(scenario)
+    }
+
+    // endregion
+
+    // region whisper (#908)
+
+    @Test
+    fun rejectsWhisperWithoutStatementOutputAtRunGate() {
+        // Like reflect, a whisper without its canonical `statement` output burns
+        // one inference per participant and stores nothing user-visible, so
+        // `validate` (the run gate, not just `validateForCommit`) requires it.
+        val scenario = makeValidatorScenario(
+            agents = 2,
+            rounds = 1,
+            phases = listOf(Phase(type = PhaseType.WHISPER)),
+        )
+        val caught = assertFailsWith<SimulationException> { validator.validate(scenario) }
+        assertTrue(caught.error is SimulationError.ScenarioValidationFailed)
+    }
+
+    @Test
+    fun acceptsWhisperWithStatementOutput() {
+        val scenario = makeValidatorScenario(
+            agents = 2,
+            rounds = 1,
+            phases = listOf(
+                Phase(type = PhaseType.WHISPER, outputSchema = mapOf("statement" to "string")),
+            ),
+        )
+        validator.validate(scenario)
+    }
+
+    // endregion
+
+    // region relationship_update (#910)
+
+    @Test
+    fun rejectsRelationshipUpdateWithNoRuleAtRunGate() {
+        // A relationship_update with neither `vote_against` nor `action_deltas` is
+        // a pure no-op (reads signals, applies zero deltas, injects nothing), so
+        // the run gate requires at least one rule — like reflect/whisper shape.
+        val scenario = makeValidatorScenario(
+            agents = 2,
+            rounds = 1,
+            phases = listOf(Phase(type = PhaseType.RELATIONSHIP_UPDATE)),
+        )
+        val caught = assertFailsWith<SimulationException> { validator.validate(scenario) }
+        assertTrue(caught.error is SimulationError.ScenarioValidationFailed)
+    }
+
+    @Test
+    fun acceptsRelationshipUpdateWithVoteRuleOnly() {
+        val scenario = makeValidatorScenario(
+            agents = 2,
+            rounds = 1,
+            phases = listOf(Phase(type = PhaseType.RELATIONSHIP_UPDATE, voteAgainst = -1)),
+        )
+        validator.validate(scenario)
+    }
+
+    @Test
+    fun acceptsRelationshipUpdateWithActionRuleOnly() {
+        val scenario = makeValidatorScenario(
+            agents = 2,
+            rounds = 1,
+            phases = listOf(
+                Phase(
+                    type = PhaseType.RELATIONSHIP_UPDATE,
+                    actionDeltas = mapOf("cooperate" to 1),
+                ),
+            ),
+        )
+        validator.validate(scenario)
+    }
+
+    @Test
+    fun rejectsRelationshipUpdateWithEmptyActionDeltas() {
+        // An empty `action_deltas: {}` map counts as no rule — same no-op shape.
+        val scenario = makeValidatorScenario(
+            agents = 2,
+            rounds = 1,
+            phases = listOf(
+                Phase(type = PhaseType.RELATIONSHIP_UPDATE, actionDeltas = emptyMap()),
+            ),
+        )
+        val caught = assertFailsWith<SimulationException> { validator.validate(scenario) }
+        assertTrue(caught.error is SimulationError.ScenarioValidationFailed)
+    }
+
+    @Test
+    fun rejectsPersonaCountMismatch() {
+        // Constructed directly because makeValidatorScenario auto-generates
+        // matching personas.
+        val scenario = Scenario(
+            id = "test",
+            name = "Test",
+            description = "Test",
+            language = "ja",
+            agentCount = 3,
+            rounds = 1,
+            context = "Context",
+            personas = listOf(Persona(name = "A", description = "D"), Persona(name = "B", description = "D")),
+            phases = listOf(Phase(type = PhaseType.SPEAK_ALL)),
+        )
+        val caught = assertFailsWith<SimulationException> { validator.validate(scenario) }
+        assertTrue(caught.error is SimulationError.ScenarioValidationFailed)
+    }
+
+    // endregion
+
+    // region Assign phase: target "all" (or nil) shape checks
+    // Unknown-target rejection now lives in ScenarioLoaderTests (caught at parse).
+
+    @Test
+    fun acceptsAssignAllWithStringSource() {
+        val scenario = makeAssignScenario(
+            target = AssignTarget.ALL,
+            source = "topic",
+            extraData = mapOf("topic" to AnyCodableValue.StringValue("Hi")),
+        )
+        validator.validate(scenario)
+    }
+
+    @Test
+    fun acceptsAssignAllWithArraySource() {
+        val scenario = makeAssignScenario(
+            target = AssignTarget.ALL,
+            source = "topics",
+            extraData = mapOf("topics" to AnyCodableValue.ArrayValue(listOf("A", "B"))),
+        )
+        validator.validate(scenario)
+    }
+
+    @Test
+    fun rejectsAssignAllWhenSourceKeyMissingFromExtraData() {
+        val scenario = makeAssignScenario(target = AssignTarget.ALL, source = "topics", extraData = emptyMap())
+        val caught = assertFailsWith<SimulationException> { validator.validate(scenario) }
+        val error = caught.error
+        assertTrue(error is SimulationError.ScenarioValidationFailed)
+        val message = error.message
+        assertTrue(message.contains("Phase 1 (assign)"))
+        assertTrue(message.contains("'topics'"))
+        assertTrue(message.contains("not found"))
+    }
+
+    @Test
+    fun acceptsAssignAllWithNilSource() {
+        // Visual Editor compat: no source specified, skip shape check
+        val scenario = makeAssignScenario(target = AssignTarget.ALL, source = null, extraData = emptyMap())
+        validator.validate(scenario)
+    }
+
+    @Test
+    fun acceptsAssignWithDefaultTarget() {
+        // nil target defaults to .all behaviour; valid array source should pass
+        val scenario = makeAssignScenario(
+            target = null,
+            source = "topics",
+            extraData = mapOf("topics" to AnyCodableValue.ArrayValue(listOf("A", "B"))),
+        )
+        validator.validate(scenario)
+    }
+
+    @Test
+    fun rejectsAssignAllWithArrayOfDictionariesSource() {
+        val scenario = makeAssignScenario(
+            target = AssignTarget.ALL,
+            source = "words",
+            extraData = mapOf(
+                "words" to AnyCodableValue.ArrayOfDictionariesValue(
+                    listOf(mapOf("majority" to "x", "minority" to "y")),
+                ),
+            ),
+        )
+        val caught = assertFailsWith<SimulationException> { validator.validate(scenario) }
+        assertTrue(caught.error is SimulationError.ScenarioValidationFailed)
+    }
+
+    @Test
+    fun rejectsAssignAllWithDictionarySource() {
+        val scenario = makeAssignScenario(
+            target = AssignTarget.ALL,
+            source = "w",
+            extraData = mapOf("w" to AnyCodableValue.DictionaryValue(mapOf("a" to "b"))),
+        )
+        val caught = assertFailsWith<SimulationException> { validator.validate(scenario) }
+        assertTrue(caught.error is SimulationError.ScenarioValidationFailed)
+    }
+
+    /** User-facing error must include 1-based phase index and source key
+     * — these end up in editor / import UI verbatim. */
+    @Test
+    fun rejectAssignAllWithBadShapeIncludesPhaseIndexAndSourceKey() {
+        val scenario = makeAssignScenario(
+            target = AssignTarget.ALL,
+            source = "words",
+            extraData = mapOf(
+                "words" to AnyCodableValue.ArrayOfDictionariesValue(
+                    listOf(mapOf("majority" to "x", "minority" to "y")),
+                ),
+            ),
+        )
+        val caught = assertFailsWith<SimulationException> { validator.validate(scenario) }
+        val error = caught.error
+        assertTrue(error is SimulationError.ScenarioValidationFailed)
+        val message = error.message
+        assertTrue(message.contains("Phase 1 (assign)"))
+        assertTrue(message.contains("'words'"))
+    }
+
+    // endregion
+
+    // region Assign phase: target "random_one" shape checks
+
+    @Test
+    fun acceptsAssignRandomOneWithArrayOfDictionariesSource() {
+        val scenario = makeAssignScenario(
+            target = AssignTarget.RANDOM_ONE,
+            source = "words",
+            extraData = mapOf(
+                "words" to AnyCodableValue.ArrayOfDictionariesValue(
+                    listOf(mapOf("majority" to "x", "minority" to "y")),
+                ),
+            ),
+        )
+        validator.validate(scenario)
+    }
+
+    @Test
+    fun rejectsAssignRandomOneWithArraySource() {
+        val scenario = makeAssignScenario(
+            target = AssignTarget.RANDOM_ONE,
+            source = "topics",
+            extraData = mapOf("topics" to AnyCodableValue.ArrayValue(listOf("A", "B"))),
+        )
+        val caught = assertFailsWith<SimulationException> { validator.validate(scenario) }
+        assertTrue(caught.error is SimulationError.ScenarioValidationFailed)
+    }
+
+    @Test
+    fun rejectsAssignRandomOneWithStringSource() {
+        val scenario = makeAssignScenario(
+            target = AssignTarget.RANDOM_ONE,
+            source = "topic",
+            extraData = mapOf("topic" to AnyCodableValue.StringValue("Hi")),
+        )
+        val caught = assertFailsWith<SimulationException> { validator.validate(scenario) }
+        assertTrue(caught.error is SimulationError.ScenarioValidationFailed)
+    }
+
+    @Test
+    fun rejectsAssignRandomOneWhenSourceKeyMissingFromExtraData() {
+        val scenario = makeAssignScenario(target = AssignTarget.RANDOM_ONE, source = "words", extraData = emptyMap())
+        val caught = assertFailsWith<SimulationException> { validator.validate(scenario) }
+        val error = caught.error
+        assertTrue(error is SimulationError.ScenarioValidationFailed)
+        val message = error.message
+        assertTrue(message.contains("Phase 1 (assign)"))
+        assertTrue(message.contains("'words'"))
+        assertTrue(message.contains("not found"))
+    }
+
+    // endregion
+
+    // region event_inject validation
+
+    @Test
+    fun acceptsEventInjectWithArraySource() {
+        val scenario = makeEventInjectScenario(
+            source = "events",
+            probability = 0.5,
+            extraData = mapOf("events" to AnyCodableValue.ArrayValue(listOf("x", "y"))),
+        )
+        val result = validator.validate(scenario)
+        assertTrue(result.warnings.isEmpty())
+    }
+
+    @Test
+    fun rejectsEventInjectWithMissingSource() {
+        val scenario = makeEventInjectScenario(source = null, probability = 1.0, extraData = emptyMap())
+        val caught = assertFailsWith<SimulationException> { validator.validate(scenario) }
+        val error = caught.error
+        assertTrue(error is SimulationError.ScenarioValidationFailed)
+        val message = error.message
+        assertTrue(message.contains("Phase 1 (event_inject)"))
+        assertTrue(message.contains("missing 'source'"))
+    }
+
+    @Test
+    fun rejectsEventInjectWhenSourceKeyAbsentFromExtraData() {
+        val scenario = makeEventInjectScenario(source = "events", probability = 1.0, extraData = emptyMap())
+        val caught = assertFailsWith<SimulationException> { validator.validate(scenario) }
+        val error = caught.error
+        assertTrue(error is SimulationError.ScenarioValidationFailed)
+        val message = error.message
+        assertTrue(message.contains("Phase 1 (event_inject)"))
+        assertTrue(message.contains("'events'"))
+        assertTrue(message.contains("not found"))
+    }
+
+    @Test
+    fun rejectsEventInjectWithDictionarySource() {
+        val scenario = makeEventInjectScenario(
+            source = "events",
+            probability = 1.0,
+            extraData = mapOf("events" to AnyCodableValue.DictionaryValue(mapOf("a" to "x"))),
+        )
+        val caught = assertFailsWith<SimulationException> { validator.validate(scenario) }
+        val error = caught.error
+        assertTrue(error is SimulationError.ScenarioValidationFailed)
+        val message = error.message
+        assertTrue(message.contains("Phase 1 (event_inject)"))
+        assertTrue(message.contains("must be a list of event strings"))
+        assertTrue(message.contains("['only_event']")) // workaround hint
+    }
+
+    @Test
+    fun rejectsEventInjectWithEmptyArraySource() {
+        val scenario = makeEventInjectScenario(
+            source = "events",
+            probability = 1.0,
+            extraData = mapOf("events" to AnyCodableValue.ArrayValue(emptyList())),
+        )
+        val caught = assertFailsWith<SimulationException> { validator.validate(scenario) }
+        val error = caught.error
+        assertTrue(error is SimulationError.ScenarioValidationFailed)
+        val message = error.message
+        assertTrue(message.contains("Phase 1 (event_inject)"))
+        assertTrue(message.contains("'events'"))
+        assertTrue(message.contains("empty"))
+    }
+
+    @Test
+    fun rejectsEventInjectWithEmptyArraySourceInsideConditional() {
+        // Locks in the engine.md invariant that validateBranch routes
+        // sub-phase shape-checks through the same validateEventInjectShape
+        // helper as top-level — a regression that bypassed the helper for
+        // nested phases would silently re-allow empty arrays inside branches.
+        val inner = Phase(type = PhaseType.EVENT_INJECT, source = "events", probability = 1.0)
+        val conditional = Phase(
+            type = PhaseType.CONDITIONAL,
+            condition = "current_round == 1",
+            thenPhases = listOf(inner),
+        )
+        val scenario = Scenario(
+            id = "test",
+            name = "Test",
+            description = "Test",
+            language = "ja",
+            agentCount = 2,
+            rounds = 1,
+            context = "Context",
+            personas = listOf(Persona(name = "A", description = "D"), Persona(name = "B", description = "D")),
+            phases = listOf(conditional),
+            extraData = mapOf("events" to AnyCodableValue.ArrayValue(emptyList())),
+        )
+        val caught = assertFailsWith<SimulationException> { validator.validate(scenario) }
+        val error = caught.error
+        assertTrue(error is SimulationError.ScenarioValidationFailed)
+        val message = error.message
+        assertTrue(message.contains("event_inject"))
+        assertTrue(message.contains("empty"))
+    }
+
+    @Test
+    fun rejectsEventInjectWithStringSource() {
+        val scenario = makeEventInjectScenario(
+            source = "events",
+            probability = 1.0,
+            extraData = mapOf("events" to AnyCodableValue.StringValue("just one")),
+        )
+        val caught = assertFailsWith<SimulationException> { validator.validate(scenario) }
+        val error = caught.error
+        assertTrue(error is SimulationError.ScenarioValidationFailed)
+        assertTrue(error.message.contains("must be a list of event strings"))
+    }
+
+    @Test
+    fun acceptsEventInjectWithDictSource() {
+        // #931: dict-shaped events `{ text, favors }` are a valid source shape.
+        val scenario = makeEventInjectScenario(
+            source = "events",
+            probability = 1.0,
+            extraData = mapOf(
+                "events" to AnyCodableValue.ArrayOfDictionariesValue(
+                    listOf(mapOf("text" to "抜け駆けが得", "favors" to "betray")),
+                ),
+            ),
+        )
+        // Must NOT throw.
+        validator.validate(scenario)
+    }
+
+    @Test
+    fun rejectsEventInjectDictEntryMissingText() {
+        // A dict entry without a non-empty `text` injects "" (silent no-op) — reject.
+        val scenario = makeEventInjectScenario(
+            source = "events",
+            probability = 1.0,
+            extraData = mapOf(
+                "events" to AnyCodableValue.ArrayOfDictionariesValue(listOf(mapOf("favors" to "betray"))),
+            ),
+        )
+        val caught = assertFailsWith<SimulationException> { validator.validate(scenario) }
+        val error = caught.error
+        assertTrue(error is SimulationError.ScenarioValidationFailed)
+        val message = error.message
+        assertTrue(message.contains("Phase 1 (event_inject)"))
+        assertTrue(message.contains("'text'"))
+    }
+
+    @Test
+    fun rejectsEventInjectWithProbabilityAboveOne() {
+        val scenario = makeEventInjectScenario(
+            source = "events",
+            probability = 1.5,
+            extraData = mapOf("events" to AnyCodableValue.ArrayValue(listOf("x"))),
+        )
+        val caught = assertFailsWith<SimulationException> { validator.validate(scenario) }
+        val error = caught.error
+        assertTrue(error is SimulationError.ScenarioValidationFailed)
+        val message = error.message
+        assertTrue(message.contains("probability"))
+        assertTrue(message.contains("out of range"))
+    }
+
+    @Test
+    fun rejectsEventInjectWithNegativeProbability() {
+        val scenario = makeEventInjectScenario(
+            source = "events",
+            probability = -0.1,
+            extraData = mapOf("events" to AnyCodableValue.ArrayValue(listOf("x"))),
+        )
+        val caught = assertFailsWith<SimulationException> { validator.validate(scenario) }
+        val error = caught.error
+        assertTrue(error is SimulationError.ScenarioValidationFailed)
+        assertTrue(error.message.contains("out of range"))
+    }
+
+    @Test
+    fun acceptsEventInjectAtProbabilityBoundaries() {
+        val lower = makeEventInjectScenario(
+            source = "events",
+            probability = 0.0,
+            extraData = mapOf("events" to AnyCodableValue.ArrayValue(listOf("x"))),
+        )
+        val upper = makeEventInjectScenario(
+            source = "events",
+            probability = 1.0,
+            extraData = mapOf("events" to AnyCodableValue.ArrayValue(listOf("x"))),
+        )
+        validator.validate(lower)
+        validator.validate(upper)
+    }
+
+    @Test
+    fun acceptsEventInjectWithoutProbability() {
+        // Default-1.0 (set at handler) is fine; no validation required.
+        val scenario = makeEventInjectScenario(
+            source = "events",
+            probability = null,
+            extraData = mapOf("events" to AnyCodableValue.ArrayValue(listOf("x"))),
+        )
+        validator.validate(scenario)
+    }
+
+    // endregion
+
+    // region language + simulationLanguage validation (DoD #2, #5)
+
+    @Test
+    fun rejectsInvalidLanguage() {
+        val scenario = makeValidatorScenario(agents = 2, rounds = 1, phases = emptyList(), language = "fr")
+        val caught = assertFailsWith<SimulationException> { validator.validate(scenario) }
+        val error = caught.error
+        assertTrue(error is SimulationError.ScenarioValidationFailed)
+        val message = error.message
+        assertTrue(message.contains("language"))
+        assertTrue(message.contains("fr"))
+    }
+
+    @Test
+    fun rejectsInvalidSimulationLanguage() {
+        val scenario = makeValidatorScenario(
+            agents = 2,
+            rounds = 1,
+            phases = emptyList(),
+            simulationLanguage = "fr",
+        )
+        val caught = assertFailsWith<SimulationException> { validator.validate(scenario) }
+        val error = caught.error
+        assertTrue(error is SimulationError.ScenarioValidationFailed)
+        val message = error.message
+        assertTrue(message.contains("simulationLanguage"))
+        assertTrue(message.contains("fr"))
+    }
+
+    @Test
+    fun acceptsValidJa() {
+        val scenario = makeValidatorScenario(agents = 2, rounds = 1, phases = emptyList(), language = "ja")
+        validator.validate(scenario)
+    }
+
+    @Test
+    fun acceptsValidEn() {
+        val scenario = makeValidatorScenario(agents = 2, rounds = 1, phases = emptyList(), language = "en")
+        validator.validate(scenario)
+    }
+
+    @Test
+    fun acceptsNilSimulationLanguage() {
+        // default simulationLanguage: null
+        val scenario = makeValidatorScenario(agents = 2, rounds = 1, phases = emptyList())
+        validator.validate(scenario)
+    }
+
+    // endregion
+
+    // region Per-phase max_sentences range (#881)
+
+    @Test
+    fun rejectsMaxSentencesBelowRange() {
+        val scenario = makeValidatorScenario(
+            agents = 2,
+            rounds = 1,
+            phases = listOf(Phase(type = PhaseType.SPEAK_ALL, maxSentences = 0)),
+        )
+        val caught = assertFailsWith<SimulationException> { validator.validate(scenario) }
+        assertTrue(caught.error is SimulationError.ScenarioValidationFailed)
+    }
+
+    @Test
+    fun rejectsMaxSentencesAboveRange() {
+        val scenario = makeValidatorScenario(
+            agents = 2,
+            rounds = 1,
+            phases = listOf(Phase(type = PhaseType.SPEAK_ALL, maxSentences = 7)),
+        )
+        val caught = assertFailsWith<SimulationException> { validator.validate(scenario) }
+        assertTrue(caught.error is SimulationError.ScenarioValidationFailed)
+    }
+
+    @Test
+    fun acceptsMaxSentencesAtBounds() {
+        for (value in listOf(1, 6)) {
+            val scenario = makeValidatorScenario(
+                agents = 2,
+                rounds = 1,
+                phases = listOf(Phase(type = PhaseType.SPEAK_ALL, maxSentences = value)),
+            )
+            validator.validate(scenario)
+        }
+    }
+
+    @Test
+    fun acceptsNilMaxSentences() {
+        val scenario = makeValidatorScenario(
+            agents = 2,
+            rounds = 1,
+            phases = listOf(Phase(type = PhaseType.SPEAK_ALL, maxSentences = null)),
+        )
+        validator.validate(scenario)
+    }
+
+    /** The range check runs at the `validateBranch` traversal site too — an
+     * out-of-range value on a phase nested inside a conditional `then:` is
+     * rejected, not silently skipped. */
+    @Test
+    fun rejectsOutOfRangeInNestedBranch() {
+        val scenario = makeValidatorScenario(
+            agents = 2,
+            rounds = 1,
+            phases = listOf(
+                Phase(
+                    type = PhaseType.CONDITIONAL,
+                    condition = "max_score >= 10",
+                    thenPhases = listOf(Phase(type = PhaseType.SPEAK_ALL, maxSentences = 0)),
+                ),
+            ),
+        )
+        val caught = assertFailsWith<SimulationException> { validator.validate(scenario) }
+        assertTrue(caught.error is SimulationError.ScenarioValidationFailed)
+    }
+
+    // endregion
+
+    // region output field NAMES ASCII-identifier rule (#607)
+
+    @Test
+    fun rejectsCjkPrimaryOutputKey() {
+        val scenario = makeValidatorScenario(
+            agents = 2,
+            rounds = 1,
+            phases = listOf(
+                Phase(type = PhaseType.SPEAK_ALL, prompt = "p", outputSchema = mapOf("内なる思考" to "string")),
+            ),
+        )
+        val caught = assertFailsWith<SimulationException> { validator.validate(scenario) }
+        assertTrue(caught.error is SimulationError.ScenarioValidationFailed)
+    }
+
+    /** Critic Axis 2: a valid canonical primary does NOT excuse a hostile
+     * *secondary* key — every output key reaches the grammar, so all keys are
+     * gated, not just the canonical primary. */
+    @Test
+    fun rejectsCjkSecondaryOutputKey() {
+        val scenario = makeValidatorScenario(
+            agents = 2,
+            rounds = 1,
+            phases = listOf(
+                Phase(
+                    type = PhaseType.SPEAK_ALL,
+                    prompt = "p",
+                    outputSchema = mapOf("statement" to "string", "内なる思考" to "string"),
+                ),
+            ),
+        )
+        val caught = assertFailsWith<SimulationException> { validator.validate(scenario) }
+        assertTrue(caught.error is SimulationError.ScenarioValidationFailed)
+    }
+
+    /** Emoji / accented-Latin keys are equally rejected — the boundary is ASCII,
+     * not "CJK specifically". */
+    @Test
+    fun rejectsNonAsciiLatinAndEmojiOutputKeys() {
+        for (badKey in listOf("café", "emoji😀", "naïve")) {
+            val scenario = makeValidatorScenario(
+                agents = 2,
+                rounds = 1,
+                phases = listOf(
+                    Phase(type = PhaseType.SPEAK_ALL, prompt = "p", outputSchema = mapOf(badKey to "string")),
+                ),
+            )
+            assertFailsWith<SimulationException>("key '$badKey' should be rejected") {
+                validator.validate(scenario)
+            }
+        }
+    }
+
+    /** Hostile keys buried inside a conditional `then:` / `else:` branch are
+     * caught by the same recursion that runs the canonical-field check. */
+    @Test
+    fun rejectsCjkOutputKeyInsideConditionalBranch() {
+        val nested = Phase(type = PhaseType.SPEAK_ALL, prompt = "p", outputSchema = mapOf("статус" to "string"))
+        val conditional = Phase(
+            type = PhaseType.CONDITIONAL,
+            condition = "max_score >= 1",
+            thenPhases = listOf(nested),
+        )
+        val scenario = makeValidatorScenario(agents = 2, rounds = 1, phases = listOf(conditional))
+        val caught = assertFailsWith<SimulationException> { validator.validate(scenario) }
+        assertTrue(caught.error is SimulationError.ScenarioValidationFailed)
+    }
+
+    /** Control: ASCII snake_case keys (the shape every preset uses) pass clean. */
+    @Test
+    fun acceptsAsciiOutputKeys() {
+        val scenario = makeValidatorScenario(
+            agents = 2,
+            rounds = 1,
+            phases = listOf(
+                Phase(
+                    type = PhaseType.SPEAK_ALL,
+                    prompt = "p",
+                    outputSchema = mapOf("statement" to "string", "inner_thought" to "string"),
+                ),
+            ),
+        )
+        val result = validator.validate(scenario)
+        assertTrue(result.warnings.isEmpty())
+    }
+
+    // endregion
 }


### PR DESCRIPTION
## Summary

ADR-023 Stage 3 「Load + validate」の **PR B1** — Swift `ScenarioValidator` の run gate（`validate()`）を `shared/engine` commonMain に port し、commonTest 兄弟を付ける。#1464（PR A）が名指した PR B のうち、commit gate（`validateForCommit` / `+CanonicalFields.swift`、29 テスト）は **B2** に送る（B 全体だと `subagent-usage.md` §2 の hard split を超えるため）。

- `ScenarioValidator.kt` — `ScenarioValidator.swift` + `+EventInject` + `+OutputFieldNames` の 1:1 port。`public class`、`@Throws(SimulationException::class)`（commonMain 初の `@Throws`。K/N は未注釈関数の例外を Swift の `catch` に渡さずプロセス終了する）。推定値は `Long` のまま比較し、`Int` 型メッセージへは clamp。
- `ScenarioValidatorTests.kt`（63 = Swift 62 + Kotlin-only 1）/ `ConditionalValidatorTests.kt`（26 = Swift 24 + Kotlin-only 2）— 同名 1:1、期待リテラルは Swift 側から採取。
- ADR-023 §12 条件4 の摂動記録: 50 変異を単独適用して専任 claimant の赤化を計測（`ScenarioValidatorTests.kt` class KDoc）。claimant 不在だった 3 機構（dict 形 empty-events guard、`"Phase N (conditional): "` の包み直し、empty-`if` guard）にテストを追加。
- KDoc / docs 追従: 「validator は Stage-3 port 待ち」→「run gate のみ port 済み・commit gate は B2・linter 未 port・`SimulationEngine` 未配線」。Swift 3 ファイルに Kotlin twin への dual-landing ポインタ。

**しないこと**: `SimulationEngine` preflight への配線（ADR-023 §4 原文どおり、linter と一体で繋ぐ。`DivergenceLedger.VALIDATOR_UNPORTED` は残す）。`ConditionEvaluator.parse` への `@Throws`（同じ穴、別スコープ — follow-up issue を立てる）。

既知の表現差 5 件（指数表記 / NaN・Inf / trim の文字集合 / ソート順 / `Int.MAX` 超の推定値表示）は class KDoc に記録、ledger 化しない（検証エラーは transcript に届かない）。

## Test plan

- `./gradlew :shared:models:jvmTest :shared:engine:jvmTest :shared:engine:compileTestKotlinMacosArm64` — 緑
- `scripts/xcodebuild.sh test -skip-testing:PasturaUITests` — 3,557 tests / 286 suites 緑（Swift 差分は doc comment のみ）
- `swiftlint lint --strict` — 緑
- UI テストはスキップ（Swift 差分がコメントのみ）

## Review

Reviewer: **Opus**（`code-reviewer`、4 シャード: 実装 / `ScenarioValidatorTests` / `ConditionalValidatorTests` + ledger / docs）。全シャード PASS、Critical 0、Warning 8 件を適用:
- class KDoc の表現差リストに `Int.MAX` clamp を 5 件目として追加、trim の差は accept/reject に効くと明記
- `InferenceEstimator.kt` の「consumer 未着」KDoc を再ポイント
- `+EventInject.swift` / `+OutputFieldNames.swift` にも dual-landing ポインタ、本体側の文言を `ScenarioLoader.swift` 先例に揃える
- テスト側 KDoc の件数（26 / 63 / 89）を実測に修正、`makeValidatorScenario` の既定言語を Swift と同じ `"ja"` に、追加テストにサイト識別の断片を 1 本

却下: 「`+EventInject` / `+OutputFieldNames` の ledger 行を `FOLDED` に」— §4 継承規則 1 で sibling は base の disposition（`PORT`）を取る。「`assertTrue(msg.contains(..), msg)` を全件に」— 既存スイート全体の様式で本 PR のスコープ外。

## Device QA

実機QA不要 — Kotlin commonMain/commonTest とコメントのみ。iOS 実行経路に変更なし。

Part of #1552 / Part of #501

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UghRKin6TSY7BkmaACDeLh
