### PR TITLE
✨ feat: ADR-023 Stage 3 — ScenarioValidator commit-gate port (PR B2)

### DIFF
--- a/Pastura/Pastura/Engine/ScenarioValidator.swift
+++ b/Pastura/Pastura/Engine/ScenarioValidator.swift
@@ -10,9 +10,10 @@ import Foundation
 /// **Dual-landed with
 /// `shared/engine/src/commonMain/kotlin/com/pastura/engine/ScenarioValidator.kt`**
 /// (spelled out so a move leaves a greppable string behind) — change both
-/// (ADR-023). The Kotlin twin carries the run gate (`validate`) from this file,
-/// `+EventInject` and `+OutputFieldNames`; `validateForCommit` /
-/// `+CanonicalFields` are not ported yet (#1552 B2). No checker verifies that
+/// (ADR-023). The Kotlin twin now carries this whole gate — both `validate` and
+/// `validateForCommit` from this file, plus `+EventInject`,
+/// `+OutputFieldNames` and `+CanonicalFields` (#1554, #1552). No checker
+/// verifies that
 /// an edit here was mirrored — for any ledger disposition — so the pairing is
 /// yours to honour; `.claude/rules/kmp-interop.md` does not load for
 /// `Pastura/**`, `engine.md` does.

--- a/Pastura/Pastura/Engine/ScenarioValidator.swift
+++ b/Pastura/Pastura/Engine/ScenarioValidator.swift
@@ -11,11 +11,10 @@ import Foundation
 /// `shared/engine/src/commonMain/kotlin/com/pastura/engine/ScenarioValidator.kt`**
 /// (spelled out so a move leaves a greppable string behind) — change both
 /// (ADR-023). The Kotlin twin now carries this whole gate — both `validate` and
-/// `validateForCommit` from this file, plus `+EventInject`,
-/// `+OutputFieldNames` and `+CanonicalFields` (#1554, #1552). No checker
-/// verifies that
-/// an edit here was mirrored — for any ledger disposition — so the pairing is
-/// yours to honour; `.claude/rules/kmp-interop.md` does not load for
+/// `validateForCommit` from this file, plus `+EventInject`, `+OutputFieldNames`
+/// and `+CanonicalFields` (PR #1554 = B1, and B2 on issue #1552). No checker
+/// verifies that an edit here was mirrored — for any ledger disposition — so the
+/// pairing is yours to honour; `.claude/rules/kmp-interop.md` does not load for
 /// `Pastura/**`, `engine.md` does.
 nonisolated public struct ScenarioValidator: Sendable {
 

--- a/docs/kmp-migration-status.md
+++ b/docs/kmp-migration-status.md
@@ -45,7 +45,7 @@ Legend: ✅ done · 🔄 in progress · 🟡 partial · ⬜ not started.
 | Wave A — non-handler run-path (scoring, mechanisms, prompt/LLM glue) | ✅ done | #1207 #1212 #1217 |
 | Wave B — 14 phase handlers | ✅ 14/14 | checklist ↓ |
 | code-phase track | ✅ done | CP1 #1226 · CP2 #1230 · CP3 #1232 |
-| Loader / validator port + `detector`·`logger` wiring | 🟡 partial | validator prerequisites in ([#1464](https://github.com/tyabu12/pastura/issues/1464)); validator run gate in ([#1552](https://github.com/tyabu12/pastura/issues/1552) B1); commit gate (B2) / loader / linter / wiring left · [ADR-023](decisions/ADR-023.md) §4 · #501 |
+| Loader / validator port + `detector`·`logger` wiring | 🟡 partial | validator prerequisites in ([#1464](https://github.com/tyabu12/pastura/issues/1464)); validator fully ported — run gate + commit gate ([#1552](https://github.com/tyabu12/pastura/issues/1552) B1/B2); loader / linter / preflight wiring left · [ADR-023](decisions/ADR-023.md) §4 · #501 |
 
 ### Wave B handler checklist
 

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/LLMCaller.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/LLMCaller.kt
@@ -401,7 +401,9 @@ internal class LLMCaller(
      * The [expectedKeys] precondition is a **compatibility guard, not a
      * refinement**: `ScenarioValidator.validateForCommit` (ported to commonMain
      * in #1552, and still Swift's own gate on the iOS side) enforces the
-     * canonical field at commit time and nothing re-checks it at run time, so a
+     * canonical field at commit time, and the run gate re-checks it for only two
+     * phase types (reflect's `note`, whisper's `statement`) — never for the speak
+     * / choose / vote phases this guard covers — so a
      * scenario persisted before that gate — or imported under ADR-020
      * backward-compat — can omit it from `output:` entirely. The grammar never
      * generates an undeclared key, so without this guard the field would read absent

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/LLMCaller.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/LLMCaller.kt
@@ -399,7 +399,8 @@ internal class LLMCaller(
      * arrives absent, empty, or as the `"..."` filler.
      *
      * The [expectedKeys] precondition is a **compatibility guard, not a
-     * refinement**: Swift's `ScenarioValidator.validateForCommit` enforces the
+     * refinement**: `ScenarioValidator.validateForCommit` (ported to commonMain
+     * in #1552, and still Swift's own gate on the iOS side) enforces the
      * canonical field at commit time and nothing re-checks it at run time, so a
      * scenario persisted before that gate — or imported under ADR-020
      * backward-compat — can omit it from `output:` entirely. The grammar never

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/ScenarioValidator.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/ScenarioValidator.kt
@@ -25,11 +25,14 @@ import com.pastura.models.SimulationError
  * trap on sibling extensions; Kotlin has neither constraint, so the whole gate
  * lives here.
  *
- * ## Scope: the RUN gate only
+ * ## Scope: both gates, neither wired
  *
- * `validateForCommit` and the canonical primary-field checks
- * (`ScenarioValidator+CanonicalFields.swift`) are **not** ported yet — they land
- * in a follow-up PR. Everything `validate(_:)` runs is here.
+ * Both halves are ported: the run gate [validate] (#1554, PR B1) and the commit
+ * gate [validateForCommit] plus its canonical-field checks, Swift's
+ * `ScenarioValidator+CanonicalFields.swift` (#1552, PR B2). What remains
+ * unported from ADR-023 §4's "Load + validate" row is `ScenarioLoader` and
+ * `ScenarioSemanticLinter` (ADR-024) — see the next section for why the
+ * linter's absence keeps even the ported half unwired.
  *
  * ## Not wired into the engine
  *

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/ScenarioValidator.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/ScenarioValidator.kt
@@ -2,6 +2,7 @@ package com.pastura.engine
 
 import com.pastura.models.AnyCodableValue
 import com.pastura.models.AssignTarget
+import com.pastura.models.OutputSchema
 import com.pastura.models.Phase
 import com.pastura.models.PhaseType
 import com.pastura.models.Scenario
@@ -194,6 +195,155 @@ public class ScenarioValidator {
         }
 
         return ValidationResult(warnings = warnings, estimatedInferences = estimated)
+    }
+
+    /**
+     * Strict validation gate for commit-to-persist callsites
+     * (`ScenarioEditorViewModel.save()`).
+     *
+     * Runs every check [validate] runs, then adds the canonical primary-field
+     * requirement: every LLM phase must declare its
+     * [ScenarioConventions.primaryField] key in `output:`. The engine and UI key
+     * on those canonical fields, so a scenario that omits them silently breaks
+     * (empty conversation log, blank UI rows, `options[0]` fallback for choose).
+     * Surfacing the error at commit time keeps already-persisted scenarios
+     * runnable while preventing new ones from entering the database in the
+     * broken shape.
+     *
+     * ## Deliberately `public`, unlike the Swift original
+     *
+     * Swift's `validateForCommit(_:)` is module-`internal`; this is the port's
+     * **first deliberate access-level widening**. An `internal` Kotlin member is
+     * not emitted into the exported Obj-C header at all, and the Stage-5 K/N
+     * consumer (`ScenarioEditorViewModel.save()`, ADR-023 §6) calls this across
+     * that boundary — so `internal` here would compile fine and leave the
+     * commit gate simply unreachable from Swift. Read this modifier as a
+     * decision, not as a copy of [validate]'s.
+     *
+     * `@Throws` is load-bearing for the same reason it is on [validate]: an
+     * un-annotated Kotlin throw does not reach Swift as a catchable error at the
+     * K/N boundary — it terminates the process.
+     *
+     * @return the [ValidationResult] produced by [validate].
+     * @throws SimulationException carrying
+     *   [SimulationError.ScenarioValidationFailed] if a limit is exceeded or a
+     *   canonical output field is missing / mis-named.
+     */
+    @Throws(SimulationException::class)
+    public fun validateForCommit(scenario: Scenario): ValidationResult {
+        val result = validate(scenario)
+        validateCanonicalFields(scenario)
+        return result
+    }
+
+    /**
+     * Enforces [ScenarioConventions.primaryField] and
+     * [ScenarioConventions.thoughtField] for LLM phases, descending into
+     * `then:` / `else:` sub-phases so violations nested in a branch are caught
+     * at commit time. Code phases are exempt (the conventions tables return
+     * `null` and the per-phase checks return early). Termination is trivial:
+     * `conditional` is depth-1 by both [validateConditionalPhase] and the YAML
+     * parser (`ScenarioLoader.mapPhase`), so the recursion bottoms out after one
+     * descent.
+     *
+     * ## The branch descent is phase-type-independent by design
+     *
+     * Unlike [validatePhases], which reaches branches only through its
+     * [PhaseType.CONDITIONAL] arm, this walks `thenPhases` / `elsePhases` for
+     * **every** phase type, and the parent label is therefore derived from
+     * `phase.type.serialName()` rather than hardcoded to `"(conditional)"`. That
+     * is not an oversight to be "fixed" into symmetry with [validatePhases]:
+     * this gate guards the programmatic-construction path, where a
+     * non-conditional phase can carry `thenPhases`, and such a violation must
+     * render `"Phase 1 (speak_all) then[1]"` — a label naming the wrong phase
+     * type would send the author looking at a phase that does not exist.
+     * Mirrors Swift's `validateCanonicalFields(_:)`, which descends
+     * unconditionally for the same reason.
+     */
+    private fun validateCanonicalFields(scenario: Scenario) {
+        scenario.phases.forEachIndexed { index, phase ->
+            val label = "Phase ${index + 1}"
+            validateCanonicalFields(phase, label)
+            val parentLabel = "$label (${phase.type.serialName()})"
+            validateBranchCanonicalFields(phase.thenPhases, parentLabel, "then")
+            validateBranchCanonicalFields(phase.elsePhases, parentLabel, "else")
+        }
+    }
+
+    /** Runs both canonical-field checks (primary + thought) for one phase. */
+    private fun validateCanonicalFields(phase: Phase, label: String) {
+        validateCanonicalPrimaryField(phase, label)
+        validateCanonicalThoughtField(phase, label)
+    }
+
+    /**
+     * Requires the phase's canonical primary output key to be declared in
+     * `output:`. A phase type with no canonical primary (every code phase, plus
+     * `narrate`, whose schema is Engine-fixed) returns `null` from the
+     * conventions table and is exempt.
+     */
+    private fun validateCanonicalPrimaryField(phase: Phase, label: String) {
+        val canonical = ScenarioConventions.primaryField(phase.type) ?: return
+        val schema = phase.outputSchema ?: emptyMap()
+        if (schema[canonical] == null) {
+            throw validationError(
+                ScenarioValidationMessage.RequiresOutputField(
+                    label = label,
+                    type = phase.type.serialName(),
+                    field = canonical,
+                ),
+            )
+        }
+    }
+
+    /**
+     * Enforces [ScenarioConventions.thoughtField]: when a phase declares any
+     * known secondary key ([OutputSchema.knownSecondaryKeys] — `inner_thought` /
+     * `reason`), it must be the phase's canonical thought field (vote→`reason`,
+     * speak_all / speak_each / choose→`inner_thought`). The secondary field is
+     * optional, so a phase that declares none passes. (Swift's `///` original
+     * writes that list as a `speak*` glob; a block comment cannot, since the
+     * glob's second character would close the KDoc.)
+     *
+     * Checks **every** declared known-secondary key rather than only
+     * `OutputSchema.thoughtFieldName`'s priority pick, so a stray `reason`
+     * alongside a canonical `inner_thought` is still caught. This is what keeps
+     * the live-streaming THINKING source (`OutputSchema.thoughtFieldName`,
+     * schema-driven) and the committed source (`TurnOutput.secondaryText`,
+     * phase-hardcoded) reading the same key — a choose authored with `reason`
+     * streamed live but went blank on commit (#760).
+     */
+    private fun validateCanonicalThoughtField(phase: Phase, label: String) {
+        val canonical = ScenarioConventions.thoughtField(phase.type) ?: return
+        val schema = phase.outputSchema ?: emptyMap()
+        for (key in OutputSchema.knownSecondaryKeys) {
+            if (schema[key] != null && key != canonical) {
+                throw validationError(
+                    ScenarioValidationMessage.SecondaryFieldMismatch(
+                        label = label,
+                        type = phase.type.serialName(),
+                        canonical = canonical,
+                        key = key,
+                    ),
+                )
+            }
+        }
+    }
+
+    /**
+     * Applies [validateCanonicalFields] to each sub-phase of one branch, with
+     * the same `parent branch[n]` label shape [validateBranch] uses so every
+     * branch-related validator message reads from a single mental template.
+     */
+    private fun validateBranchCanonicalFields(
+        phases: List<Phase>?,
+        parentLabel: String,
+        branchLabel: String,
+    ) {
+        phases ?: return
+        phases.forEachIndexed { subIndex, subPhase ->
+            validateCanonicalFields(subPhase, "$parentLabel $branchLabel[${subIndex + 1}]")
+        }
     }
 
     /**

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/ScenarioValidator.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/ScenarioValidator.kt
@@ -11,28 +11,31 @@ import com.pastura.models.ScenarioValidationMessage
 import com.pastura.models.SimulationError
 
 /**
- * Validates a [Scenario] against execution limits before running.
+ * Validates a [Scenario] against execution limits.
  *
- * Enforces agent count (2–10), round count (≤30), estimated inference count
- * (warn >50, error >100), and phase-field semantics (e.g. assign-phase
- * target/source compatibility) to prevent runaway or misconfigured simulations.
+ * Two entry points, not one. [validate] is the **run gate**: agent count (2–10),
+ * round count (≤30), estimated inference count (warn >50, error >100), and
+ * phase-field semantics (e.g. assign-phase target/source compatibility), all to
+ * prevent runaway or misconfigured simulations. [validateForCommit] is the
+ * **commit gate**: everything the run gate checks, plus the canonical
+ * output-field requirement that only applies when a scenario is being persisted.
  *
- * Kotlin port of `Pastura/Pastura/Engine/ScenarioValidator.swift` plus its two
- * sibling extensions `ScenarioValidator+EventInject.swift` and
- * `ScenarioValidator+OutputFieldNames.swift` (ADR-023 §4, the "Load + validate"
- * row). The Swift originals split across three files only to stay under
+ * Kotlin port of `Pastura/Pastura/Engine/ScenarioValidator.swift` plus its three
+ * sibling extensions `ScenarioValidator+EventInject.swift`,
+ * `ScenarioValidator+OutputFieldNames.swift` and
+ * `ScenarioValidator+CanonicalFields.swift` (ADR-023 §4, the "Load + validate"
+ * row). The Swift originals split across four files only to stay under
  * SwiftLint's file/type length caps and to dodge a default-MainActor isolation
  * trap on sibling extensions; Kotlin has neither constraint, so the whole gate
  * lives here.
  *
  * ## Scope: both gates, neither wired
  *
- * Both halves are ported: the run gate [validate] (#1554, PR B1) and the commit
- * gate [validateForCommit] plus its canonical-field checks, Swift's
- * `ScenarioValidator+CanonicalFields.swift` (#1552, PR B2). What remains
- * unported from ADR-023 §4's "Load + validate" row is `ScenarioLoader` and
- * `ScenarioSemanticLinter` (ADR-024) — see the next section for why the
- * linter's absence keeps even the ported half unwired.
+ * Both halves are ported, under issue #1552: the run gate [validate] (PR #1554,
+ * B1) and the commit gate [validateForCommit] with its canonical-field checks
+ * (PR B2). What remains unported from ADR-023 §4's "Load + validate" row is
+ * `ScenarioLoader` and `ScenarioSemanticLinter` (ADR-024) — see the next
+ * section for why the linter's absence keeps even the ported half unwired.
  *
  * ## Not wired into the engine
  *
@@ -226,6 +229,16 @@ public class ScenarioValidator {
      * `@Throws` is load-bearing for the same reason it is on [validate]: an
      * un-annotated Kotlin throw does not reach Swift as a catchable error at the
      * K/N boundary — it terminates the process.
+     *
+     * Do not assume the resulting export is CI-protected. It has no Swift
+     * consumer yet, and the only Swift consumer there will ever be is the gate
+     * spike under `tools/kmp-gate-spike`, which builds **nightly**
+     * (`.claude/rules/kmp-interop.md`). A later rename or signature change here
+     * reddens a nightly run, not the PR that breaks it. (The spike's path is
+     * written without its usual trailing `-slash-star-star` glob on purpose:
+     * Kotlin block comments **nest**, so that sequence inside a KDoc opens a
+     * second comment, and the next close-marker ends only the inner one —
+     * silently commenting out the rest of the file. Measured here, the hard way.)
      *
      * @return the [ValidationResult] produced by [validate].
      * @throws SimulationException carrying

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/SimulationEngine.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/SimulationEngine.kt
@@ -42,7 +42,7 @@ import kotlinx.coroutines.launch
  *
  * | Absent | Why |
  * |---|---|
- * | `ScenarioValidator` preflight + `ScenarioSemanticLinter` (ADR-024) | §4's `Load + validate` row, which the linter joined on 2026-07-19 (before that, §4 did not mention it and this row's `(§4)` citation pointed at nothing). [ScenarioValidator] ports the **run gate only** (`validate`; the commit gate `validateForCommit` is #1552 B2) and the linter is unported; neither is wired here, because §4 gates the preflight on both together and wiring one side would split it across languages. Nothing gates a scenario on this side yet, which is why the ported code must not assume validator floors — see `PromptBuilder`. |
+ * | `ScenarioValidator` preflight + `ScenarioSemanticLinter` (ADR-024) | §4's `Load + validate` row, which the linter joined on 2026-07-19 (before that, §4 did not mention it and this row's `(§4)` citation pointed at nothing). [ScenarioValidator] is now ported in full — run gate `validate` (#1554) and commit gate `validateForCommit` (#1552) — but the linter is unported; neither is wired here, because §4 gates the preflight on both together and wiring one side would split it across languages. Nothing gates a scenario on this side yet, which is why the ported code must not assume validator floors — see `PromptBuilder`. |
  * | Resume (`resumingFrom` seed / `startRound`) | needs the Data layer's persisted state; D2 keeps Data in Swift |
  * | `LanguageDetector` / `EngineLogger` injection | injection is Stage-3 freight — absent from `PhaseContext`. §4 ports both **seams only** (`LanguageDetector` in PR-3, `EngineLogger` in PR-2); the concrete `OSLogEngineLogger` / `NLLanguageDetector` stay in Swift App/ |
  *

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/DivergenceLedger.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/DivergenceLedger.kt
@@ -91,9 +91,10 @@ internal object DivergenceLedger {
 
         /**
          * Kotlin's `SimulationEngine` runs no preflight gate, so it behaves
-         * differently for scenarios Swift rejects. `ScenarioValidator.validate`
-         * is ported (run gate only — `validateForCommit` is #1552 B2) but
-         * deliberately unwired: ADR-023 §4 gates the preflight on the validator
+         * differently for scenarios Swift rejects. `ScenarioValidator` is now
+         * ported in full — the run gate `validate` (#1554) and the commit gate
+         * `validateForCommit` (#1552) — but deliberately unwired: ADR-023 §4
+         * gates the preflight on the validator
          * and `ScenarioSemanticLinter` together, and the linter is unported. The
          * class name stays until the wiring lands — it names the gate, not the
          * port.

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/ScenarioValidatorCommitTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/ScenarioValidatorCommitTests.kt
@@ -1,0 +1,81 @@
+package com.pastura.engine
+
+import com.pastura.models.Phase
+import com.pastura.models.PhaseType
+import com.pastura.models.SimulationError
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+/**
+ * Smoke coverage for [ScenarioValidator.validateForCommit] — the commit-gate
+ * half of the validator, ported from Swift's
+ * `Pastura/Pastura/Engine/ScenarioValidator+CanonicalFields.swift`.
+ *
+ * Deliberately minimal: three cases pinning accept, reject, and the
+ * phase-type-derived branch label. The full 1:1 port of Swift's
+ * `Pastura/PasturaTests/Engine/ScenarioValidatorTests+Commit.swift` (29 tests) lands in
+ * the next commit on this branch.
+ */
+class ScenarioValidatorCommitTests {
+
+    private val validator = ScenarioValidator()
+
+    @Test
+    fun acceptsSpeakAllWithCanonicalStatementField() {
+        val scenario = makeValidatorScenario(
+            agents = 2,
+            rounds = 1,
+            phases = listOf(
+                Phase(type = PhaseType.SPEAK_ALL, outputSchema = mapOf("statement" to "string")),
+            ),
+        )
+        val result = validator.validateForCommit(scenario)
+        assertTrue(result.warnings.isEmpty())
+    }
+
+    @Test
+    fun rejectsSpeakAllMissingCanonicalStatementField() {
+        val scenario = makeValidatorScenario(
+            agents = 2,
+            rounds = 1,
+            phases = listOf(
+                Phase(type = PhaseType.SPEAK_ALL, outputSchema = mapOf("appeal" to "string")),
+            ),
+        )
+        val caught = assertFailsWith<SimulationException> { validator.validateForCommit(scenario) }
+        val error = caught.error
+        assertTrue(error is SimulationError.ScenarioValidationFailed)
+        assertTrue(error.message.contains("'statement'"))
+    }
+
+    /**
+     * Pins the phase-type-derived branch parent label: the canonical-field
+     * descent visits `thenPhases` / `elsePhases` for **every** phase type, not
+     * just `conditional`, so a non-conditional carrier must render its own
+     * `serialName()` in the label — never a hardcoded `(conditional)`.
+     */
+    @Test
+    fun branchLabelCarriesTheParentPhaseTypeNotConditional() {
+        val scenario = makeValidatorScenario(
+            agents = 2,
+            rounds = 1,
+            phases = listOf(
+                Phase(
+                    type = PhaseType.SPEAK_ALL,
+                    outputSchema = mapOf("statement" to "string"),
+                    thenPhases = listOf(
+                        Phase(
+                            type = PhaseType.SPEAK_ALL,
+                            outputSchema = mapOf("appeal" to "string"),
+                        ),
+                    ),
+                ),
+            ),
+        )
+        val caught = assertFailsWith<SimulationException> { validator.validateForCommit(scenario) }
+        val error = caught.error
+        assertTrue(error is SimulationError.ScenarioValidationFailed)
+        assertTrue(error.message.startsWith("Phase 1 (speak_all) then[1] "))
+    }
+}

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/ScenarioValidatorCommitTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/ScenarioValidatorCommitTests.kt
@@ -167,6 +167,11 @@ class ScenarioValidatorCommitTests {
         validator.validateForCommit(scenario)
     }
 
+    // Both reflect rejections are dominated by the run gate: [validate]'s REFLECT
+    // arm (`validateReflectShape`) throws before `validateCanonicalFields` is
+    // reached, so they stay green with the commit-gate check deleted entirely.
+    // Kept as faithful Swift transcriptions — they claim no commit-gate mechanism
+    // (see the check-deleted row of [ScenarioValidatorTests]' perturbation record).
     @Test
     fun rejectsReflectWithoutNote() {
         val phase = Phase(
@@ -548,7 +553,6 @@ class ScenarioValidatorCommitTests {
         )
         validator.validateForCommit(scenario)
     }
-
 
     /**
      * Pins the phase-type-derived branch parent label: the canonical-field

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/ScenarioValidatorCommitTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/ScenarioValidatorCommitTests.kt
@@ -18,15 +18,17 @@ import kotlin.test.assertTrue
  * tests, all 1:1 by name (with the Swift `validateForCommit_` / `validate_`
  * prefix dropped; two run-gate-leniency cases keep a disambiguating
  * `...AtRunGate` suffix instead, noted at their definitions, mirroring how
- * `ScenarioValidatorTests.kt` disambiguates its own run-gate cases) — plus
- * one Kotlin-only pin, [branchLabelCarriesTheParentPhaseTypeNotConditional],
- * which has no Swift sibling: it locks in that the branch-descent label
- * derives from `phase.type.serialName()` rather than a hardcoded
- * `"(conditional)"`. Swift behaves identically here — its
- * `validateCanonicalFields(_:)` also descends for every phase type — but all
- * three of its branch cases build a `.conditional` parent, so no Swift test
- * can tell the two label shapes apart. The gap was found while porting; this
- * pin closes it on the Kotlin side only.
+ * `ScenarioValidatorTests.kt` disambiguates its own run-gate cases) — plus two
+ * Kotlin-only pins with no Swift sibling, for a suite total of 31.
+ *
+ * Both pins close a mechanism the ADR-023 §12 condition-4 sweep found
+ * unclaimed on **both** sides;
+ * [branchLabelCarriesTheParentPhaseTypeNotConditional] and
+ * [acceptsCodePhaseDeclaringAStraySecondaryKey] carry the reasoning at their
+ * definitions, and notes 8–9 of [ScenarioValidatorTests]' perturbation record
+ * carry the measurement. That record covers this suite too — the sweep ran
+ * all three validator suites as one measurement, so it is the single place
+ * the commit gate's mechanism-to-claimant mapping lives.
  */
 class ScenarioValidatorCommitTests {
 
@@ -510,7 +512,43 @@ class ScenarioValidatorCommitTests {
 
     // endregion
 
-    // region Kotlin-only pin (no Swift sibling)
+    // region Kotlin-only pins (no Swift sibling)
+
+    /**
+     * Pins the thought-field rule's code-phase exemption:
+     * [com.pastura.models.ScenarioConventions.thoughtField] returns `null` for
+     * every code phase, so a code phase declaring a known secondary key is
+     * accepted rather than measured against a canonical it does not have.
+     *
+     * Added because the ADR-023 §12 condition-4 sweep found the exemption's
+     * `?: return` had **no** claimant on either side — no Swift test constructs
+     * a code phase with an `output:` block at all, so replacing the early
+     * return with a fallback canonical reddened nothing. The fixture is
+     * deliberately unrealistic (`summarize` emits no LLM output, so authoring
+     * an `output:` for it is a mistake); it exists to make the exemption
+     * observable, not to bless the shape.
+     */
+    @Test
+    fun acceptsCodePhaseDeclaringAStraySecondaryKey() {
+        val scenario = makeValidatorScenario(
+            agents = 2,
+            rounds = 1,
+            phases = listOf(
+                Phase(
+                    type = PhaseType.SPEAK_ALL,
+                    prompt = "Speak.",
+                    outputSchema = mapOf("statement" to "string"),
+                ),
+                Phase(
+                    type = PhaseType.SUMMARIZE,
+                    template = "Round done",
+                    outputSchema = mapOf("reason" to "string"),
+                ),
+            ),
+        )
+        validator.validateForCommit(scenario)
+    }
+
 
     /**
      * Pins the phase-type-derived branch parent label: the canonical-field

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/ScenarioValidatorCommitTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/ScenarioValidatorCommitTests.kt
@@ -8,46 +8,509 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
 /**
- * Smoke coverage for [ScenarioValidator.validateForCommit] — the commit-gate
- * half of the validator, ported from Swift's
- * `Pastura/Pastura/Engine/ScenarioValidator+CanonicalFields.swift`.
+ * Strict-validation checks that fire only at commit-to-persist time
+ * (`ScenarioEditorViewModel.save()`), not on every keystroke and not at
+ * runtime. See `ScenarioConventions` for the canonical-field convention these
+ * checks enforce.
  *
- * Deliberately minimal: three cases pinning accept, reject, and the
- * phase-type-derived branch label. The full 1:1 port of Swift's
- * `Pastura/PasturaTests/Engine/ScenarioValidatorTests+Commit.swift` (29 tests) lands in
- * the next commit on this branch.
+ * commonTest sibling of Swift's
+ * `Pastura/PasturaTests/Engine/ScenarioValidatorTests+Commit.swift` — 29
+ * tests, all 1:1 by name (with the Swift `validateForCommit_` / `validate_`
+ * prefix dropped; two run-gate-leniency cases keep a disambiguating
+ * `...AtRunGate` suffix instead, noted at their definitions, mirroring how
+ * `ScenarioValidatorTests.kt` disambiguates its own run-gate cases) — plus
+ * one Kotlin-only pin, [branchLabelCarriesTheParentPhaseTypeNotConditional],
+ * which has no Swift sibling: it locks in that the branch-descent label
+ * derives from `phase.type.serialName()` rather than a hardcoded
+ * `"(conditional)"`. Swift behaves identically here — its
+ * `validateCanonicalFields(_:)` also descends for every phase type — but all
+ * three of its branch cases build a `.conditional` parent, so no Swift test
+ * can tell the two label shapes apart. The gap was found while porting; this
+ * pin closes it on the Kotlin side only.
  */
 class ScenarioValidatorCommitTests {
 
     private val validator = ScenarioValidator()
 
+    // region Speak phases (canonical: statement)
+
     @Test
-    fun acceptsSpeakAllWithCanonicalStatementField() {
-        val scenario = makeValidatorScenario(
-            agents = 2,
-            rounds = 1,
-            phases = listOf(
-                Phase(type = PhaseType.SPEAK_ALL, outputSchema = mapOf("statement" to "string")),
-            ),
+    fun acceptsSpeakAllWithStatement() {
+        val phase = Phase(
+            type = PhaseType.SPEAK_ALL,
+            prompt = "Speak.",
+            outputSchema = mapOf("statement" to "string", "inner_thought" to "string"),
         )
-        val result = validator.validateForCommit(scenario)
-        assertTrue(result.warnings.isEmpty())
+        val scenario = makeValidatorScenario(agents = 2, rounds = 1, phases = listOf(phase))
+        validator.validateForCommit(scenario)
     }
 
     @Test
-    fun rejectsSpeakAllMissingCanonicalStatementField() {
-        val scenario = makeValidatorScenario(
-            agents = 2,
-            rounds = 1,
-            phases = listOf(
-                Phase(type = PhaseType.SPEAK_ALL, outputSchema = mapOf("appeal" to "string")),
-            ),
+    fun acceptsSpeakEachWithStatement() {
+        val phase = Phase(
+            type = PhaseType.SPEAK_EACH,
+            prompt = "Speak.",
+            outputSchema = mapOf("statement" to "string"),
         )
+        val scenario = makeValidatorScenario(agents = 2, rounds = 1, phases = listOf(phase))
+        validator.validateForCommit(scenario)
+    }
+
+    @Test
+    fun rejectsSpeakAllWithoutStatement() {
+        val phase = Phase(
+            type = PhaseType.SPEAK_ALL,
+            prompt = "Speak.",
+            outputSchema = mapOf("appeal" to "string", "inner_thought" to "string"),
+        )
+        val scenario = makeValidatorScenario(agents = 2, rounds = 1, phases = listOf(phase))
+        val caught = assertFailsWith<SimulationException> { validator.validateForCommit(scenario) }
+        assertTrue(caught.error is SimulationError.ScenarioValidationFailed)
+    }
+
+    @Test
+    fun rejectsSpeakEachWithBokeAlias() {
+        // The legacy `boke:` alias was dropped in #309 — must now error.
+        val phase = Phase(
+            type = PhaseType.SPEAK_EACH,
+            prompt = "Speak.",
+            outputSchema = mapOf("boke" to "string"),
+        )
+        val scenario = makeValidatorScenario(agents = 2, rounds = 1, phases = listOf(phase))
+        val caught = assertFailsWith<SimulationException> { validator.validateForCommit(scenario) }
+        assertTrue(caught.error is SimulationError.ScenarioValidationFailed)
+    }
+
+    @Test
+    fun rejectsSpeakAllWithMissingOutputSchema() {
+        val phase = Phase(type = PhaseType.SPEAK_ALL, prompt = "Speak.")
+        val scenario = makeValidatorScenario(agents = 2, rounds = 1, phases = listOf(phase))
+        val caught = assertFailsWith<SimulationException> { validator.validateForCommit(scenario) }
+        assertTrue(caught.error is SimulationError.ScenarioValidationFailed)
+    }
+
+    // endregion
+
+    // region Choose (canonical: action)
+
+    @Test
+    fun acceptsChooseWithAction() {
+        val phase = Phase(
+            type = PhaseType.CHOOSE,
+            prompt = "Choose.",
+            outputSchema = mapOf("action" to "string"),
+            options = listOf("yes", "no"),
+        )
+        val scenario = makeValidatorScenario(agents = 2, rounds = 1, phases = listOf(phase))
+        validator.validateForCommit(scenario)
+    }
+
+    @Test
+    fun rejectsChooseWithFactionAlias() {
+        // The kinoko gallery scenario was previously broken by `faction:` —
+        // OutputSchema.from binds the GBNF enum constraint only on field name
+        // `action`, and ChooseHandler reads `output.action` directly, so any
+        // other name silently defaults every agent to options[0]. The
+        // canonical check at commit time is the structural fix.
+        val phase = Phase(
+            type = PhaseType.CHOOSE,
+            prompt = "Choose.",
+            outputSchema = mapOf("faction" to "string"),
+            options = listOf("kinoko", "takenoko"),
+        )
+        val scenario = makeValidatorScenario(agents = 2, rounds = 1, phases = listOf(phase))
+        val caught = assertFailsWith<SimulationException> { validator.validateForCommit(scenario) }
+        assertTrue(caught.error is SimulationError.ScenarioValidationFailed)
+    }
+
+    // endregion
+
+    // region Vote (canonical: vote)
+
+    @Test
+    fun acceptsVoteWithVoteField() {
+        val phase = Phase(
+            type = PhaseType.VOTE,
+            prompt = "Vote.",
+            outputSchema = mapOf("vote" to "string", "reason" to "string"),
+        )
+        val scenario = makeValidatorScenario(agents = 2, rounds = 1, phases = listOf(phase))
+        validator.validateForCommit(scenario)
+    }
+
+    @Test
+    fun rejectsVoteWithoutVoteField() {
+        val phase = Phase(
+            type = PhaseType.VOTE,
+            prompt = "Vote.",
+            outputSchema = mapOf("target" to "string"),
+        )
+        val scenario = makeValidatorScenario(agents = 2, rounds = 1, phases = listOf(phase))
+        val caught = assertFailsWith<SimulationException> { validator.validateForCommit(scenario) }
+        assertTrue(caught.error is SimulationError.ScenarioValidationFailed)
+    }
+
+    // endregion
+
+    // region Reflect (canonical: note, no secondary field)
+
+    @Test
+    fun acceptsReflectWithNote() {
+        val phase = Phase(
+            type = PhaseType.REFLECT,
+            prompt = "Reflect.",
+            outputSchema = mapOf("note" to "string"),
+        )
+        val scenario = makeValidatorScenario(agents = 2, rounds = 1, phases = listOf(phase))
+        validator.validateForCommit(scenario)
+    }
+
+    @Test
+    fun rejectsReflectWithoutNote() {
+        val phase = Phase(
+            type = PhaseType.REFLECT,
+            prompt = "Reflect.",
+            outputSchema = mapOf("memo" to "string"),
+        )
+        val scenario = makeValidatorScenario(agents = 2, rounds = 1, phases = listOf(phase))
+        val caught = assertFailsWith<SimulationException> { validator.validateForCommit(scenario) }
+        assertTrue(caught.error is SimulationError.ScenarioValidationFailed)
+    }
+
+    @Test
+    fun rejectsReflectWithMissingOutputSchema() {
+        val phase = Phase(type = PhaseType.REFLECT, prompt = "Reflect.")
+        val scenario = makeValidatorScenario(agents = 2, rounds = 1, phases = listOf(phase))
+        val caught = assertFailsWith<SimulationException> { validator.validateForCommit(scenario) }
+        assertTrue(caught.error is SimulationError.ScenarioValidationFailed)
+    }
+
+    // endregion
+
+    // region Code phases (no canonical field — exempt)
+
+    @Test
+    fun acceptsCodePhases() {
+        // Code phases (score_calc / summarize / assign / eliminate) emit no
+        // LLM output and have no canonical primary field — they should pass
+        // the commit gate without an `output:` schema.
+        val phases = listOf(
+            Phase(
+                type = PhaseType.SPEAK_ALL,
+                prompt = "Speak.",
+                outputSchema = mapOf("statement" to "string"),
+            ),
+            Phase(type = PhaseType.SUMMARIZE, template = "Round done"),
+            Phase(type = PhaseType.ELIMINATE),
+        )
+        val scenario = makeValidatorScenario(agents = 2, rounds = 1, phases = phases)
+        validator.validateForCommit(scenario)
+    }
+
+    // endregion
+
+    // region Composes with validate()
+
+    @Test
+    fun runsValidateChecksFirst() {
+        // A scenario that fails the agent-count check should still throw —
+        // validateForCommit composes by calling validate(_:) before adding
+        // the canonical-field check.
+        val phase = Phase(
+            type = PhaseType.SPEAK_ALL,
+            prompt = "Speak.",
+            outputSchema = mapOf("statement" to "string"),
+        )
+        val scenario = makeValidatorScenario(agents = 0, rounds = 1, phases = listOf(phase))
+        val caught = assertFailsWith<SimulationException> { validator.validateForCommit(scenario) }
+        assertTrue(caught.error is SimulationError.ScenarioValidationFailed)
+    }
+
+    // endregion
+
+    // region Runtime path is lenient (regression guard)
+
+    /** Swift sibling: `validate_acceptsScenarioMissingCanonicalSpeakField`. */
+    @Test
+    fun acceptsScenarioMissingCanonicalSpeakFieldAtRunGate() {
+        // The regular `validate(_:)` path (used by `SimulationRunner`) must
+        // NOT enforce the canonical-field rule — only `validateForCommit`
+        // does. Otherwise a scenario authored before this convention landed
+        // could refuse to run.
+        val phase = Phase(
+            type = PhaseType.SPEAK_ALL,
+            prompt = "Speak.",
+            outputSchema = mapOf("appeal" to "string"),
+        )
+        val scenario = makeValidatorScenario(agents = 2, rounds = 1, phases = listOf(phase))
+        validator.validate(scenario)
+    }
+
+    // endregion
+
+    // region Conditional sub-phases (canonical-field check recurses depth-1)
+
+    @Test
+    fun rejectsSpeakAllInsideThenBranchMissingStatement() {
+        // Regression: `validateCanonicalPrimaryFields` originally walked only
+        // `scenario.phases` and ignored `thenPhases` / `elsePhases`. A
+        // conditional branch with a misnamed canonical field would slip past
+        // the commit gate and recreate the exact "speak_all missing statement"
+        // bug class #318 was meant to prevent. Recursion is depth-1 by validator
+        // construction so termination is trivial.
+        val nested = Phase(
+            type = PhaseType.SPEAK_ALL,
+            prompt = "Inner.",
+            outputSchema = mapOf("appeal" to "string"),
+        )
+        val conditional = Phase(
+            type = PhaseType.CONDITIONAL,
+            condition = "max_score >= 1",
+            thenPhases = listOf(nested),
+        )
+        val scenario = makeValidatorScenario(agents = 2, rounds = 1, phases = listOf(conditional))
+        val caught = assertFailsWith<SimulationException> { validator.validateForCommit(scenario) }
+        assertTrue(caught.error is SimulationError.ScenarioValidationFailed)
+    }
+
+    @Test
+    fun rejectsVoteInsideElseBranchMissingVoteField() {
+        val nested = Phase(
+            type = PhaseType.VOTE,
+            prompt = "Vote.",
+            outputSchema = mapOf("target" to "string"),
+        )
+        val conditional = Phase(
+            type = PhaseType.CONDITIONAL,
+            condition = "max_score >= 1",
+            thenPhases = listOf(Phase(type = PhaseType.SUMMARIZE, template = "ok")),
+            elsePhases = listOf(nested),
+        )
+        val scenario = makeValidatorScenario(agents = 2, rounds = 1, phases = listOf(conditional))
+        val caught = assertFailsWith<SimulationException> { validator.validateForCommit(scenario) }
+        assertTrue(caught.error is SimulationError.ScenarioValidationFailed)
+    }
+
+    @Test
+    fun acceptsSpeakAllInsideThenBranchWithStatement() {
+        val nested = Phase(
+            type = PhaseType.SPEAK_ALL,
+            prompt = "Inner.",
+            outputSchema = mapOf("statement" to "string"),
+        )
+        val conditional = Phase(
+            type = PhaseType.CONDITIONAL,
+            condition = "max_score >= 1",
+            thenPhases = listOf(nested),
+        )
+        val scenario = makeValidatorScenario(agents = 2, rounds = 1, phases = listOf(conditional))
+        validator.validateForCommit(scenario)
+    }
+
+    // endregion
+
+    // region Error message includes phase index + canonical field name
+
+    @Test
+    fun errorMentionsPhaseAndCanonicalField() {
+        val phase = Phase(
+            type = PhaseType.SPEAK_ALL,
+            prompt = "Speak.",
+            outputSchema = mapOf("appeal" to "string"),
+        )
+        val scenario = makeValidatorScenario(agents = 2, rounds = 1, phases = listOf(phase))
         val caught = assertFailsWith<SimulationException> { validator.validateForCommit(scenario) }
         val error = caught.error
         assertTrue(error is SimulationError.ScenarioValidationFailed)
-        assertTrue(error.message.contains("'statement'"))
+        // Partial-match per CLAUDE.md i18n rule — assert the message names
+        // the canonical field, phase type, and 1-based phase index, not exact
+        // wording. The phase-index part of the contract is what lets a user
+        // disambiguate when several phases share a type.
+        val message = error.message
+        assertTrue(message.contains("statement"))
+        assertTrue(message.contains("speak_all"))
+        assertTrue(message.contains("Phase 1"))
     }
+
+    // endregion
+
+    // region Canonical thought (secondary) field
+    //
+    // Companion to the primary-field checks above. The secondary field is
+    // OPTIONAL, but when a known secondary key (`inner_thought` / `reason`)
+    // is declared it must be the phase's canonical one
+    // (`ScenarioConventions.thoughtField(for:)`): vote→reason,
+    // speak*/choose→inner_thought. This keeps the streaming THINKING source
+    // (`OutputSchema.thoughtFieldName`, schema-driven) and the committed
+    // source (`TurnOutput.secondaryText`, phase-hardcoded) reading the same
+    // key — a choose authored with `reason` streamed live but went blank on
+    // commit (#760).
+
+    @Test
+    fun acceptsChooseWithInnerThought() {
+        val phase = Phase(
+            type = PhaseType.CHOOSE,
+            prompt = "Choose.",
+            outputSchema = mapOf("action" to "string", "inner_thought" to "string"),
+            options = listOf("yes", "no"),
+        )
+        val scenario = makeValidatorScenario(agents = 2, rounds = 1, phases = listOf(phase))
+        validator.validateForCommit(scenario)
+    }
+
+    @Test
+    fun rejectsChooseWithReason() {
+        // The #760 root case: choose authored `reason` (not canonical
+        // `inner_thought`). Streaming surfaced it but the committed row read
+        // the empty `inner_thought`, so the reasoning vanished on commit.
+        val phase = Phase(
+            type = PhaseType.CHOOSE,
+            prompt = "Choose.",
+            outputSchema = mapOf("action" to "string", "reason" to "string"),
+            options = listOf("kinoko", "takenoko"),
+        )
+        val scenario = makeValidatorScenario(agents = 2, rounds = 1, phases = listOf(phase))
+        val caught = assertFailsWith<SimulationException> { validator.validateForCommit(scenario) }
+        assertTrue(caught.error is SimulationError.ScenarioValidationFailed)
+    }
+
+    @Test
+    fun rejectsSpeakAllWithReason() {
+        // Speak phases are canonical-`inner_thought` too, so a stray `reason`
+        // is rejected — symmetric to the choose case.
+        val phase = Phase(
+            type = PhaseType.SPEAK_ALL,
+            prompt = "Speak.",
+            outputSchema = mapOf("statement" to "string", "reason" to "string"),
+        )
+        val scenario = makeValidatorScenario(agents = 2, rounds = 1, phases = listOf(phase))
+        val caught = assertFailsWith<SimulationException> { validator.validateForCommit(scenario) }
+        assertTrue(caught.error is SimulationError.ScenarioValidationFailed)
+    }
+
+    @Test
+    fun rejectsVoteWithInnerThought() {
+        // Vote's canonical secondary is `reason`; `inner_thought` is the wrong
+        // key for vote (the inverse of the choose/speak direction).
+        val phase = Phase(
+            type = PhaseType.VOTE,
+            prompt = "Vote.",
+            outputSchema = mapOf("vote" to "string", "inner_thought" to "string"),
+        )
+        val scenario = makeValidatorScenario(agents = 2, rounds = 1, phases = listOf(phase))
+        val caught = assertFailsWith<SimulationException> { validator.validateForCommit(scenario) }
+        assertTrue(caught.error is SimulationError.ScenarioValidationFailed)
+    }
+
+    @Test
+    fun rejectsChooseWithBothInnerThoughtAndReason() {
+        // The rule must inspect EVERY declared known-secondary key, not just
+        // `OutputSchema.thoughtFieldName`'s priority pick (which returns
+        // `inner_thought` here and would miss the stray `reason`).
+        val phase = Phase(
+            type = PhaseType.CHOOSE,
+            prompt = "Choose.",
+            outputSchema = mapOf(
+                "action" to "string",
+                "inner_thought" to "string",
+                "reason" to "string",
+            ),
+            options = listOf("yes", "no"),
+        )
+        val scenario = makeValidatorScenario(agents = 2, rounds = 1, phases = listOf(phase))
+        val caught = assertFailsWith<SimulationException> { validator.validateForCommit(scenario) }
+        assertTrue(caught.error is SimulationError.ScenarioValidationFailed)
+    }
+
+    @Test
+    fun acceptsChooseWithNoSecondaryField() {
+        // Secondary is optional — only the canonical primary (`action`) plus
+        // no thought field still passes.
+        val phase = Phase(
+            type = PhaseType.CHOOSE,
+            prompt = "Choose.",
+            outputSchema = mapOf("action" to "string"),
+            options = listOf("yes", "no"),
+        )
+        val scenario = makeValidatorScenario(agents = 2, rounds = 1, phases = listOf(phase))
+        validator.validateForCommit(scenario)
+    }
+
+    @Test
+    fun acceptsUnknownSecondaryKey() {
+        // The rule keys only on `OutputSchema.knownSecondaryKeys`
+        // (inner_thought / reason). A non-known extra field (`notes`) is not a
+        // secondary key and must not trip the check.
+        val phase = Phase(
+            type = PhaseType.CHOOSE,
+            prompt = "Choose.",
+            outputSchema = mapOf("action" to "string", "notes" to "string"),
+            options = listOf("yes", "no"),
+        )
+        val scenario = makeValidatorScenario(agents = 2, rounds = 1, phases = listOf(phase))
+        validator.validateForCommit(scenario)
+    }
+
+    /** Swift sibling: `validate_acceptsChooseWithReason`. */
+    @Test
+    fun acceptsChooseWithReasonAtRunGate() {
+        // Runtime `validate(_:)` stays lenient — only `validateForCommit`
+        // enforces the canonical thought-field rule, so a scenario authored
+        // before this convention still runs.
+        val phase = Phase(
+            type = PhaseType.CHOOSE,
+            prompt = "Choose.",
+            outputSchema = mapOf("action" to "string", "reason" to "string"),
+            options = listOf("kinoko", "takenoko"),
+        )
+        val scenario = makeValidatorScenario(agents = 2, rounds = 1, phases = listOf(phase))
+        validator.validate(scenario)
+    }
+
+    @Test
+    fun rejectsChooseWithReasonInsideThenBranch() {
+        // Recurses into conditional branches, same as the primary-field check.
+        val nested = Phase(
+            type = PhaseType.CHOOSE,
+            prompt = "Choose.",
+            outputSchema = mapOf("action" to "string", "reason" to "string"),
+            options = listOf("yes", "no"),
+        )
+        val conditional = Phase(
+            type = PhaseType.CONDITIONAL,
+            condition = "max_score >= 1",
+            thenPhases = listOf(nested),
+        )
+        val scenario = makeValidatorScenario(agents = 2, rounds = 1, phases = listOf(conditional))
+        val caught = assertFailsWith<SimulationException> { validator.validateForCommit(scenario) }
+        assertTrue(caught.error is SimulationError.ScenarioValidationFailed)
+    }
+
+    @Test
+    fun thoughtFieldErrorMentionsPhaseAndKeys() {
+        val phase = Phase(
+            type = PhaseType.CHOOSE,
+            prompt = "Choose.",
+            outputSchema = mapOf("action" to "string", "reason" to "string"),
+            options = listOf("yes", "no"),
+        )
+        val scenario = makeValidatorScenario(agents = 2, rounds = 1, phases = listOf(phase))
+        val caught = assertFailsWith<SimulationException> { validator.validateForCommit(scenario) }
+        val error = caught.error
+        assertTrue(error is SimulationError.ScenarioValidationFailed)
+        // Partial-match per CLAUDE.md i18n rule — the message names the
+        // canonical field, the offending field, the phase type, and the
+        // 1-based phase index.
+        val message = error.message
+        assertTrue(message.contains("inner_thought"))
+        assertTrue(message.contains("reason"))
+        assertTrue(message.contains("choose"))
+        assertTrue(message.contains("Phase 1"))
+    }
+
+    // endregion
+
+    // region Kotlin-only pin (no Swift sibling)
 
     /**
      * Pins the phase-type-derived branch parent label: the canonical-field
@@ -78,4 +541,6 @@ class ScenarioValidatorCommitTests {
         assertTrue(error is SimulationError.ScenarioValidationFailed)
         assertTrue(error.message.startsWith("Phase 1 (speak_all) then[1] "))
     }
+
+    // endregion
 }

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/ScenarioValidatorTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/ScenarioValidatorTests.kt
@@ -54,7 +54,7 @@ import kotlin.test.assertTrue
  * | `language` gate | `scenario.language !in ACCEPTED_LANGUAGES` → `in` | [rejectsInvalidLanguage] | 68 — every valid-language fixture then throws |
  * | `simulationLanguage` null-accept arm | `val simulationLanguage = scenario.simulationLanguage` → `… ?: "fr"` | [acceptsNilSimulationLanguage] | 66 — every fixture leaves it null; see note 2 |
  * | …membership polarity | `simulationLanguage !in …` → `in` | [rejectsInvalidSimulationLanguage] | none |
- * | `agentCount` ≥ 2 | `if (scenario.agentCount < 2)` → `if (false)` | [rejectsZeroAgents], [rejectsSingleAgent] | none |
+ * | `agentCount` ≥ 2 | `if (scenario.agentCount < 2)` → `if (false)` | [rejectsZeroAgents], [rejectsSingleAgent] | 1 — [ScenarioValidatorCommitTests.runsValidateChecksFirst]: its `agents = 0` fixture then passes every remaining check (`makeValidatorScenario` derives zero personas, so the count matches), so nothing throws |
  * | `agentCount` ≤ 10 | `if (scenario.agentCount > 10)` → `if (false)` | [rejectsMoreThan10Agents] | none |
  * | persona count matches `agentCount` | `!=` → `==` | [rejectsPersonaCountMismatch] | 67 — every matched-persona fixture then throws |
  * | `rounds` ≤ 30 | `if (scenario.rounds > 30)` → `if (false)` | [rejectsMoreThan30Rounds] | none |
@@ -110,7 +110,7 @@ import kotlin.test.assertTrue
  * | Mechanism broken | Mutation | Dedicated claimant | Incidental |
  * |---|---|---|---|
  * | Commit gate runs [validate]'s checks first | `val result = validate(scenario)` → a literal `ValidationResult` | `runsValidateChecksFirst` | none |
- * | …then runs the canonical-field check at all | the `validateCanonicalFields(scenario)` call deleted | all 15 rejecting commit cases, e.g. `rejectsSpeakAllWithoutStatement` | none — all 15 fail on their own assertion |
+ * | …then runs the canonical-field check at all | the `validateCanonicalFields(scenario)` call deleted | 15 of the suite's 18 rejecting cases, e.g. `rejectsSpeakAllWithoutStatement` | none — all 15 fail on their own assertion. The other three claim no commit-gate mechanism: `rejectsReflectWithoutNote` and `rejectsReflectWithMissingOutputSchema` are pre-empted by the run gate's [validateReflectShape], and `runsValidateChecksFirst` rejects on `agentCount` |
  * | Canonical **primary** field required | `if (schema[canonical] == null)` → `if (false)` | 9 cases, e.g. `rejectsVoteWithoutVoteField`, `rejectsChooseWithFactionAlias` | none |
  * | …and code phases exempt from it | the primary `?: return` → `?: "statement"` | `acceptsCodePhases`, `acceptsSpeakAllInsideThenBranchWithStatement`, `acceptsCodePhaseDeclaringAStraySecondaryKey` | none |
  * | Canonical **thought** field enforced | `if (schema[key] != null && key != canonical)` → `if (false)` | 6 cases, e.g. `rejectsVoteWithInnerThought`, `rejectsSpeakAllWithReason` | none |
@@ -128,14 +128,21 @@ import kotlin.test.assertTrue
  *    for). The second sweep proved it once: adding the three tests in note 3 moved
  *    three `Incidental` / claimant cells that had nothing to do with them
  *    (`validatePhases` CONDITIONAL 23 → 25 red, EVENT_INJECT 8 → 9, parse pre-flight
- *    2 → 3). This third sweep (PR B2) proved it twice over, at a longer range: a
- *    whole new suite chaining through [validate] moved the three global-gate rows
- *    and nothing else (`language` 53 → 68 red, `simulationLanguage` null-accept
- *    51 → 66, persona count 52 → 67 — each gaining exactly the accepting
- *    commit-gate fixtures), and then adding the single test in note 8 moved five
- *    more cells, three of them in rows that test has nothing to do with. Every row
- *    above was re-measured after each landing; none of the remaining run-gate rows
- *    moved, which is a measurement, not an assumption.
+ *    2 → 3). This third sweep (PR B2) proved it twice over, at a longer range.
+ *    All figures below are `Incidental` counts, the same quantity the table's
+ *    cells carry — **not** red totals, which run one higher on every row that has
+ *    a single claimant. First, a whole new suite chaining through [validate] moved
+ *    four rows: `language` 52 → 67, `simulationLanguage` null-accept 50 → 65,
+ *    persona count 51 → 66, and `agentCount` ≥ 2 from `none` to 1. The first three
+ *    gained 15 apiece — 12 of the commit suite's accepting fixtures, plus the 3
+ *    *rejecting* ones that assert message **content** (`errorMentions…`,
+ *    `thoughtFieldErrorMentions…`, `branchLabel…`), whose
+ *    `is ScenarioValidationFailed` check survives a global-gate throw while their
+ *    `contains` / `startsWith` does not. Then adding the single accepting test in
+ *    note 8 moved five more cells, three of them in those same global-gate rows it
+ *    has nothing else to do with, taking them to 68 / 66 / 67. Every row above was
+ *    re-measured after each landing; the rows not named here measured identical,
+ *    which is a measurement, not an assumption.
  * 2. **Two mutations do not compile in their obvious form, and the substitutes are
  *    not equivalent.** `if (false)` on the `logWindow` and `simulationLanguage`
  *    guards drops the smart cast their `!= null &&` left arm provides, so the throw

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/ScenarioValidatorTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/ScenarioValidatorTests.kt
@@ -35,25 +35,28 @@ import kotlin.test.assertTrue
  * count was asserted before applying (all 50 matched **exactly once**) and the
  * mutated text re-read to confirm it landed; a `replace` that silently no-ops leaves
  * the original behaviour and reads as verified. The file was restored byte-identically
- * after each run. The unmutated baseline was measured green (89 tests, both suites)
+ * after each run (`git diff --exit-code` on the file after the last revert). The
+ * unmutated baseline was measured green (**120 tests across the three suites**)
  * immediately before the first mutation and again after the last revert, so every
  * reddening below is signal rather than pre-existing noise. Counts are measured, not
  * derived — re-measure rather than reason if you change a fixture. Measured
- * 2026-08-26, #1552.
+ * 2026-08-26, #1552 (PR B2; the run-gate rows were first measured in PR B1 and are
+ * re-measured here — see note 1).
  *
- * The sweep ran **only** these two suites. That is sufficient rather than a shortcut:
- * `grep` confirms no other `shared/engine` code constructs [ScenarioValidator] — the
- * gate is deliberately not wired into the engine yet (see the class KDoc on
- * [ScenarioValidator]), so no other suite could redden.
+ * The sweep ran **only** these three suites — [ScenarioValidatorTests],
+ * [ConditionalValidatorTests], and [ScenarioValidatorCommitTests]. That is sufficient
+ * rather than a shortcut: `grep` confirms no other `shared/engine` code constructs
+ * [ScenarioValidator] — the gate is deliberately not wired into the engine yet (see
+ * the class KDoc on [ScenarioValidator]), so no other suite could redden.
  *
  * | Mechanism broken | Mutation | Dedicated claimant | Incidental |
  * |---|---|---|---|
- * | `language` gate | `scenario.language !in ACCEPTED_LANGUAGES` → `in` | [rejectsInvalidLanguage] | 52 — every valid-language fixture then throws |
- * | `simulationLanguage` null-accept arm | `val simulationLanguage = scenario.simulationLanguage` → `… ?: "fr"` | [acceptsNilSimulationLanguage] | 50 — every fixture leaves it null; see note 2 |
+ * | `language` gate | `scenario.language !in ACCEPTED_LANGUAGES` → `in` | [rejectsInvalidLanguage] | 68 — every valid-language fixture then throws |
+ * | `simulationLanguage` null-accept arm | `val simulationLanguage = scenario.simulationLanguage` → `… ?: "fr"` | [acceptsNilSimulationLanguage] | 66 — every fixture leaves it null; see note 2 |
  * | …membership polarity | `simulationLanguage !in …` → `in` | [rejectsInvalidSimulationLanguage] | none |
  * | `agentCount` ≥ 2 | `if (scenario.agentCount < 2)` → `if (false)` | [rejectsZeroAgents], [rejectsSingleAgent] | none |
  * | `agentCount` ≤ 10 | `if (scenario.agentCount > 10)` → `if (false)` | [rejectsMoreThan10Agents] | none |
- * | persona count matches `agentCount` | `!=` → `==` | [rejectsPersonaCountMismatch] | 51 — every matched-persona fixture then throws |
+ * | persona count matches `agentCount` | `!=` → `==` | [rejectsPersonaCountMismatch] | 67 — every matched-persona fixture then throws |
  * | `rounds` ≤ 30 | `if (scenario.rounds > 30)` → `if (false)` | [rejectsMoreThan30Rounds] | none |
  * | `logWindow` ≥ 1 | `logWindow < 1` → `logWindow < 0` (not `if (false)`; see note 2) | [rejectsZeroLogWindow] | none |
  * | Estimate > 100 is an error | `if (estimated > 100)` → `if (false)` | [errorsWhenInferencesExceed100] | none |
@@ -99,14 +102,40 @@ import kotlin.test.assertTrue
  * | whisper message `type` arg | same, whisper site | *(none — expected green, note 7)* | none |
  * | relationship_update message `type` arg | same, relationship_update site | *(none — expected green, note 7)* | none |
  *
- * Seven things this table encodes that are easy to misread:
+ * ### Commit gate ([ScenarioValidator.validateForCommit], PR B2)
+ *
+ * Same driver, same run, same baseline. Every claimant below lives in
+ * [ScenarioValidatorCommitTests]; the class prefix is dropped for width.
+ *
+ * | Mechanism broken | Mutation | Dedicated claimant | Incidental |
+ * |---|---|---|---|
+ * | Commit gate runs [validate]'s checks first | `val result = validate(scenario)` → a literal `ValidationResult` | `runsValidateChecksFirst` | none |
+ * | …then runs the canonical-field check at all | the `validateCanonicalFields(scenario)` call deleted | all 15 rejecting commit cases, e.g. `rejectsSpeakAllWithoutStatement` | none — all 15 fail on their own assertion |
+ * | Canonical **primary** field required | `if (schema[canonical] == null)` → `if (false)` | 9 cases, e.g. `rejectsVoteWithoutVoteField`, `rejectsChooseWithFactionAlias` | none |
+ * | …and code phases exempt from it | the primary `?: return` → `?: "statement"` | `acceptsCodePhases`, `acceptsSpeakAllInsideThenBranchWithStatement`, `acceptsCodePhaseDeclaringAStraySecondaryKey` | none |
+ * | Canonical **thought** field enforced | `if (schema[key] != null && key != canonical)` → `if (false)` | 6 cases, e.g. `rejectsVoteWithInnerThought`, `rejectsSpeakAllWithReason` | none |
+ * | …checked for **every** declared known-secondary key, not the priority pick | the loop iterates only `knownSecondaryKeys.firstOrNull { schema[it] != null }` | `rejectsChooseWithBothInnerThoughtAndReason` | none |
+ * | …and code phases exempt from it | the thought `?: return` → `?: "inner_thought"` | `acceptsCodePhaseDeclaringAStraySecondaryKey` — **added**, note 8 | none |
+ * | Descent into `then:` | the `validateBranchCanonicalFields(phase.thenPhases, …)` call deleted | `rejectsSpeakAllInsideThenBranchMissingStatement`, `rejectsChooseWithReasonInsideThenBranch`, `branchLabelCarriesTheParentPhaseTypeNotConditional` | none |
+ * | Descent into `else:` | same, else site | `rejectsVoteInsideElseBranchMissingVoteField` | none |
+ * | Parent label derived from the phase type | the `serialName()` interpolation → a hardcoded `"(conditional)"` | `branchLabelCarriesTheParentPhaseTypeNotConditional` — **added**, note 9 | none |
+ * | Sub-phase index is 1-based | `subIndex + 1` → `subIndex` in the branch label | `branchLabelCarriesTheParentPhaseTypeNotConditional` | none |
+ *
+ * Nine things this table encodes that are easy to misread:
  *
  * 1. ⚠️ **Re-measure the whole table when you add a fixture, not the row you were
  *    thinking about** (the lesson [InferenceEstimatorTests]' record was corrected
- *    for). This record is the second sweep: adding the three tests in note 3 moved
+ *    for). The second sweep proved it once: adding the three tests in note 3 moved
  *    three `Incidental` / claimant cells that had nothing to do with them
  *    (`validatePhases` CONDITIONAL 23 → 25 red, EVENT_INJECT 8 → 9, parse pre-flight
- *    2 → 3). Every row above was re-measured after they landed.
+ *    2 → 3). This third sweep (PR B2) proved it twice over, at a longer range: a
+ *    whole new suite chaining through [validate] moved the three global-gate rows
+ *    and nothing else (`language` 53 → 68 red, `simulationLanguage` null-accept
+ *    51 → 66, persona count 52 → 67 — each gaining exactly the accepting
+ *    commit-gate fixtures), and then adding the single test in note 8 moved five
+ *    more cells, three of them in rows that test has nothing to do with. Every row
+ *    above was re-measured after each landing; none of the remaining run-gate rows
+ *    moved, which is a measurement, not an assumption.
  * 2. **Two mutations do not compile in their obvious form, and the substitutes are
  *    not equivalent.** `if (false)` on the `logWindow` and `simulationLanguage`
  *    guards drops the smart cast their `!= null &&` left arm provides, so the throw
@@ -146,6 +175,26 @@ import kotlin.test.assertTrue
  *    `type` argument would ship silently. Closing it (one `contains("reflect")`
  *    per test) was declined for Swift parity — the siblings assert type only —
  *    not overlooked.
+ * 8. **The thought rule's code-phase exemption had no claimant on either side.**
+ *    `ScenarioConventions.thoughtField` returns `null` for every code phase, so the
+ *    `?: return` is what keeps a code phase from being measured against a canonical
+ *    it does not have — but no Swift test constructs a code phase with an `output:`
+ *    block at all, so replacing the early return with a fallback canonical reddened
+ *    nothing. Rather than paper over it (note 3's precedent),
+ *    `ScenarioValidatorCommitTests.acceptsCodePhaseDeclaringAStraySecondaryKey` was
+ *    added. Its fixture is deliberately unrealistic — a `summarize` emits no LLM
+ *    output, so authoring an `output:` for it is a mistake — and exists to make the
+ *    exemption observable, not to bless the shape.
+ * 9. **The branch-label rows are the port's one behavioural near-miss, caught here.**
+ *    Swift's `validateCanonicalFields(_:)` descends into `then:` / `else:` for
+ *    *every* phase type, unlike the run gate's [validatePhases], which reaches
+ *    branches only through its `CONDITIONAL` arm. All three Swift branch cases build
+ *    a `.conditional` parent, so a Kotlin port that hardcoded `"(conditional)"` into
+ *    the parent label would have passed the whole 1:1 transcription — and diverged
+ *    from Swift on any non-conditional phase carrying `thenPhases`, message text
+ *    only, with no gate able to see it (a rejected scenario produces no parity
+ *    transcript). `branchLabelCarriesTheParentPhaseTypeNotConditional` is the pin;
+ *    it has no Swift sibling because no Swift test can distinguish the two shapes.
  */
 class ScenarioValidatorTests {
 


### PR DESCRIPTION
## Summary

ADR-023 Stage 3「Load + validate」グループの **PR B2** — #1554（PR B1）が run gate（`validate`）を port した続きで、**commit gate 側**を port する。これで `ScenarioValidator` は Swift 4 ファイルすべてが Kotlin commonMain に揃う。

- Swift `ScenarioValidator+CanonicalFields.swift`（102 行）+ `ScenarioValidator.swift` の `validateForCommit` を `ScenarioValidator.kt` に追記
- テスト兄弟 `ScenarioValidatorTests+Commit.swift`（29 件）を `ScenarioValidatorCommitTests.kt` に同名 1:1 転記 + Kotlin 専用 pin 2 件 = 31 件
- ADR-023 §12 条件4 の摂動記録を **3 スイート横断で再実測**
- 「commit gate は未 port / Swift 専用」と書いていた 5 箇所の文言を追従

### 設計判断 2 件

**1. `validateForCommit` を `public` にした（Swift 側は module-`internal`）** — port 初の意図的な可視性拡大。Kotlin の `internal` メンバは exported Obj-C ヘッダに出ないため、`internal` のままだと Stage-5 の K/N consumer（`ScenarioEditorViewModel.save()`）から commit gate に到達できない。member KDoc に理由を記録済み。あわせて、この export に **per-PR の CI 信号が無い**（唯一の Swift consumer である gate spike は nightly ビルド）ことも KDoc に明記した。

**2. canonical-field の branch 降下は phase 型非依存** — Swift の `validateCanonicalFields(_:)` は `.conditional` に限らず**すべての** phase の `thenPhases` / `elsePhases` に降り、親ラベルを `phase.type.rawValue` から作る。run gate の `validatePhases`（`CONDITIONAL` arm 経由でしか branch に届かない）との非対称は意図的。

この 2 点目は本 PR で唯一の**挙動の危うい箇所**だった。Swift 側 29 件の branch ケースは 3 件とも `.conditional` 親なので、Kotlin 側で `"(conditional)"` をリテラル固定しても 1:1 転記は全部緑のまま通り、非 conditional の `thenPhases` キャリアでのみ Swift とメッセージが割れる — しかも validation で弾かれた scenario は parity transcript を生まないので、どのゲートにも見えない。計画段階の `critic` レビューが指摘し、`branchLabelCarriesTheParentPhaseTypeNotConditional` で pin した。

### 摂動記録の再実測（ADR-023 §12 条件4）

commit gate は `validate` を貫くので、**accepting な commit fixture はすべて run-gate 全機構の incidental claimant になる**。既存記録の Incidental 列が丸ごと古くなり、「掃引は 2 スイートのみで十分」という根拠自体も偽になったため、件数の手直しではなく **61 変異 × 3 スイートを全部やり直した**（基準緑 120、各変異で `total` を検証、毎回 byte-identical に復元して最後に `git diff --exit-code` で確認）。

- 動いたのは 4 行のみ: 大域ゲート 3 行（`language` 52→68、`simulationLanguage` null-accept 50→66、persona 51→67 incidental）と `agentCount` ≥ 2（`none`→1）。残りの run-gate 行は実測値が一致 — 推論ではなく測定として記録した
- claimant 不在の機構を 1 件検出（thought rule の code-phase 免除、Swift 側にも兄弟なし）→ `acceptsCodePhaseDeclaringAStraySecondaryKey` を追加して塞いだ
- そのテスト 1 本の追加がさらに 5 セルを動かし、うち 3 つは無関係な行だった。注記 1 の「fixture を足したら表全体を再実測せよ」の 2 例目として記録

## この PR で **しない** こと

- `SimulationEngine` preflight への配線 — ADR-023 §4 原文どおり、未 port の `ScenarioSemanticLinter`（ADR-024）と一体で繋ぐ。片側だけ繋ぐと preflight が言語間で分裂する。`DivergenceLedger.VALIDATOR_UNPORTED` は残す（クラス名は gate を指しており port 状況を指していない）
- `ConditionEvaluator.parse` への `@Throws` 追加 — 同じ K/N の穴だが別スコープ。**follow-up**
- `shared/adr-023-port-ledger.tsv` の編集 — `PORT` 行は `kotlin_target` を持てず、`+CanonicalFields.swift` は既に `PORT` 行

## Test plan

- `./gradlew :shared:engine:jvmTest`（validator 3 スイート）— 120 passed / 0 failed
- `./gradlew :shared:models:jvmTest :shared:engine:jvmTest` の CI ペア + `compileCommonMainKotlinMetadata` — いずれも成功
- `scripts/xcodebuild.sh test` — 3548 passed / 0 failed / 21 skipped
- `swiftlint lint --quiet --strict` — クリーン
- 摂動掃引 61 変異は使い捨てドライバで実行（リポジトリには入れていない）。復元は `git diff --exit-code` で検証済み

## Review

Reviewer: **Opus**（`code-reviewer`）。初回は `SCOPE_TOO_LARGE`（814 追加行 / 8 ファイル）で 2 シャードに分割 — 実装 + docs / commonTest。

- **シャード1（実装 + docs）**: PASS、Critical 0 / Warning 1 / Suggestion 4 — 全件適用。クラス KDoc の要約が run gate しか説明していなかった点、`LLMCaller` の「run time では再チェックしない」が reflect / whisper には当てはまらない点、export に per-PR 信号が無いこと、issue と PR の番号の書き分け、Swift ヘッダの折り返し
- **シャード2（commonTest）**: FAIL、Critical 0 / Warning 2 / Suggestion 3 — 全件適用。両 Warning とも私の摂動記録の実測不整合で、こちらの測定データで裏付けが取れた: (a) `agentCount` ≥ 2 行の Incidental が `none` ではなく 1（`runsValidateChecksFirst` の `agents = 0` fixture）、(b) 注記 1 が red 合計と Incidental 合計を混ぜており、+15 の内訳も「accepting fixture ちょうど」ではなく accepting 12 + メッセージ内容を assert する rejecting 3 だった

却下ゼロ。修正はすべてコメント / KDoc のみで新規ロジックを含まないため、再レビューは回していない。

修正中に 1 件自分で踏んだ罠も記録しておく: **Kotlin のブロックコメントはネストする**ので、KDoc 内に glob 付きパスを書くと入れ子コメントが開いてファイル後半が丸ごとコメントアウトされる（`Unresolved reference` の山として出る）。該当箇所の KDoc に注記済み。

## Device QA

実機QA不要 — Kotlin commonMain / commonTest とコメントのみ。iOS の実行経路に変更なし（Swift 側の差分は doc comment 1 箇所だけ）。

Closes #1552 / Part of #501
