### PR TITLE
🐛 fix: key digest sections by (date, run_id) and lock the append

### DIFF
--- a/.claude/skills/model-eval/scripts/append_eval.py
+++ b/.claude/skills/model-eval/scripts/append_eval.py
@@ -2,16 +2,21 @@
 """Append one /model-eval scorecard section to the local eval digest.
 
 This is the THIRD fork of `.claude/skills/scenario-factory/scripts/
-append_digest.py`'s marker / same-key-idempotency / bootstrap core —
+append_digest.py`'s marker / same-key-idempotency / bootstrap / flock core —
 `append_digest.py` (factory) -> `.claude/skills/scenario-refine/scripts/
-append_audit.py` (refine) -> this file. If the shared 2-marker core ever
-needs a real fix (bootstrap, marker validation, section-replace mechanics),
+append_audit.py` (refine) -> this file. All three forks now carry the flock
+(#1542 swept it across the set). If the shared 2-marker core ever needs a
+real fix (bootstrap, marker validation, section-replace mechanics, locking),
 sweep all three files.
 
 usage: append_eval.py --results <results.json> --journal <eval-digest.md>
 
 The journal is a LOCAL log (gitignored — not committed). If absent it is
 bootstrapped from a scaffold.
+
+The journal read-modify-write runs under an exclusive flock on
+`<journal>.lock`: sibling runs sharing a main checkout would otherwise
+interleave and lose a whole section regardless of key.
 
 Section key is (date, model.profile_id) — unlike the factory/refine digests
 (date-only), a single day can run the battery against more than one model
@@ -56,6 +61,8 @@ of its rules are enforced here and which stay in SKILL.md prose (#1419).
 """
 
 import argparse
+import contextlib
+import fcntl
 import json
 import os
 import re
@@ -86,6 +93,28 @@ See `.claude/skills/model-eval/SKILL.md` for the battery definition, rubric,
 and gate criteria. The `**Gate**:` line in each section is the per-run call;
 this file does not aggregate a final recommendation across models.
 """
+
+
+@contextlib.contextmanager
+def journal_lock(journal_path):
+    """Exclusive flock on `<journal>.lock` around the whole read-modify-write.
+
+    The (date, profile_id) key stops two same-day runs from OVERWRITING each
+    other's section, but not from interleaving: both read the same body, both
+    write, and the loser's section vanishes. The lock file is separate from
+    the journal so the truncating write below can never drop it. Mirrors
+    append_digest.py's digest_lock() / append_audit.py's journal_lock()."""
+    lock_path = journal_path + ".lock"
+    os.makedirs(os.path.dirname(lock_path) or ".", exist_ok=True)
+    fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o644)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        yield
+    finally:
+        try:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+        finally:
+            os.close(fd)
 
 
 def cell(value):
@@ -308,6 +337,11 @@ def main():
         print(f"append_eval: {err}", file=sys.stderr)
         return 1
 
+    with journal_lock(args.journal):
+        return _append_locked(args, results)
+
+
+def _append_locked(args, results):
     if not os.path.exists(args.journal):
         os.makedirs(os.path.dirname(args.journal) or ".", exist_ok=True)
         with open(args.journal, "w", encoding="utf-8") as f:

--- a/.claude/skills/model-eval/scripts/append_eval.py
+++ b/.claude/skills/model-eval/scripts/append_eval.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python3
 """Append one /model-eval scorecard section to the local eval digest.
 
-This is the THIRD fork of `.claude/skills/scenario-factory/scripts/
+This is the THIRD of FOUR forks of `.claude/skills/scenario-factory/scripts/
 append_digest.py`'s marker / same-key-idempotency / bootstrap / flock core —
 `append_digest.py` (factory) -> `.claude/skills/scenario-refine/scripts/
-append_audit.py` (refine) -> this file. All three forks now carry the flock
-(#1542 swept it across the set). If the shared 2-marker core ever needs a
-real fix (bootstrap, marker validation, section-replace mechanics, locking),
-sweep all three files.
+append_audit.py` (refine) -> this file -> `.claude/skills/queue-consumer/
+scripts/append_digest.py` (queue). All four forks now carry the flock (#1542
+swept it across the set; the queue fork is single-marker and append-only, but
+shares the rest). If the shared core ever needs a real fix (bootstrap, marker
+validation, section-replace mechanics, locking), sweep all four files.
 
 usage: append_eval.py --results <results.json> --journal <eval-digest.md>
 

--- a/.claude/skills/model-eval/tests/run_tests.sh
+++ b/.claude/skills/model-eval/tests/run_tests.sh
@@ -15,6 +15,26 @@ trap 'rm -rf "$TMP"' EXIT
 
 fail() { echo "FAIL: $1" >&2; exit 1; }
 
+# Bounded poll helpers for the flock cases below. Synchronization is by
+# sentinel file / process liveness, never by a sleep margin: a cold python
+# start on a loaded CI runner outruns any fixed margin, and a margin that is
+# too short would fire the "did not write" assertion on a CORRECT
+# implementation. Every poll is capped so a hang fails loudly, not silently.
+await_file() {   # $1 = path to wait for, $2 = failure message
+  i=0
+  until [ -e "$1" ]; do
+    i=$((i + 1)); [ "$i" -le 600 ] || fail "$2 (timed out after 60s)"
+    sleep 0.1
+  done
+}
+await_pid() {    # $1 = pid to wait to become observable, $2 = failure message
+  i=0
+  until kill -0 "$1" 2>/dev/null; do
+    i=$((i + 1)); [ "$i" -le 600 ] || fail "$2 (timed out after 60s)"
+    sleep 0.1
+  done
+}
+
 # --- analyze_model_eval.py --------------------------------------------------
 RESULT=$(python3 "$SCRIPTS/analyze_model_eval.py" fixtures/run_ok.jsonl fixtures/run_crashed.jsonl)
 echo "$RESULT" > "$TMP/analyze_out.json"
@@ -188,24 +208,36 @@ LK="$TMP/lock"; mkdir -p "$LK"
 python3 "$SCRIPTS/append_eval.py" \
   --results fixtures/results_sample.json --journal "$LK/eval-digest.md" >/dev/null \
   || fail "lock: seed append should succeed"
-python3 - "$LK/eval-digest.md.lock" <<'PY' &
+# The helper takes the flock and only THEN writes a readiness sentinel; the
+# shell waits for that sentinel before launching the append, and releases the
+# helper through a second sentinel once the assertion is done — so the hold
+# always covers the polls without a guessed duration (the 60s inside is a
+# safety cap so a broken test cannot hang CI, not a schedule).
+python3 - "$LK/eval-digest.md.lock" "$LK/held" "$LK/release" <<'PY' &
 import fcntl, os, sys, time
 fd = os.open(sys.argv[1], os.O_CREAT | os.O_RDWR, 0o644)
 fcntl.flock(fd, fcntl.LOCK_EX)
-time.sleep(4)
+open(sys.argv[2], "w").close()   # readiness sentinel: the lock is now HELD
+deadline = time.time() + 60
+while not os.path.exists(sys.argv[3]) and time.time() < deadline:
+    time.sleep(0.05)
 fcntl.flock(fd, fcntl.LOCK_UN)
 os.close(fd)
 PY
 HOLDER_PID=$!
-sleep 1   # generous margin: let the helper acquire before the append starts
+await_file "$LK/held" "lock: helper never acquired the flock"
 python3 "$SCRIPTS/append_eval.py" \
   --results fixtures/results_sample_profile2.json --journal "$LK/eval-digest.md" \
   >/dev/null 2>&1 &
 APPEND_PID=$!
-sleep 1
+await_pid "$APPEND_PID" "lock: the append process never came up"
+sleep 0.5   # settle: the holder keeps the lock until the release sentinel
+            # below, so a generous settle costs wall time, never a false
+            # failure — unlike the fixed margin this replaced.
 COUNT_DURING=$(grep -c "^## 2026-07-07 — " "$LK/eval-digest.md")
 [ "$COUNT_DURING" -eq 1 ] \
   || fail "lock: append wrote the journal while the lock was held"
+: > "$LK/release"
 wait "$HOLDER_PID"
 wait "$APPEND_PID" || fail "lock: append failed after the lock was released"
 COUNT_AFTER=$(grep -c "^## 2026-07-07 — " "$LK/eval-digest.md")

--- a/.claude/skills/model-eval/tests/run_tests.sh
+++ b/.claude/skills/model-eval/tests/run_tests.sh
@@ -11,26 +11,29 @@ cd "$(dirname "$0")"
 SCRIPTS=../scripts
 REPO_ROOT="$(cd ../../../.. && pwd)"
 TMP=$(mktemp -d)
-trap 'rm -rf "$TMP"' EXIT
+HOLDER_PID=""
+# The flock cases below run a lock holder with a 60s deadline. A failing
+# assertion must not orphan it: it inherits the harness's stdout, so an
+# orphan can stall a piped CI invocation for the whole deadline.
+cleanup() { [ -n "$HOLDER_PID" ] && kill "$HOLDER_PID" 2>/dev/null; rm -rf "$TMP"; return 0; }
+trap cleanup EXIT
 
 fail() { echo "FAIL: $1" >&2; exit 1; }
 
 # Bounded poll helpers for the flock cases below. Synchronization is by
-# sentinel file / process liveness, never by a sleep margin: a cold python
-# start on a loaded CI runner outruns any fixed margin, and a margin that is
-# too short would fire the "did not write" assertion on a CORRECT
-# implementation. Every poll is capped so a hang fails loudly, not silently.
+# sentinel file: the append is launched through a wrapper that touches a
+# "started" sentinel immediately before exec'ing python, and the holder keeps
+# the lock until the release sentinel. The short settle after the started
+# sentinel IS a sleep margin, but a one-sided one — the lock is still held
+# across it, so a slow python start can only yield a false PASS, never a false
+# failure. What makes the case bite is the liveness assertion immediately
+# before the release (the append must still be running, and not defunct)
+# together with the post-release assertions. Every poll is capped so a hang
+# fails loudly, not silently.
 await_file() {   # $1 = path to wait for, $2 = failure message
-  i=0
+  local i=0
   until [ -e "$1" ]; do
-    i=$((i + 1)); [ "$i" -le 600 ] || fail "$2 (timed out after 60s)"
-    sleep 0.1
-  done
-}
-await_pid() {    # $1 = pid to wait to become observable, $2 = failure message
-  i=0
-  until kill -0 "$1" 2>/dev/null; do
-    i=$((i + 1)); [ "$i" -le 600 ] || fail "$2 (timed out after 60s)"
+    i=$((i + 1)); [ "$i" -le 600 ] || fail "$2 (timed out after ~600 polls)"
     sleep 0.1
   done
 }
@@ -212,33 +215,59 @@ python3 "$SCRIPTS/append_eval.py" \
 # shell waits for that sentinel before launching the append, and releases the
 # helper through a second sentinel once the assertion is done — so the hold
 # always covers the polls without a guessed duration (the 60s inside is a
-# safety cap so a broken test cannot hang CI, not a schedule).
+# safety cap so a broken test cannot hang CI, not a schedule — blowing it
+# exits the helper non-zero, which the wait below turns into a FAIL).
 python3 - "$LK/eval-digest.md.lock" "$LK/held" "$LK/release" <<'PY' &
 import fcntl, os, sys, time
 fd = os.open(sys.argv[1], os.O_CREAT | os.O_RDWR, 0o644)
 fcntl.flock(fd, fcntl.LOCK_EX)
 open(sys.argv[2], "w").close()   # readiness sentinel: the lock is now HELD
 deadline = time.time() + 60
-while not os.path.exists(sys.argv[3]) and time.time() < deadline:
+while not os.path.exists(sys.argv[3]):
+    if time.time() >= deadline:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+        os.close(fd)
+        sys.exit("lock helper: release sentinel never appeared")
     time.sleep(0.05)
 fcntl.flock(fd, fcntl.LOCK_UN)
 os.close(fd)
 PY
 HOLDER_PID=$!
 await_file "$LK/held" "lock: helper never acquired the flock"
-python3 "$SCRIPTS/append_eval.py" \
+# bash assigns $! at fork and `kill -0` also succeeds on an unreaped zombie,
+# so neither proves the append got as far as the lock. Launch it through a
+# wrapper that touches a "started" sentinel immediately before exec'ing
+# python (exec keeps $! pointing at the python process itself).
+cat > "$LK/append_wrapper.sh" <<'EOF'
+#!/bin/bash
+# $1 = "started" sentinel; the rest is the command to exec.
+started=$1; shift
+: > "$started"
+exec "$@"
+EOF
+bash "$LK/append_wrapper.sh" "$LK/started" \
+  python3 "$SCRIPTS/append_eval.py" \
   --results fixtures/results_sample_profile2.json --journal "$LK/eval-digest.md" \
   >/dev/null 2>&1 &
 APPEND_PID=$!
-await_pid "$APPEND_PID" "lock: the append process never came up"
-sleep 0.5   # settle: the holder keeps the lock until the release sentinel
-            # below, so a generous settle costs wall time, never a false
-            # failure — unlike the fixed margin this replaced.
+await_file "$LK/started" "lock: the append never started"
+sleep 0.5   # one-sided settle: the holder keeps the lock across it, so this
+            # can only cost wall time, never a false failure.
+# ...and the append must still be ALIVE and blocked here. An append that
+# already exited — or that never took the lock at all — would satisfy the
+# "did not write" assertion below vacuously.
+APPEND_STATE=$(ps -o state= -p "$APPEND_PID" 2>/dev/null | tr -d '[:space:]' || true)
+[ -n "$APPEND_STATE" ] \
+  || fail "lock: the append exited instead of blocking on the held lock"
+case "$APPEND_STATE" in
+  Z*) fail "lock: the append is defunct — it exited instead of blocking on the held lock" ;;
+esac
 COUNT_DURING=$(grep -c "^## 2026-07-07 — " "$LK/eval-digest.md")
 [ "$COUNT_DURING" -eq 1 ] \
   || fail "lock: append wrote the journal while the lock was held"
 : > "$LK/release"
-wait "$HOLDER_PID"
+wait "$HOLDER_PID" || fail "lock: holder timed out waiting for the release sentinel"
+HOLDER_PID=""
 wait "$APPEND_PID" || fail "lock: append failed after the lock was released"
 COUNT_AFTER=$(grep -c "^## 2026-07-07 — " "$LK/eval-digest.md")
 [ "$COUNT_AFTER" -eq 2 ] \

--- a/.claude/skills/model-eval/tests/run_tests.sh
+++ b/.claude/skills/model-eval/tests/run_tests.sh
@@ -180,6 +180,38 @@ fi
 grep -qF "Retry: #751" "$PARTIAL_SECTION" \
   || fail "append: partial blocked section missing the Retry line"
 
+# (f) the append really takes an exclusive flock on <journal>.lock — the
+# (date, profile_id) key alone does not stop a concurrent read-modify-write
+# from losing a whole section. A helper holds the lock while an append is
+# launched.
+LK="$TMP/lock"; mkdir -p "$LK"
+python3 "$SCRIPTS/append_eval.py" \
+  --results fixtures/results_sample.json --journal "$LK/eval-digest.md" >/dev/null \
+  || fail "lock: seed append should succeed"
+python3 - "$LK/eval-digest.md.lock" <<'PY' &
+import fcntl, os, sys, time
+fd = os.open(sys.argv[1], os.O_CREAT | os.O_RDWR, 0o644)
+fcntl.flock(fd, fcntl.LOCK_EX)
+time.sleep(4)
+fcntl.flock(fd, fcntl.LOCK_UN)
+os.close(fd)
+PY
+HOLDER_PID=$!
+sleep 1   # generous margin: let the helper acquire before the append starts
+python3 "$SCRIPTS/append_eval.py" \
+  --results fixtures/results_sample_profile2.json --journal "$LK/eval-digest.md" \
+  >/dev/null 2>&1 &
+APPEND_PID=$!
+sleep 1
+COUNT_DURING=$(grep -c "^## 2026-07-07 — " "$LK/eval-digest.md")
+[ "$COUNT_DURING" -eq 1 ] \
+  || fail "lock: append wrote the journal while the lock was held"
+wait "$HOLDER_PID"
+wait "$APPEND_PID" || fail "lock: append failed after the lock was released"
+COUNT_AFTER=$(grep -c "^## 2026-07-07 — " "$LK/eval-digest.md")
+[ "$COUNT_AFTER" -eq 2 ] \
+  || fail "lock: second profile's section missing after the lock was released"
+
 # --- run_scenario.sh --profile canary (PASTURA_HARNESS_BIN test seam) ------
 FAKE_BIN="$TMP/fake_harness.sh"
 cat > "$FAKE_BIN" <<'EOF'

--- a/.claude/skills/queue-consumer/scripts/append_digest.py
+++ b/.claude/skills/queue-consumer/scripts/append_digest.py
@@ -15,12 +15,26 @@ Resolution:
      (bare repo / unexpected layout) — this is the real wrong-target
      catch now that the tracked-check is gone.
   2. If the digest is absent there, bootstrap a fresh scaffold (the log
-     is no longer tracked, so a clean clone / first run has no file).
-     A present file must still carry the section marker (main() checks)
-     — a stray wrong target would lack it.
+     is no longer tracked, so a clean clone / first run has no file) —
+     under the lock, since creating the target is part of the
+     read-modify-write. A present file must still carry the section
+     marker — a stray wrong target would lack it.
 
 With --digest (tests, manual use) resolution is skipped, but the marker
 check below still applies.
+
+This is the FOURTH fork of `.claude/skills/scenario-factory/scripts/
+append_digest.py`'s marker / bootstrap / flock core (the others: refine's
+append_audit.py, model-eval's append_eval.py); all four now carry the flock
+(#1542 swept it across the set). If that shared core ever needs a real fix,
+sweep all four files.
+
+The digest read-modify-write — resolution's bootstrap-if-absent included —
+runs under an exclusive flock on `<digest>.lock`. This fork is the most
+exposed member of the family: it deliberately targets the MAIN checkout, so
+runs from every routine worktree write ONE shared file, and it is
+append-only, so an interleaved read-modify-write drops a whole run record
+with no key to recover it from.
 
 The digest must contain exactly one section marker:
 
@@ -53,6 +67,8 @@ Results JSON schema (composed by the /queue-consumer session):
 """
 
 import argparse
+import contextlib
+import fcntl
 import json
 import os
 import re
@@ -84,7 +100,11 @@ def cell(value):
 
 
 def resolve_main_digest():
-    """Locate the main checkout's local digest; bootstrap it if absent."""
+    """Locate the main checkout's local digest. Resolution only — the
+    bootstrap-if-absent moved into _append_locked(): creating the target is
+    itself part of the read-modify-write and must happen under the lock, or
+    two first runs racing from different worktrees each write a scaffold and
+    one loses its section."""
     common = subprocess.run(
         ["git", "rev-parse", "--path-format=absolute", "--git-common-dir"],
         capture_output=True, text=True, check=True).stdout.strip()
@@ -92,15 +112,30 @@ def resolve_main_digest():
         sys.exit(f"unexpected --git-common-dir {common!r} (bare repo?) — "
                  "pass --digest explicitly")
     main_root = os.path.dirname(common)
-    path = os.path.join(main_root, DIGEST_RELPATH)
-    if not os.path.exists(path):
-        # Local-log model: the digest is gitignored, so a clean clone or
-        # the very first run has no file. Bootstrap the scaffold (with the
-        # section marker) rather than aborting.
-        os.makedirs(os.path.dirname(path), exist_ok=True)
-        with open(path, "w", encoding="utf-8") as f:
-            f.write(SCAFFOLD)
-    return path
+    return os.path.join(main_root, DIGEST_RELPATH)
+
+
+@contextlib.contextmanager
+def digest_lock(digest_path):
+    """Exclusive flock on `<digest>.lock` around the whole read-modify-write.
+
+    Every routine worktree resolves to the SAME main-checkout digest, so two
+    runs would otherwise both read the body, both write, and the loser's
+    section would vanish — and this log is append-only, so there is no key to
+    recover it from. The lock file is separate from the digest so the
+    truncating write below can never drop it. Mirrors the factory digest's
+    digest_lock() / the refine journal's journal_lock()."""
+    lock_path = digest_path + ".lock"
+    os.makedirs(os.path.dirname(lock_path) or ".", exist_ok=True)
+    fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o644)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        yield
+    finally:
+        try:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+        finally:
+            os.close(fd)
 
 
 def render_section(results):
@@ -147,7 +182,27 @@ def main():
             sys.exit(f"issue {issue.get('number')}: outcome must be one of "
                      f"{OUTCOMES}, got: {issue.get('outcome')!r}")
 
+    # Resolve first, lock the resolved path, then bootstrap / read / write
+    # under it. Parsing and validation above touch no target file, so they
+    # stay outside the lock.
+    may_bootstrap = args.digest is None
     digest_path = args.digest or resolve_main_digest()
+    with digest_lock(digest_path):
+        return _append_locked(digest_path, results, run_id, may_bootstrap)
+
+
+def _append_locked(digest_path, results, run_id, may_bootstrap):
+    """Bootstrap-if-absent, read, and rewrite the digest. Caller must hold
+    digest_lock()."""
+    if may_bootstrap and not os.path.exists(digest_path):
+        # Local-log model: the digest is gitignored, so a clean clone or the
+        # very first run has no file. Bootstrap the scaffold (with the section
+        # marker) rather than aborting. Re-checked here, under the lock — the
+        # racing sibling may have created it since resolution.
+        os.makedirs(os.path.dirname(digest_path), exist_ok=True)
+        with open(digest_path, "w", encoding="utf-8") as f:
+            f.write(SCAFFOLD)
+
     with open(digest_path, encoding="utf-8") as f:
         digest = f.read()
     if digest.count(SECTIONS_MARKER) != 1:

--- a/.claude/skills/queue-consumer/tests/run_tests.sh
+++ b/.claude/skills/queue-consumer/tests/run_tests.sh
@@ -11,26 +11,29 @@ cd "$(dirname "$0")"
 SCRIPTS=$(cd ../scripts && pwd)
 FIXTURES=$(cd fixtures && pwd)
 TMP=$(mktemp -d)
-trap 'rm -rf "$TMP"' EXIT
+HOLDER_PID=""
+# The flock cases below run a lock holder with a 60s deadline. A failing
+# assertion must not orphan it: it inherits the harness's stdout, so an
+# orphan can stall a piped CI invocation for the whole deadline.
+cleanup() { [ -n "$HOLDER_PID" ] && kill "$HOLDER_PID" 2>/dev/null; rm -rf "$TMP"; return 0; }
+trap cleanup EXIT
 
 fail() { echo "FAIL: $1" >&2; exit 1; }
 
 # Bounded poll helpers for the flock cases below. Synchronization is by
-# sentinel file / process liveness, never by a sleep margin: a cold python
-# start on a loaded CI runner outruns any fixed margin, and a margin that is
-# too short would fire the "did not write" assertion on a CORRECT
-# implementation. Every poll is capped so a hang fails loudly, not silently.
+# sentinel file: the append is launched through a wrapper that touches a
+# "started" sentinel immediately before exec'ing python, and the holder keeps
+# the lock until the release sentinel. The short settle after the started
+# sentinel IS a sleep margin, but a one-sided one — the lock is still held
+# across it, so a slow python start can only yield a false PASS, never a false
+# failure. What makes the case bite is the liveness assertion immediately
+# before the release (the append must still be running, and not defunct)
+# together with the post-release assertions. Every poll is capped so a hang
+# fails loudly, not silently.
 await_file() {   # $1 = path to wait for, $2 = failure message
-  i=0
+  local i=0
   until [ -e "$1" ]; do
-    i=$((i + 1)); [ "$i" -le 600 ] || fail "$2 (timed out after 60s)"
-    sleep 0.1
-  done
-}
-await_pid() {    # $1 = pid to wait to become observable, $2 = failure message
-  i=0
-  until kill -0 "$1" 2>/dev/null; do
-    i=$((i + 1)); [ "$i" -le 600 ] || fail "$2 (timed out after 60s)"
+    i=$((i + 1)); [ "$i" -le 600 ] || fail "$2 (timed out after ~600 polls)"
     sleep 0.1
   done
 }
@@ -142,31 +145,57 @@ printf '%s' "$SEED" > "$LK/digest.md"
 # shell waits for that sentinel before launching the append, and releases the
 # helper through a second sentinel once the assertion is done — so the hold
 # always covers the polls without a guessed duration (the 60s inside is a
-# safety cap so a broken test cannot hang CI, not a schedule).
+# safety cap so a broken test cannot hang CI, not a schedule — blowing it
+# exits the helper non-zero, which the wait below turns into a FAIL).
 python3 - "$LK/digest.md.lock" "$LK/held" "$LK/release" <<'PY' &
 import fcntl, os, sys, time
 fd = os.open(sys.argv[1], os.O_CREAT | os.O_RDWR, 0o644)
 fcntl.flock(fd, fcntl.LOCK_EX)
 open(sys.argv[2], "w").close()   # readiness sentinel: the lock is now HELD
 deadline = time.time() + 60
-while not os.path.exists(sys.argv[3]) and time.time() < deadline:
+while not os.path.exists(sys.argv[3]):
+    if time.time() >= deadline:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+        os.close(fd)
+        sys.exit("lock helper: release sentinel never appeared")
     time.sleep(0.05)
 fcntl.flock(fd, fcntl.LOCK_UN)
 os.close(fd)
 PY
 HOLDER_PID=$!
 await_file "$LK/held" "lock: helper never acquired the flock"
-python3 "$SCRIPTS/append_digest.py" \
+# bash assigns $! at fork and `kill -0` also succeeds on an unreaped zombie,
+# so neither proves the append got as far as the lock. Launch it through a
+# wrapper that touches a "started" sentinel immediately before exec'ing
+# python (exec keeps $! pointing at the python process itself).
+cat > "$LK/append_wrapper.sh" <<'EOF'
+#!/bin/bash
+# $1 = "started" sentinel; the rest is the command to exec.
+started=$1; shift
+: > "$started"
+exec "$@"
+EOF
+bash "$LK/append_wrapper.sh" "$LK/started" \
+  python3 "$SCRIPTS/append_digest.py" \
   --results "$FIXTURES/results_sample.json" --digest "$LK/digest.md" >/dev/null 2>&1 &
 APPEND_PID=$!
-await_pid "$APPEND_PID" "lock: the append process never came up"
-sleep 0.5   # settle: the holder keeps the lock until the release sentinel
-            # below, so a generous settle costs wall time, never a false
-            # failure.
+await_file "$LK/started" "lock: the append never started"
+sleep 0.5   # one-sided settle: the holder keeps the lock across it, so this
+            # can only cost wall time, never a false failure.
+# ...and the append must still be ALIVE and blocked here. An append that
+# already exited — or that never took the lock at all — would satisfy the
+# "did not write" assertion below vacuously.
+APPEND_STATE=$(ps -o state= -p "$APPEND_PID" 2>/dev/null | tr -d '[:space:]' || true)
+[ -n "$APPEND_STATE" ] \
+  || fail "lock: the append exited instead of blocking on the held lock"
+case "$APPEND_STATE" in
+  Z*) fail "lock: the append is defunct — it exited instead of blocking on the held lock" ;;
+esac
 grep -q "^## 2026-06-14 01:30$" "$LK/digest.md" \
   && fail "lock: append wrote the digest while the lock was held"
 : > "$LK/release"
-wait "$HOLDER_PID"
+wait "$HOLDER_PID" || fail "lock: holder timed out waiting for the release sentinel"
+HOLDER_PID=""
 wait "$APPEND_PID" || fail "lock: append failed after the lock was released"
 grep -q "^## 2026-06-14 01:30$" "$LK/digest.md" \
   || fail "lock: section missing after the lock was released"

--- a/.claude/skills/queue-consumer/tests/run_tests.sh
+++ b/.claude/skills/queue-consumer/tests/run_tests.sh
@@ -15,6 +15,26 @@ trap 'rm -rf "$TMP"' EXIT
 
 fail() { echo "FAIL: $1" >&2; exit 1; }
 
+# Bounded poll helpers for the flock cases below. Synchronization is by
+# sentinel file / process liveness, never by a sleep margin: a cold python
+# start on a loaded CI runner outruns any fixed margin, and a margin that is
+# too short would fire the "did not write" assertion on a CORRECT
+# implementation. Every poll is capped so a hang fails loudly, not silently.
+await_file() {   # $1 = path to wait for, $2 = failure message
+  i=0
+  until [ -e "$1" ]; do
+    i=$((i + 1)); [ "$i" -le 600 ] || fail "$2 (timed out after 60s)"
+    sleep 0.1
+  done
+}
+await_pid() {    # $1 = pid to wait to become observable, $2 = failure message
+  i=0
+  until kill -0 "$1" 2>/dev/null; do
+    i=$((i + 1)); [ "$i" -le 600 ] || fail "$2 (timed out after 60s)"
+    sleep 0.1
+  done
+}
+
 SEED="# digest
 
 <!-- queue-digest:sections -->
@@ -110,6 +130,46 @@ grep -q "queue-digest:sections" "$REPO/data/queue/digest.md" \
   || fail "resolver: bootstrap did not write the section marker"
 grep -q "^## 2026-06-16 01:30$" "$REPO/data/queue/digest.md" \
   || fail "resolver: bootstrap did not append the section"
+
+# --- the append takes an exclusive flock on <digest>.lock (#1542) -----------
+# Every routine worktree resolves to the SAME main-checkout digest and this log
+# is append-only, so an interleaved read-modify-write drops a whole run record
+# with no key to recover it from. A helper holds the lock while an append is
+# launched; the append must block, not write.
+LK="$TMP/lock"; mkdir -p "$LK"
+printf '%s' "$SEED" > "$LK/digest.md"
+# The helper takes the flock and only THEN writes a readiness sentinel; the
+# shell waits for that sentinel before launching the append, and releases the
+# helper through a second sentinel once the assertion is done — so the hold
+# always covers the polls without a guessed duration (the 60s inside is a
+# safety cap so a broken test cannot hang CI, not a schedule).
+python3 - "$LK/digest.md.lock" "$LK/held" "$LK/release" <<'PY' &
+import fcntl, os, sys, time
+fd = os.open(sys.argv[1], os.O_CREAT | os.O_RDWR, 0o644)
+fcntl.flock(fd, fcntl.LOCK_EX)
+open(sys.argv[2], "w").close()   # readiness sentinel: the lock is now HELD
+deadline = time.time() + 60
+while not os.path.exists(sys.argv[3]) and time.time() < deadline:
+    time.sleep(0.05)
+fcntl.flock(fd, fcntl.LOCK_UN)
+os.close(fd)
+PY
+HOLDER_PID=$!
+await_file "$LK/held" "lock: helper never acquired the flock"
+python3 "$SCRIPTS/append_digest.py" \
+  --results "$FIXTURES/results_sample.json" --digest "$LK/digest.md" >/dev/null 2>&1 &
+APPEND_PID=$!
+await_pid "$APPEND_PID" "lock: the append process never came up"
+sleep 0.5   # settle: the holder keeps the lock until the release sentinel
+            # below, so a generous settle costs wall time, never a false
+            # failure.
+grep -q "^## 2026-06-14 01:30$" "$LK/digest.md" \
+  && fail "lock: append wrote the digest while the lock was held"
+: > "$LK/release"
+wait "$HOLDER_PID"
+wait "$APPEND_PID" || fail "lock: append failed after the lock was released"
+grep -q "^## 2026-06-14 01:30$" "$LK/digest.md" \
+  || fail "lock: section missing after the lock was released"
 
 # present-but-marker-less file via the resolver → still refuses
 echo "# broken, no marker" > "$REPO/data/queue/digest.md"

--- a/.claude/skills/scenario-factory/SKILL.md
+++ b/.claude/skills/scenario-factory/SKILL.md
@@ -38,6 +38,11 @@ Non-goals:
   SECOND section instead of replacing its own — reuse the original value. If
   two cycles could plausibly start within the same second, give one a
   disambiguating suffix (`01:23:45-b`) rather than sharing the value.
+  **A resumed session has no memory of it**, which is exactly the re-append
+  case, so recover rather than mint: read `run_id` back from this cycle's
+  results JSON temp file, else from the cycle's `## <DATE> — <RUN_ID>` heading
+  in `data/factory/digest.md`. Only when neither exists is this a genuinely
+  new cycle — mint it with `date +%H:%M:%S`.
 - Generated YAMLs: `data/factory/scenarios/<DATE>/` (gitignored; kept
   local for later promotion — do NOT write into `runs/`, that is the
   harness output dir)

--- a/.claude/skills/scenario-factory/SKILL.md
+++ b/.claude/skills/scenario-factory/SKILL.md
@@ -389,10 +389,14 @@ never sinks a third night into it.
 ## Step 5 — Append the digest
 
 1. Write the results JSON (schema documented in `append_digest.py`'s
-   docstring: date / model / notes / per-scenario id, name, theme, **axis**,
+   docstring: date / **run_id** / model / notes / per-scenario id, name, theme, **axis**,
    yaml, run_log, status, attempts, duration_sec, scores (5 axes: coherence /
    interaction / breakdown_free / humor / development), comment, error) to
-   a temp file. Set `axis` to the Step 1.5 axis this scenario targeted (e.g.
+   a temp file. Set `run_id` to this cycle's `HH:MM:SS` start time — the
+   digest section key is (date, run_id), so a second cycle on the same date
+   gets its own section instead of overwriting the first (#1542). Reuse the
+   SAME `run_id` when re-appending a partially-failed cycle, so it replaces
+   its own section. Set `axis` to the Step 1.5 axis this scenario targeted (e.g.
    `"elimination / creative"`) so cross-night rotation can read it back. Keep
    `notes` a **single line** (a line-initial `## ` or `|` would split the digest
    section on re-parse): `tournament: <N> sketched → <selected ids>; sketches:
@@ -404,7 +408,8 @@ never sinks a third night into it.
      --digest data/factory/digest.md
    ```
 3. Verify: `grep -c 'factory-digest:' data/factory/digest.md` must print
-   `2` (both markers survived), and the new `## <DATE>` section exists.
+   `2` (both markers survived), and the new `## <DATE> — <RUN_ID>` section
+   exists.
 
 ## Step 5.5 — Propose lessons (inbox)
 

--- a/.claude/skills/scenario-factory/SKILL.md
+++ b/.claude/skills/scenario-factory/SKILL.md
@@ -30,6 +30,14 @@ Non-goals:
 - `MODEL`: `~/Models/gemma-4-E2B-it-Q4_K_M.gguf` (sha256 matches the
   `ModelRegistry` pin)
 - `DATE`: today as `YYYY-MM-DD`; `DATESTAMP`: `YYYYMMDD`
+- `RUN_ID`: this cycle's start time as `HH:MM:SS`, captured ONCE here at the
+  top of the cycle and reused **verbatim** in every append it makes. It is the
+  second half of the digest section key `(DATE, RUN_ID)`, which is what stops
+  a second cycle on the same date from overwriting the first (#1542). Taking
+  the clock again when re-appending a partially-failed cycle would write a
+  SECOND section instead of replacing its own — reuse the original value. If
+  two cycles could plausibly start within the same second, give one a
+  disambiguating suffix (`01:23:45-b`) rather than sharing the value.
 - Generated YAMLs: `data/factory/scenarios/<DATE>/` (gitignored; kept
   local for later promotion — do NOT write into `runs/`, that is the
   harness output dir)
@@ -71,10 +79,13 @@ Read four sources, in order:
 - **(b) `data/factory/digest-index.jsonl`** for FULL-history dedup — one line
   per past scenario (id / name / theme / axis / status / scores, no comments;
   ~19 KB vs the ~97 KB digest). Collect every past **id, name, theme** here.
-- **(c) Only the NEWEST 2 sections of `data/factory/digest.md`** for the
-  freshest nuance — last nights' comments, lessons, and axis-rotation context.
-  **NEVER read the whole digest** (it exceeds the session Read cap, ~39k
-  tokens): read with `offset`/`limit`, or stop at the 2nd `## <date>` heading.
+- **(c) Only the NEWEST 2 DATES' sections of `data/factory/digest.md`** for
+  the freshest nuance — last nights' comments, lessons, and axis-rotation
+  context. Headings are `## <date> — <run_id>` and one date can carry several
+  of them (#1542), so count DATES, not headings, or a night that ran twice
+  crowds out the previous night entirely. **NEVER read the whole digest** (it
+  exceeds the session Read cap, ~39k tokens): read with `offset`/`limit`, or
+  stop at the first heading whose date is the 3rd distinct one.
 - **(d) The newest 2 files in `data/factory/sketches/`** as a seed bank —
   **grep the `### S` heading and `paper:` lines only, never Read them whole**
   (context budget). A runner-up that lost only on axis-distinctness may be
@@ -389,15 +400,13 @@ never sinks a third night into it.
 ## Step 5 — Append the digest
 
 1. Write the results JSON (schema documented in `append_digest.py`'s
-   docstring: date / **run_id** / model / notes / per-scenario id, name, theme, **axis**,
-   yaml, run_log, status, attempts, duration_sec, scores (5 axes: coherence /
-   interaction / breakdown_free / humor / development), comment, error) to
-   a temp file. Set `run_id` to this cycle's `HH:MM:SS` start time — the
-   digest section key is (date, run_id), so a second cycle on the same date
-   gets its own section instead of overwriting the first (#1542). Reuse the
-   SAME `run_id` when re-appending a partially-failed cycle, so it replaces
-   its own section. Set `axis` to the Step 1.5 axis this scenario targeted (e.g.
-   `"elimination / creative"`) so cross-night rotation can read it back. Keep
+   docstring: date / **run_id** / model / notes / per-scenario id, name, theme,
+   **axis**, yaml, run_log, status, attempts, duration_sec, scores (5 axes:
+   coherence / interaction / breakdown_free / humor / development), comment,
+   error) to a temp file. Set `run_id` to the `RUN_ID` fixed in § Constants —
+   reuse that value, do not re-read the clock here. Set `axis` to the Step 1.5
+   axis this scenario targeted (e.g. `"elimination / creative"`) so cross-night
+   rotation can read it back. Keep
    `notes` a **single line** (a line-initial `## ` or `|` would split the digest
    section on re-parse): `tournament: <N> sketched → <selected ids>; sketches:
    data/factory/sketches/<DATE>.md; incubator: <none | v2 of <id> →

--- a/.claude/skills/scenario-factory/SKILL.md
+++ b/.claude/skills/scenario-factory/SKILL.md
@@ -39,10 +39,16 @@ Non-goals:
   two cycles could plausibly start within the same second, give one a
   disambiguating suffix (`01:23:45-b`) rather than sharing the value.
   **A resumed session has no memory of it**, which is exactly the re-append
-  case, so recover rather than mint: read `run_id` back from this cycle's
-  results JSON temp file, else from the cycle's `## <DATE> — <RUN_ID>` heading
-  in `data/factory/digest.md`. Only when neither exists is this a genuinely
-  new cycle — mint it with `date +%H:%M:%S`.
+  case — but both places it could be read back from are DATE-keyed, not
+  run-keyed: `/tmp/factory_results_<DATE>.json` is overwritten by a second
+  same-day cycle, and one date can now carry several `## <DATE> — <RUN_ID>`
+  sections in `data/factory/digest.md`. Recovering a sibling's value REPLACES
+  that sibling's section; over-minting only adds a spurious one — so recover
+  only when today has exactly one candidate (one results temp file whose
+  `run_id` has no section yet, or exactly one section for `<DATE>`). When the
+  date carries more than one run_id and you cannot identify your own, mint a
+  suffixed RUN_ID (`01:23:45-b`) rather than guess. A genuinely new cycle
+  mints with `date +%H:%M:%S`.
 - Generated YAMLs: `data/factory/scenarios/<DATE>/` (gitignored; kept
   local for later promotion — do NOT write into `runs/`, that is the
   harness output dir)

--- a/.claude/skills/scenario-factory/scripts/append_digest.py
+++ b/.claude/skills/scenario-factory/scripts/append_digest.py
@@ -293,13 +293,23 @@ def split_row_cells(line):
     return [p.strip().replace("\\|", "|") for p in parts]
 
 
-def _rebuild_fail(date, header, msg):
+def _rebuild_fail(date, line, msg, kind="table shape", label="header",
+                  remedy=None):
     """Rebuild is a manual/recovery operation — unlike the nightly append it
     MUST NOT fail-open into a silently partial index. Hard-fail loudly and
-    write nothing."""
-    print(f"rebuild-index: unrecognized table shape in section {date}: {msg}",
+    write nothing.
+
+    `kind` / `label` name the line the operator has to look at: the table
+    header for a column/row-shape failure, the `## <date> — <suffix>` heading
+    for an unparseable run_id. Pointing at the wrong one sends them editing a
+    table that is fine. `remedy` spells out the edit when there is exactly
+    one — this is the tool reached for when the digest is ALREADY damaged, so
+    a dead end here has no fallback."""
+    print(f"rebuild-index: unrecognized {kind} in section {date}: {msg}",
           file=sys.stderr)
-    print(f"  header: {header}", file=sys.stderr)
+    print(f"  {label}: {line}", file=sys.stderr)
+    if remedy:
+        print(f"  fix: {remedy}", file=sys.stderr)
     sys.exit(2)
 
 
@@ -345,7 +355,12 @@ def _rebuild_index_locked(digest_path):
         # rather than fail-open into a silently wrong index.
         if run_id is not None and validate_run_id(run_id):
             _rebuild_fail(date, heading.strip(),
-                          f"heading suffix is not a valid run_id: {run_id!r}")
+                          f"heading suffix is not a valid run_id: {run_id!r}",
+                          kind="section heading", label="heading",
+                          remedy=(f"edit the heading to `## {date} — HH:MM:SS` "
+                                  f"(any run_id of that shape — the cycle's "
+                                  f"start time is the convention), or delete "
+                                  f"the section, then re-run --rebuild-index"))
         section_count += 1
 
         table_lines = [l for l in rest.split("\n") if l.lstrip().startswith("|")]

--- a/.claude/skills/scenario-factory/scripts/append_digest.py
+++ b/.claude/skills/scenario-factory/scripts/append_digest.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
-"""Append one factory-cycle section to the local digest, date-idempotently.
+"""Append one factory-cycle section to the local digest, (date, run_id)-idempotently.
 
 usage: append_digest.py --results <results.json> --digest <digest.md>
+         (results.json must carry `run_id` — the section key is (date, run_id))
        append_digest.py --digest <digest.md> --rebuild-index
 
 Alongside the digest an append also writes a machine-readable sidecar index
@@ -22,14 +23,32 @@ The digest must contain both marker comments:
                                       (newest first)
   <!-- factory-digest:promotion -->   promotion pointer footer; never modified
 
-If a section for the same date already exists between the markers it is
-REPLACED (so re-running a partially-failed cycle is safe) and a warning
-goes to stderr. Missing markers are a hard error — never blind-append.
+If a section for the same (date, run_id) already exists between the markers
+it is REPLACED (so re-running a partially-failed cycle is safe) and a warning
+goes to stderr. Two cycles sharing a date but not a run_id keep SEPARATE
+sections — before #1542 the key was the date alone and the second run of a
+day silently wiped the first run's judging record. A legacy date-only
+`## <date>` heading never matches the replace pattern, so pre-#1542 sections
+in an existing local digest survive untouched.
+
+Digest + sidecar writes are serialized by an exclusive flock on
+`<digest>.lock`: sibling runs sharing a main checkout would otherwise
+interleave a read-modify-write and lose a whole section regardless of key.
+
+Missing markers are a hard error — never blind-append.
 
 Results JSON schema (composed by the /scenario-factory session):
 
 {
   "date": "YYYY-MM-DD",
+  "run_id": "01:23:45",   // REQUIRED. Recommended value: the cycle's HH:MM:SS
+                          // start time — the heading already carries the date,
+                          // so unlike queue-consumer's full "YYYY-MM-DD HH:MM"
+                          // only the clock part is needed to disambiguate.
+                          // Never auto-derived from the clock: a generated
+                          // default would give a re-run of a partially-failed
+                          // cycle a NEW key and duplicate its section instead
+                          // of replacing it.
   "model": "gemma-4-E2B-it-Q4_K_M",
   "notes": "optional free text",
   "scenarios": [
@@ -55,12 +74,19 @@ Results JSON schema (composed by the /scenario-factory session):
 """
 
 import argparse
+import contextlib
+import fcntl
 import json
 import os
 import re
 import sys
+from datetime import datetime
 
 SECTIONS_MARKER = "<!-- factory-digest:sections -->"
+# run_id shape: short, filesystem/markdown-safe, and heading-legible. The
+# clock-shaped subset is additionally range-checked (see validate_run_id).
+RUN_ID_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9:_-]{0,15}")
+CLOCK_RE = re.compile(r"\d{2}:\d{2}(:\d{2})?")
 PROMOTION_MARKER = "<!-- factory-digest:promotion -->"
 RUBRIC_KEYS = ["coherence", "interaction", "breakdown_free", "humor", "development"]
 # Bootstrap scaffold for a fresh local log (the digest is gitignored, so a
@@ -81,6 +107,46 @@ Promotion: channels documented in `.claude/skills/scenario-factory/SKILL.md` § 
 """
 
 
+def validate_run_id(run_id):
+    """Return an error string, or None when `run_id` is usable as a section key.
+
+    A clock-shaped value is range-checked so a typo like `99:99` is rejected at
+    append time rather than becoming a permanent, unreachable section key."""
+    if not isinstance(run_id, str) or not RUN_ID_RE.fullmatch(run_id):
+        return (f"results.run_id must match {RUN_ID_RE.pattern} "
+                f"(recommended: the cycle's HH:MM:SS start time), "
+                f"got: {run_id!r}")
+    if CLOCK_RE.fullmatch(run_id):
+        fmt = "%H:%M:%S" if run_id.count(":") == 2 else "%H:%M"
+        try:
+            datetime.strptime(run_id, fmt)
+        except ValueError:
+            return f"results.run_id looks like a clock time but is not one: {run_id!r}"
+    return None
+
+
+@contextlib.contextmanager
+def digest_lock(digest_path):
+    """Exclusive flock on `<digest>.lock` around the whole read-modify-write.
+
+    The (date, run_id) key stops two same-day runs from OVERWRITING each other's
+    section, but not from interleaving: both read the same body, both write, and
+    the loser's section vanishes. The lock file is separate from the digest so
+    the truncating write below can never drop it, and it covers the sidecar too
+    — a sibling must never observe digest and index half-updated."""
+    lock_path = digest_path + ".lock"
+    os.makedirs(os.path.dirname(lock_path) or ".", exist_ok=True)
+    fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o644)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        yield
+    finally:
+        try:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+        finally:
+            os.close(fd)
+
+
 def cell(value):
     """Escape a markdown table cell; em-dash for absent values."""
     if value is None or value == "":
@@ -95,7 +161,7 @@ def render_section(results):
         counts[s.get("status", "failed")] = counts.get(s.get("status", "failed"), 0) + 1
 
     lines = [
-        f"## {results['date']}",
+        f"## {results['date']} — {results['run_id']}",
         "",
         f"Model: {results.get('model', '?')} | Scenarios: {len(scenarios)} "
         f"(ok {counts['ok']} / failed {counts['failed']} / "
@@ -147,7 +213,7 @@ def index_path_for(digest_path):
     return os.path.join(os.path.dirname(digest_path) or ".", INDEX_FILENAME)
 
 
-def build_index_lines(date, scenarios):
+def build_index_lines(date, run_id, scenarios):
     """One index object per scenario. `comment` omitted by design; `axis` /
     `scores` are absent-safe (null when the scenario has none)."""
     lines = []
@@ -161,6 +227,7 @@ def build_index_lines(date, scenarios):
             scores = {**scores, **{k: scores.get(k) for k in RUBRIC_KEYS if k not in scores}}
         lines.append({
             "date": date,
+            "run_id": run_id,
             "id": s.get("id"),
             "name": s.get("name"),
             "theme": s.get("theme"),
@@ -173,13 +240,19 @@ def build_index_lines(date, scenarios):
 
 def write_index_incremental(digest_path, results):
     """Update the sidecar from the IN-MEMORY results (not by re-parsing the
-    digest just written). Date-idempotent: drop existing same-date lines before
-    appending, mirroring the digest's section replace. Bootstraps the file if
-    absent. Fail-open: any write failure is a single non-fatal stderr warning —
-    the append (digest is already persisted) must never fail on the cache."""
+    digest just written). (date, run_id)-idempotent: drop existing lines with
+    BOTH the same date and the same run_id, mirroring the digest's section
+    replace. A pre-#1542 line has no `run_id` key, so it reads as None and can
+    never collide with a real run_id — the same survival property the digest's
+    legacy date-only headings have. Bootstraps the file if absent. Fail-open:
+    any write failure is a single non-fatal stderr warning — the append (digest
+    is already persisted) must never fail on the cache.
+
+    Caller must hold digest_lock()."""
     index_path = index_path_for(digest_path)
     date = results["date"]
-    new_lines = build_index_lines(date, results.get("scenarios", []))
+    run_id = results["run_id"]
+    new_lines = build_index_lines(date, run_id, results.get("scenarios", []))
     try:
         kept = []
         if os.path.exists(index_path):
@@ -189,7 +262,7 @@ def write_index_incremental(digest_path, results):
                     if not raw:
                         continue
                     obj = json.loads(raw)
-                    if obj.get("date") == date:
+                    if obj.get("date") == date and obj.get("run_id") == run_id:
                         continue  # replaced below
                     kept.append(obj)
         with open(index_path, "w", encoding="utf-8") as f:
@@ -227,10 +300,18 @@ def rebuild_index(digest_path):
     """Regenerate the ENTIRE sidecar by parsing the digest's markdown tables.
     Header-name-keyed column mapping (not fixed indices) so all three historical
     shapes parse — pre-axis-column, 4-axis, 5-axis. Writes nothing on any
-    unrecognized shape."""
+    unrecognized shape.
+
+    Read-and-rewrite runs under digest_lock(): a nightly append racing a manual
+    rebuild would otherwise rebuild from a half-written digest."""
     if not os.path.exists(digest_path):
         print(f"rebuild-index: digest not found: {digest_path}", file=sys.stderr)
         return 1
+    with digest_lock(digest_path):
+        return _rebuild_index_locked(digest_path)
+
+
+def _rebuild_index_locked(digest_path):
     with open(digest_path, encoding="utf-8") as f:
         digest = f.read()
     for marker in (SECTIONS_MARKER, PROMOTION_MARKER):
@@ -242,12 +323,15 @@ def rebuild_index(digest_path):
 
     all_lines = []
     section_count = 0
-    # Sections are `## YYYY-MM-DD` blocks between the two markers.
+    # Sections are `## YYYY-MM-DD — <run_id>` blocks between the two markers.
+    # The date-only form is the pre-#1542 heading: still parsed, with a null
+    # run_id that can never collide with a real one.
     for chunk in re.split(r"(?m)^## ", body):
         heading, _, rest = chunk.partition("\n")
-        date = heading.strip()
-        if not re.fullmatch(r"\d{4}-\d{2}-\d{2}", date):
+        m = re.fullmatch(r"(\d{4}-\d{2}-\d{2})(?: — (.+))?", heading.strip())
+        if not m:
             continue  # preamble / non-section text
+        date, run_id = m.group(1), m.group(2)
         section_count += 1
 
         table_lines = [l for l in rest.split("\n") if l.lstrip().startswith("|")]
@@ -298,6 +382,7 @@ def rebuild_index(digest_path):
                                           f"in column {cn!r}")
             all_lines.append({
                 "date": date,
+                "run_id": run_id,   # None for a legacy date-only heading
                 "id": field("id"),
                 "name": field("name"),
                 "theme": field("theme"),
@@ -339,7 +424,21 @@ def main():
         print(f"results.date must be YYYY-MM-DD, got: {results.get('date')!r}",
               file=sys.stderr)
         return 1
+    run_id_err = validate_run_id(results.get("run_id"))
+    if run_id_err:
+        # The digest is the only durable record of a night's judging, so an
+        # unattended run that trips this must be recoverable by hand — name the
+        # file the operator has to edit and what to do to it.
+        print(f"append_digest: {run_id_err}", file=sys.stderr)
+        print(f"  add a `run_id` to {args.results} and re-run the append",
+              file=sys.stderr)
+        return 1
 
+    with digest_lock(args.digest):
+        return _append_locked(args, results)
+
+
+def _append_locked(args, results):
     if not os.path.exists(args.digest):
         # Local-log model: the digest is gitignored, so a clean clone or
         # the very first run has no file. Bootstrap the scaffold.
@@ -360,15 +459,18 @@ def main():
     head, _, tail = digest.partition(SECTIONS_MARKER)
     body, _, footer = tail.partition(PROMOTION_MARKER)
 
-    # Date idempotency: drop an existing same-date section (everything from
-    # its `## <date>` heading up to the next `## ` heading or body end).
+    # (date, run_id) idempotency: drop an existing section with the SAME key
+    # (everything from its `## <date> — <run_id>` heading up to the next `## `
+    # heading or body end). A legacy date-only `## <date>` heading cannot match
+    # this pattern, which is what keeps pre-#1542 sections alive.
     pattern = re.compile(
-        rf"^## {re.escape(results['date'])}\n.*?(?=^## |\Z)",
+        rf"^## {re.escape(results['date'])} — {re.escape(results['run_id'])}\n"
+        r".*?(?=^## |\Z)",
         re.DOTALL | re.MULTILINE)
     body, replaced = pattern.subn("", body)
     if replaced:
-        print(f"warning: replaced existing section for {results['date']}",
-              file=sys.stderr)
+        print(f"warning: replaced existing section for {results['date']} "
+              f"— {results['run_id']}", file=sys.stderr)
 
     section = render_section(results)
     body = "\n\n" + section + "\n" + body.strip("\n") + ("\n\n" if body.strip("\n") else "\n")
@@ -381,7 +483,7 @@ def main():
     write_index_incremental(args.digest, results)
 
     action = "replaced" if replaced else "appended"
-    print(f"{action} section {results['date']} "
+    print(f"{action} section {results['date']} — {results['run_id']} "
           f"({len(results.get('scenarios', []))} scenario(s)) in {args.digest}")
     return 0
 

--- a/.claude/skills/scenario-factory/scripts/append_digest.py
+++ b/.claude/skills/scenario-factory/scripts/append_digest.py
@@ -1,6 +1,13 @@
 #!/usr/bin/env python3
 """Append one factory-cycle section to the local digest, (date, run_id)-idempotently.
 
+This is the ROOT of a four-script fork family sharing this marker /
+same-key-idempotency / bootstrap / flock core: forked by
+`.claude/skills/scenario-refine/scripts/append_audit.py`,
+`.claude/skills/model-eval/scripts/append_eval.py` and
+`.claude/skills/queue-consumer/scripts/append_digest.py`. A real fix to that
+shared core is swept across all four.
+
 usage: append_digest.py --results <results.json> --digest <digest.md>
          (results.json must carry `run_id` — the section key is (date, run_id))
        append_digest.py --digest <digest.md> --rebuild-index
@@ -332,6 +339,13 @@ def _rebuild_index_locked(digest_path):
         if not m:
             continue  # preamble / non-section text
         date, run_id = m.group(1), m.group(2)
+        # A suffix is held to the same shape the append path enforces, so a
+        # hand-edited heading (`## <date> — rerun after the OOM`) cannot enter
+        # the index as a run_id. Rebuild is a recovery operation: it hard-fails
+        # rather than fail-open into a silently wrong index.
+        if run_id is not None and validate_run_id(run_id):
+            _rebuild_fail(date, heading.strip(),
+                          f"heading suffix is not a valid run_id: {run_id!r}")
         section_count += 1
 
         table_lines = [l for l in rest.split("\n") if l.lstrip().startswith("|")]

--- a/.claude/skills/scenario-factory/tests/fixtures/results_sample.json
+++ b/.claude/skills/scenario-factory/tests/fixtures/results_sample.json
@@ -1,5 +1,6 @@
 {
   "date": "2026-06-13",
+  "run_id": "01:23:45",
   "model": "gemma-4-E2B-it-Q4_K_M",
   "notes": "fixture cycle for append_digest tests",
   "scenarios": [

--- a/.claude/skills/scenario-factory/tests/run_tests.sh
+++ b/.claude/skills/scenario-factory/tests/run_tests.sh
@@ -50,7 +50,7 @@ echo "$T" | grep -q "1 unparseable line" || fail "transcript: truncated line not
 cp fixtures/digest_seed.md "$TMP/digest.md"
 python3 "$SCRIPTS/append_digest.py" \
   --results fixtures/results_sample.json --digest "$TMP/digest.md" >/dev/null
-grep -q "^## 2026-06-13$" "$TMP/digest.md" || fail "digest: section heading missing"
+grep -q "^## 2026-06-13 — 01:23:45$" "$TMP/digest.md" || fail "digest: section heading missing"
 grep -q "factory_20260613_test_ok" "$TMP/digest.md" || fail "digest: ok row missing"
 grep -q '設定は一貫、ボケの幅 \\| は狭め' "$TMP/digest.md" || fail "digest: pipe not escaped in comment"
 grep -q 'elimination / creative' "$TMP/digest.md" || fail "digest: axis column not rendered"
@@ -63,10 +63,10 @@ grep -q '| 1 | 2 | 3 | 4 | – |' "$TMP/digest.md" || fail "digest: null develop
 grep -q "factory-digest:promotion" "$TMP/digest.md" || fail "digest: promotion marker lost"
 tail -1 "$TMP/digest.md" | grep -q "^Promotion:" || fail "digest: promotion line no longer last"
 
-# date idempotency: re-append replaces, never duplicates
+# (date, run_id) idempotency: re-append replaces, never duplicates
 python3 "$SCRIPTS/append_digest.py" \
   --results fixtures/results_sample.json --digest "$TMP/digest.md" >/dev/null 2>"$TMP/warn"
-COUNT=$(grep -c "^## 2026-06-13$" "$TMP/digest.md")
+COUNT=$(grep -c "^## 2026-06-13 — 01:23:45$" "$TMP/digest.md")
 [ "$COUNT" -eq 1 ] || fail "digest: re-append duplicated the section ($COUNT)"
 grep -q "warning: replaced" "$TMP/warn" || fail "digest: replace warning missing"
 
@@ -83,7 +83,7 @@ python3 "$SCRIPTS/append_digest.py" \
   || fail "digest: absent file should bootstrap, not error"
 grep -q "factory-digest:sections" "$TMP/bootstrap.md" || fail "bootstrap: sections marker missing"
 grep -q "factory-digest:promotion" "$TMP/bootstrap.md" || fail "bootstrap: promotion marker missing"
-grep -q "^## 2026-06-13$" "$TMP/bootstrap.md" || fail "bootstrap: section not appended"
+grep -q "^## 2026-06-13 — 01:23:45$" "$TMP/bootstrap.md" || fail "bootstrap: section not appended"
 tail -1 "$TMP/bootstrap.md" | grep -q "^Promotion:" || fail "bootstrap: promotion line not last"
 
 # --- append_digest.py: sidecar index ----------------------------------------
@@ -140,7 +140,7 @@ echo '{not json' > "$CI/digest-index.jsonl"
 python3 "$SCRIPTS/append_digest.py" \
   --results fixtures/results_sample.json --digest "$CI/digest.md" >/dev/null 2>"$CI/warn" \
   || fail "index: corrupt existing index line must not fail the append"
-grep -q "^## 2026-06-13$" "$CI/digest.md" || fail "index: digest not updated on corrupt index line"
+grep -q "^## 2026-06-13 — 01:23:45$" "$CI/digest.md" || fail "index: digest not updated on corrupt index line"
 grep -q -- "--rebuild-index" "$CI/warn" || fail "index: corrupt-line warning must name --rebuild-index"
 
 # round-trip: --rebuild-index off the produced digest == the incremental index
@@ -208,8 +208,140 @@ mkdir "$UW/digest-index.jsonl"   # a directory can't be overwritten by a file
 python3 "$SCRIPTS/append_digest.py" \
   --results fixtures/results_sample.json --digest "$UW/digest.md" >/dev/null 2>"$UW/warn" \
   || fail "index: unwritable index must not fail the append"
-grep -q "^## 2026-06-13$" "$UW/digest.md" || fail "index: digest not updated when index write fails"
+grep -q "^## 2026-06-13 — 01:23:45$" "$UW/digest.md" || fail "index: digest not updated when index write fails"
 grep -q -- "--rebuild-index" "$UW/warn" || fail "index: failure warning must name --rebuild-index"
+
+# --- append_digest.py: (date, run_id) section key (#1542) --------------------
+# Two /scenario-factory cycles can share a date in the same main checkout
+# (a re-run after a fix, a second nightly pass). Before #1542 the second
+# append silently wiped the first run's judging record — the digest is the
+# only durable one — so these cases pin the compound key.
+RK="$TMP/runkey"; mkdir -p "$RK"
+cp fixtures/digest_seed.md "$RK/digest.md"
+jq '.run_id = "02:34:56"
+    | .scenarios = [.scenarios[0]]
+    | .scenarios[0].id = "factory_20260613_second_run"' \
+  fixtures/results_sample.json > "$RK/results_run2.json"
+
+# (a) REGRESSION TEST FOR #1542: same date, different run_ids → both survive.
+python3 "$SCRIPTS/append_digest.py" \
+  --results fixtures/results_sample.json --digest "$RK/digest.md" >/dev/null
+python3 "$SCRIPTS/append_digest.py" \
+  --results "$RK/results_run2.json" --digest "$RK/digest.md" >/dev/null
+grep -q "^## 2026-06-13 — 01:23:45$" "$RK/digest.md" \
+  || fail "runkey: first run's section wiped by a same-date second run (#1542)"
+grep -q "^## 2026-06-13 — 02:34:56$" "$RK/digest.md" \
+  || fail "runkey: second run's section missing"
+grep -q "factory_20260613_test_ok" "$RK/digest.md" || fail "runkey: run-1 rows lost"
+grep -q "factory_20260613_second_run" "$RK/digest.md" || fail "runkey: run-2 rows lost"
+RKIDX="$RK/digest-index.jsonl"
+[ "$(jq -es 'map(select(.run_id=="01:23:45")) | length' "$RKIDX")" -eq 3 ] \
+  || fail "runkey: run-1 index lines lost (#1542)"
+[ "$(jq -es 'map(select(.run_id=="02:34:56")) | length' "$RKIDX")" -eq 1 ] \
+  || fail "runkey: run-2 index line missing"
+
+# (b) re-appending the SAME (date, run_id) replaces only that section
+python3 "$SCRIPTS/append_digest.py" \
+  --results "$RK/results_run2.json" --digest "$RK/digest.md" >/dev/null 2>"$RK/warn"
+grep -q "warning: replaced" "$RK/warn" || fail "runkey: replace warning missing"
+[ "$(grep -c "^## 2026-06-13 — 02:34:56$" "$RK/digest.md")" -eq 1 ] \
+  || fail "runkey: same-key re-append duplicated the section"
+[ "$(grep -c "^## 2026-06-13 — 01:23:45$" "$RK/digest.md")" -eq 1 ] \
+  || fail "runkey: sibling run's section disturbed by a same-key re-append"
+[ "$(jq -es 'map(select(.run_id=="01:23:45")) | length' "$RKIDX")" -eq 3 ] \
+  || fail "runkey: sibling run's index lines disturbed by a same-key re-append"
+[ "$(jq -es 'map(select(.run_id=="02:34:56")) | length' "$RKIDX")" -eq 1 ] \
+  || fail "runkey: same-key re-append duplicated index lines"
+
+# (c) run_id is REQUIRED and shape-checked; a rejected results JSON must leave
+# the digest byte-identical (an unattended run has to be recoverable by hand).
+RV="$TMP/runid_valid"; mkdir -p "$RV"
+cp "$RK/digest.md" "$RV/digest.md"
+cp "$RV/digest.md" "$RV/digest.before"
+jq 'del(.run_id)' fixtures/results_sample.json > "$RV/no_run_id.json"
+if python3 "$SCRIPTS/append_digest.py" \
+  --results "$RV/no_run_id.json" --digest "$RV/digest.md" 2>"$RV/err"; then
+  fail "runid: missing run_id should be a hard error"
+fi
+grep -q "run_id" "$RV/err" || fail "runid: error message must name run_id"
+grep -q "no_run_id.json" "$RV/err" || fail "runid: error message must name the results path"
+cmp -s "$RV/digest.before" "$RV/digest.md" || fail "runid: digest touched by a rejected append"
+# 99:99 has the right shape but is not a real clock time
+jq '.run_id = "99:99"' fixtures/results_sample.json > "$RV/bad_clock.json"
+if python3 "$SCRIPTS/append_digest.py" \
+  --results "$RV/bad_clock.json" --digest "$RV/digest.md" 2>/dev/null; then
+  fail "runid: 99:99 should be rejected as a non-clock run_id"
+fi
+cmp -s "$RV/digest.before" "$RV/digest.md" || fail "runid: digest touched by an invalid run_id"
+
+# (d) --rebuild-index over a digest holding BOTH a legacy date-only section
+# and new run_id-suffixed ones: legacy lines carry run_id null (they predate
+# the key change and must never collide with a real run_id).
+LG="$TMP/legacy"; mkdir -p "$LG"
+cat > "$LG/digest.md" <<'EOF'
+# Digest
+<!-- factory-digest:sections -->
+
+## 2026-06-14 — 02:00:00
+
+| id | name | theme | axis | status | (a) coherence | (b) interaction | (c) breakdown-free | (d) humor | (e) development | comment |
+|---|---|---|---|---|---|---|---|---|---|---|
+| new_b | 新 | t | – | ok | 4 | 3 | 5 | 2 | 3 | c |
+
+## 2026-06-14 — 01:00:00
+
+| id | name | theme | axis | status | (a) coherence | (b) interaction | (c) breakdown-free | (d) humor | (e) development | comment |
+|---|---|---|---|---|---|---|---|---|---|---|
+| new_a | 新 | t | – | ok | 4 | 3 | 5 | 2 | 3 | c |
+
+## 2026-06-13
+
+| id | name | theme | axis | status | (a) coherence | (b) interaction | (c) breakdown-free | (d) humor | (e) development | comment |
+|---|---|---|---|---|---|---|---|---|---|---|
+| old_a | 旧 | t | – | ok | 1 | 2 | 3 | 4 | – | c |
+
+<!-- factory-digest:promotion -->
+Promotion: x
+EOF
+python3 "$SCRIPTS/append_digest.py" \
+  --digest "$LG/digest.md" --rebuild-index >/dev/null || fail "legacy: rebuild failed"
+LGIDX="$LG/digest-index.jsonl"
+[ "$(grep -c . "$LGIDX")" -eq 3 ] \
+  || fail "legacy: expected 3 lines, got $(grep -c . "$LGIDX")"
+jq -es 'map(select(.id=="old_a"))[0].run_id == null' "$LGIDX" >/dev/null \
+  || fail "legacy: date-only section should rebuild with run_id null"
+jq -es 'map(select(.id=="new_a"))[0].run_id == "01:00:00"' "$LGIDX" >/dev/null \
+  || fail "legacy: suffixed section run_id not parsed"
+jq -es 'map(select(.id=="new_b"))[0].run_id == "02:00:00"' "$LGIDX" >/dev/null \
+  || fail "legacy: second suffixed section not parsed"
+
+# (e) the append really takes an exclusive flock on <digest>.lock — the
+# compound key alone does not stop a concurrent read-modify-write from losing
+# a whole section. A helper holds the lock while an append is launched.
+LK="$TMP/lock"; mkdir -p "$LK"
+cp fixtures/digest_seed.md "$LK/digest.md"
+python3 - "$LK/digest.md.lock" <<'PY' &
+import fcntl, os, sys, time
+fd = os.open(sys.argv[1], os.O_CREAT | os.O_RDWR, 0o644)
+fcntl.flock(fd, fcntl.LOCK_EX)
+time.sleep(4)
+fcntl.flock(fd, fcntl.LOCK_UN)
+os.close(fd)
+PY
+HOLDER_PID=$!
+sleep 1   # generous margin: let the helper acquire before the append starts
+python3 "$SCRIPTS/append_digest.py" \
+  --results fixtures/results_sample.json --digest "$LK/digest.md" >/dev/null 2>&1 &
+APPEND_PID=$!
+sleep 1
+grep -q "^## 2026-06-13" "$LK/digest.md" \
+  && fail "lock: append wrote the digest while the lock was held"
+wait "$HOLDER_PID"
+wait "$APPEND_PID" || fail "lock: append failed after the lock was released"
+grep -q "^## 2026-06-13 — 01:23:45$" "$LK/digest.md" \
+  || fail "lock: section missing after the lock was released"
+[ "$(grep -c . "$LK/digest-index.jsonl")" -eq 3 ] \
+  || fail "lock: sidecar index not updated after the lock was released"
 
 # --- gallery_census.py ------------------------------------------------------
 C=$(python3 "$SCRIPTS/gallery_census.py" fixtures/gallery_census_sample.json)

--- a/.claude/skills/scenario-factory/tests/run_tests.sh
+++ b/.claude/skills/scenario-factory/tests/run_tests.sh
@@ -335,6 +335,18 @@ jq -es 'map(select(.id=="new_a"))[0].run_id == "01:00:00"' "$LGIDX" >/dev/null \
 jq -es 'map(select(.id=="new_b"))[0].run_id == "02:00:00"' "$LGIDX" >/dev/null \
   || fail "legacy: second suffixed section not parsed"
 
+# a hand-edited heading suffix is NOT a run_id: rebuild hard-fails rather than
+# letting free text into the index, and writes nothing.
+BH="$TMP/badheading"; mkdir -p "$BH"
+sed 's/^## 2026-06-14 — 02:00:00$/## 2026-06-14 — rerun after the OOM/' \
+  "$LG/digest.md" > "$BH/digest.md"
+if python3 "$SCRIPTS/append_digest.py" \
+  --digest "$BH/digest.md" --rebuild-index >/dev/null 2>"$BH/err"; then
+  fail "badheading: a non-run_id heading suffix should hard-fail the rebuild"
+fi
+grep -q "run_id" "$BH/err" || fail "badheading: error must name run_id"
+[ ! -f "$BH/digest-index.jsonl" ] || fail "badheading: index written despite hard-fail"
+
 # (e) the append really takes an exclusive flock on <digest>.lock — the
 # compound key alone does not stop a concurrent read-modify-write from losing
 # a whole section. A helper holds the lock while an append is launched.

--- a/.claude/skills/scenario-factory/tests/run_tests.sh
+++ b/.claude/skills/scenario-factory/tests/run_tests.sh
@@ -12,6 +12,26 @@ TMP=$(mktemp -d)
 trap 'rm -rf "$TMP"' EXIT
 
 fail() { echo "FAIL: $1" >&2; exit 1; }
+
+# Bounded poll helpers for the flock cases below. Synchronization is by
+# sentinel file / process liveness, never by a sleep margin: a cold python
+# start on a loaded CI runner outruns any fixed margin, and a margin that is
+# too short would fire the "did not write" assertion on a CORRECT
+# implementation. Every poll is capped so a hang fails loudly, not silently.
+await_file() {   # $1 = path to wait for, $2 = failure message
+  i=0
+  until [ -e "$1" ]; do
+    i=$((i + 1)); [ "$i" -le 600 ] || fail "$2 (timed out after 60s)"
+    sleep 0.1
+  done
+}
+await_pid() {    # $1 = pid to wait to become observable, $2 = failure message
+  i=0
+  until kill -0 "$1" 2>/dev/null; do
+    i=$((i + 1)); [ "$i" -le 600 ] || fail "$2 (timed out after 60s)"
+    sleep 0.1
+  done
+}
 check_status() { # <label> <jsonl> <exit_code> <expected_status>
   local got
   got=$(bash "$SCRIPTS/run_scenario.sh" --classify "$2" "$3" | jq -r '.status')
@@ -320,22 +340,34 @@ jq -es 'map(select(.id=="new_b"))[0].run_id == "02:00:00"' "$LGIDX" >/dev/null \
 # a whole section. A helper holds the lock while an append is launched.
 LK="$TMP/lock"; mkdir -p "$LK"
 cp fixtures/digest_seed.md "$LK/digest.md"
-python3 - "$LK/digest.md.lock" <<'PY' &
+# The helper takes the flock and only THEN writes a readiness sentinel; the
+# shell waits for that sentinel before launching the append, and releases the
+# helper through a second sentinel once the assertion is done — so the hold
+# always covers the polls without a guessed duration (the 60s inside is a
+# safety cap so a broken test cannot hang CI, not a schedule).
+python3 - "$LK/digest.md.lock" "$LK/held" "$LK/release" <<'PY' &
 import fcntl, os, sys, time
 fd = os.open(sys.argv[1], os.O_CREAT | os.O_RDWR, 0o644)
 fcntl.flock(fd, fcntl.LOCK_EX)
-time.sleep(4)
+open(sys.argv[2], "w").close()   # readiness sentinel: the lock is now HELD
+deadline = time.time() + 60
+while not os.path.exists(sys.argv[3]) and time.time() < deadline:
+    time.sleep(0.05)
 fcntl.flock(fd, fcntl.LOCK_UN)
 os.close(fd)
 PY
 HOLDER_PID=$!
-sleep 1   # generous margin: let the helper acquire before the append starts
+await_file "$LK/held" "lock: helper never acquired the flock"
 python3 "$SCRIPTS/append_digest.py" \
   --results fixtures/results_sample.json --digest "$LK/digest.md" >/dev/null 2>&1 &
 APPEND_PID=$!
-sleep 1
+await_pid "$APPEND_PID" "lock: the append process never came up"
+sleep 0.5   # settle: the holder keeps the lock until the release sentinel
+            # below, so a generous settle costs wall time, never a false
+            # failure — unlike the fixed margin this replaced.
 grep -q "^## 2026-06-13" "$LK/digest.md" \
   && fail "lock: append wrote the digest while the lock was held"
+: > "$LK/release"
 wait "$HOLDER_PID"
 wait "$APPEND_PID" || fail "lock: append failed after the lock was released"
 grep -q "^## 2026-06-13 — 01:23:45$" "$LK/digest.md" \

--- a/.claude/skills/scenario-factory/tests/run_tests.sh
+++ b/.claude/skills/scenario-factory/tests/run_tests.sh
@@ -9,26 +9,29 @@ set -eu
 cd "$(dirname "$0")"
 SCRIPTS=../scripts
 TMP=$(mktemp -d)
-trap 'rm -rf "$TMP"' EXIT
+HOLDER_PID=""
+# The flock cases below run a lock holder with a 60s deadline. A failing
+# assertion must not orphan it: it inherits the harness's stdout, so an
+# orphan can stall a piped CI invocation for the whole deadline.
+cleanup() { [ -n "$HOLDER_PID" ] && kill "$HOLDER_PID" 2>/dev/null; rm -rf "$TMP"; return 0; }
+trap cleanup EXIT
 
 fail() { echo "FAIL: $1" >&2; exit 1; }
 
 # Bounded poll helpers for the flock cases below. Synchronization is by
-# sentinel file / process liveness, never by a sleep margin: a cold python
-# start on a loaded CI runner outruns any fixed margin, and a margin that is
-# too short would fire the "did not write" assertion on a CORRECT
-# implementation. Every poll is capped so a hang fails loudly, not silently.
+# sentinel file: the append is launched through a wrapper that touches a
+# "started" sentinel immediately before exec'ing python, and the holder keeps
+# the lock until the release sentinel. The short settle after the started
+# sentinel IS a sleep margin, but a one-sided one — the lock is still held
+# across it, so a slow python start can only yield a false PASS, never a false
+# failure. What makes the case bite is the liveness assertion immediately
+# before the release (the append must still be running, and not defunct)
+# together with the post-release assertions. Every poll is capped so a hang
+# fails loudly, not silently.
 await_file() {   # $1 = path to wait for, $2 = failure message
-  i=0
+  local i=0
   until [ -e "$1" ]; do
-    i=$((i + 1)); [ "$i" -le 600 ] || fail "$2 (timed out after 60s)"
-    sleep 0.1
-  done
-}
-await_pid() {    # $1 = pid to wait to become observable, $2 = failure message
-  i=0
-  until kill -0 "$1" 2>/dev/null; do
-    i=$((i + 1)); [ "$i" -le 600 ] || fail "$2 (timed out after 60s)"
+    i=$((i + 1)); [ "$i" -le 600 ] || fail "$2 (timed out after ~600 polls)"
     sleep 0.1
   done
 }
@@ -340,12 +343,33 @@ jq -es 'map(select(.id=="new_b"))[0].run_id == "02:00:00"' "$LGIDX" >/dev/null \
 BH="$TMP/badheading"; mkdir -p "$BH"
 sed 's/^## 2026-06-14 — 02:00:00$/## 2026-06-14 — rerun after the OOM/' \
   "$LG/digest.md" > "$BH/digest.md"
+# Seed an EXISTING index first: "nothing was created" is the cheap half of
+# the guarantee. The regression that actually costs data is a hard-fail that
+# truncates or partially rewrites the index already on disk, so the payload
+# below must survive the failing rebuild byte-for-byte.
+printf '%s\n' '{"date":"2026-06-13","run_id":null,"id":"old_a"}' \
+              '{"date":"2026-06-14","run_id":"01:00:00","id":"new_a"}' \
+  > "$BH/digest-index.jsonl"
+cp "$BH/digest-index.jsonl" "$BH/index.before"
 if python3 "$SCRIPTS/append_digest.py" \
   --digest "$BH/digest.md" --rebuild-index >/dev/null 2>"$BH/err"; then
   fail "badheading: a non-run_id heading suffix should hard-fail the rebuild"
 fi
 grep -q "run_id" "$BH/err" || fail "badheading: error must name run_id"
-[ ! -f "$BH/digest-index.jsonl" ] || fail "badheading: index written despite hard-fail"
+# the diagnostic must point at the HEADING (not the table header, which is
+# fine here) and state the one edit that unblocks the rebuild
+grep -q "^  heading: " "$BH/err" || fail "badheading: error must point at the heading line"
+grep -q "HH:MM:SS" "$BH/err" || fail "badheading: error must state the heading remediation"
+cmp -s "$BH/index.before" "$BH/digest-index.jsonl" \
+  || fail "badheading: existing index truncated or rewritten despite hard-fail"
+# and on a digest with no index yet, the hard-fail must not create one
+BH2="$TMP/badheading_fresh"; mkdir -p "$BH2"
+cp "$BH/digest.md" "$BH2/digest.md"
+if python3 "$SCRIPTS/append_digest.py" \
+  --digest "$BH2/digest.md" --rebuild-index >/dev/null 2>&1; then
+  fail "badheading: a non-run_id heading suffix should hard-fail the rebuild"
+fi
+[ ! -f "$BH2/digest-index.jsonl" ] || fail "badheading: index written despite hard-fail"
 
 # (e) the append really takes an exclusive flock on <digest>.lock — the
 # compound key alone does not stop a concurrent read-modify-write from losing
@@ -356,31 +380,57 @@ cp fixtures/digest_seed.md "$LK/digest.md"
 # shell waits for that sentinel before launching the append, and releases the
 # helper through a second sentinel once the assertion is done — so the hold
 # always covers the polls without a guessed duration (the 60s inside is a
-# safety cap so a broken test cannot hang CI, not a schedule).
+# safety cap so a broken test cannot hang CI, not a schedule — blowing it
+# exits the helper non-zero, which the wait below turns into a FAIL).
 python3 - "$LK/digest.md.lock" "$LK/held" "$LK/release" <<'PY' &
 import fcntl, os, sys, time
 fd = os.open(sys.argv[1], os.O_CREAT | os.O_RDWR, 0o644)
 fcntl.flock(fd, fcntl.LOCK_EX)
 open(sys.argv[2], "w").close()   # readiness sentinel: the lock is now HELD
 deadline = time.time() + 60
-while not os.path.exists(sys.argv[3]) and time.time() < deadline:
+while not os.path.exists(sys.argv[3]):
+    if time.time() >= deadline:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+        os.close(fd)
+        sys.exit("lock helper: release sentinel never appeared")
     time.sleep(0.05)
 fcntl.flock(fd, fcntl.LOCK_UN)
 os.close(fd)
 PY
 HOLDER_PID=$!
 await_file "$LK/held" "lock: helper never acquired the flock"
-python3 "$SCRIPTS/append_digest.py" \
+# bash assigns $! at fork and `kill -0` also succeeds on an unreaped zombie,
+# so neither proves the append got as far as the lock. Launch it through a
+# wrapper that touches a "started" sentinel immediately before exec'ing
+# python (exec keeps $! pointing at the python process itself).
+cat > "$LK/append_wrapper.sh" <<'EOF'
+#!/bin/bash
+# $1 = "started" sentinel; the rest is the command to exec.
+started=$1; shift
+: > "$started"
+exec "$@"
+EOF
+bash "$LK/append_wrapper.sh" "$LK/started" \
+  python3 "$SCRIPTS/append_digest.py" \
   --results fixtures/results_sample.json --digest "$LK/digest.md" >/dev/null 2>&1 &
 APPEND_PID=$!
-await_pid "$APPEND_PID" "lock: the append process never came up"
-sleep 0.5   # settle: the holder keeps the lock until the release sentinel
-            # below, so a generous settle costs wall time, never a false
-            # failure — unlike the fixed margin this replaced.
+await_file "$LK/started" "lock: the append never started"
+sleep 0.5   # one-sided settle: the holder keeps the lock across it, so this
+            # can only cost wall time, never a false failure.
+# ...and the append must still be ALIVE and blocked here. An append that
+# already exited — or that never took the lock at all — would satisfy the
+# "did not write" assertion below vacuously.
+APPEND_STATE=$(ps -o state= -p "$APPEND_PID" 2>/dev/null | tr -d '[:space:]' || true)
+[ -n "$APPEND_STATE" ] \
+  || fail "lock: the append exited instead of blocking on the held lock"
+case "$APPEND_STATE" in
+  Z*) fail "lock: the append is defunct — it exited instead of blocking on the held lock" ;;
+esac
 grep -q "^## 2026-06-13" "$LK/digest.md" \
   && fail "lock: append wrote the digest while the lock was held"
 : > "$LK/release"
-wait "$HOLDER_PID"
+wait "$HOLDER_PID" || fail "lock: holder timed out waiting for the release sentinel"
+HOLDER_PID=""
 wait "$APPEND_PID" || fail "lock: append failed after the lock was released"
 grep -q "^## 2026-06-13 — 01:23:45$" "$LK/digest.md" \
   || fail "lock: section missing after the lock was released"

--- a/.claude/skills/scenario-refine/SKILL.md
+++ b/.claude/skills/scenario-refine/SKILL.md
@@ -287,18 +287,21 @@ promotion — it stays in `improvements/`. See § Promotion.
 ## Step 5 — Append the journal
 
 1. Compose the results JSON (schema in `append_audit.py`'s docstring: date /
-   model / notes / per-scenario id, name, channel, category, yaml, run_log,
-   status, attempts, duration_sec, scores {coherence, interaction,
+   **run_id** / model / notes / per-scenario id, name, channel, category, yaml,
+   run_log, status, attempts, duration_sec, scores {coherence, interaction,
    breakdown_free, development, payoff}, payoff_axis, comment, error,
-   candidate_of). Write
-   it to a temp file.
+   candidate_of). Set `run_id` to this cycle's `HH:MM:SS` start time — the
+   section key is (date, run_id), so a second cycle on the same date gets its
+   own section instead of overwriting the first (#1542). Reuse the SAME
+   `run_id` when re-appending a partially-failed cycle, so it replaces its own
+   section. Write it to a temp file.
 2. ```bash
    python3 .claude/skills/scenario-refine/scripts/append_audit.py \
      --results /tmp/refine_results_<DATE>.json \
      --journal data/factory/audit-digest.md
    ```
 3. Verify: `grep -c 'audit-digest:' data/factory/audit-digest.md` prints `2`
-   (both markers survived) and the new `## <DATE>` section exists.
+   (both markers survived) and the new `## <DATE> — <RUN_ID>` section exists.
 
 ## Step 5.5 — Propose lessons (inbox)
 

--- a/.claude/skills/scenario-refine/SKILL.md
+++ b/.claude/skills/scenario-refine/SKILL.md
@@ -64,7 +64,12 @@ Actually changing a shipped scenario is a SEPARATE, human-driven step (see
   the same date from overwriting the first (#1542). Re-reading the clock when
   re-appending a partially-failed cycle would write a SECOND section instead
   of replacing its own. Two cycles that could start within the same second
-  must not share it — suffix one (`01:23:45-b`).
+  must not share it — suffix one (`01:23:45-b`). **A resumed session has no
+  memory of it**, which is exactly the re-append case, so recover rather than
+  mint: read `run_id` back from this cycle's results JSON temp file
+  (`/tmp/refine_results_<DATE>.json`), else from the cycle's
+  `## <DATE> — <RUN_ID>` heading in `data/factory/audit-digest.md`. Only when
+  neither exists is this a genuinely new cycle — mint it with `date +%H:%M:%S`.
 - `COUNT`: scenarios to evaluate this cycle (rotation slice). Default `5`
   (≈10-15 min before A/B). Running the whole ~21-scenario inventory nightly
   would take ≈45-90 min; the rotation re-checks the oldest slice instead.

--- a/.claude/skills/scenario-refine/SKILL.md
+++ b/.claude/skills/scenario-refine/SKILL.md
@@ -58,6 +58,13 @@ Actually changing a shipped scenario is a SEPARATE, human-driven step (see
   `model` so the baseline delta keys on it — a model swap re-evaluates the
   inventory from scratch.
 - `DATE`: today as `YYYY-MM-DD`.
+- `RUN_ID`: this cycle's start time as `HH:MM:SS`, captured ONCE here and
+  reused **verbatim** in every append it makes. It is the second half of the
+  journal section key `(DATE, RUN_ID)`, which is what stops a second cycle on
+  the same date from overwriting the first (#1542). Re-reading the clock when
+  re-appending a partially-failed cycle would write a SECOND section instead
+  of replacing its own. Two cycles that could start within the same second
+  must not share it — suffix one (`01:23:45-b`).
 - `COUNT`: scenarios to evaluate this cycle (rotation slice). Default `5`
   (≈10-15 min before A/B). Running the whole ~21-scenario inventory nightly
   would take ≈45-90 min; the rotation re-checks the oldest slice instead.
@@ -290,11 +297,8 @@ promotion — it stays in `improvements/`. See § Promotion.
    **run_id** / model / notes / per-scenario id, name, channel, category, yaml,
    run_log, status, attempts, duration_sec, scores {coherence, interaction,
    breakdown_free, development, payoff}, payoff_axis, comment, error,
-   candidate_of). Set `run_id` to this cycle's `HH:MM:SS` start time — the
-   section key is (date, run_id), so a second cycle on the same date gets its
-   own section instead of overwriting the first (#1542). Reuse the SAME
-   `run_id` when re-appending a partially-failed cycle, so it replaces its own
-   section. Write it to a temp file.
+   candidate_of). Set `run_id` to the `RUN_ID` fixed in § Constants — reuse
+   that value, do not re-read the clock here. Write it to a temp file.
 2. ```bash
    python3 .claude/skills/scenario-refine/scripts/append_audit.py \
      --results /tmp/refine_results_<DATE>.json \

--- a/.claude/skills/scenario-refine/SKILL.md
+++ b/.claude/skills/scenario-refine/SKILL.md
@@ -65,11 +65,17 @@ Actually changing a shipped scenario is a SEPARATE, human-driven step (see
   re-appending a partially-failed cycle would write a SECOND section instead
   of replacing its own. Two cycles that could start within the same second
   must not share it — suffix one (`01:23:45-b`). **A resumed session has no
-  memory of it**, which is exactly the re-append case, so recover rather than
-  mint: read `run_id` back from this cycle's results JSON temp file
-  (`/tmp/refine_results_<DATE>.json`), else from the cycle's
-  `## <DATE> — <RUN_ID>` heading in `data/factory/audit-digest.md`. Only when
-  neither exists is this a genuinely new cycle — mint it with `date +%H:%M:%S`.
+  memory of it**, which is exactly the re-append case — but both places it
+  could be read back from are DATE-keyed, not run-keyed:
+  `/tmp/refine_results_<DATE>.json` is overwritten by a second same-day cycle,
+  and one date can now carry several `## <DATE> — <RUN_ID>` sections in
+  `data/factory/audit-digest.md`. Recovering a sibling's value REPLACES that
+  sibling's section; over-minting only adds a spurious one — so recover only
+  when today has exactly one candidate (one results temp file whose `run_id`
+  has no section yet, or exactly one section for `<DATE>`). When the date
+  carries more than one run_id and you cannot identify your own, mint a
+  suffixed RUN_ID (`01:23:45-b`) rather than guess. A genuinely new cycle
+  mints with `date +%H:%M:%S`.
 - `COUNT`: scenarios to evaluate this cycle (rotation slice). Default `5`
   (≈10-15 min before A/B). Running the whole ~21-scenario inventory nightly
   would take ≈45-90 min; the rotation re-checks the oldest slice instead.

--- a/.claude/skills/scenario-refine/scripts/append_audit.py
+++ b/.claude/skills/scenario-refine/scripts/append_audit.py
@@ -194,7 +194,13 @@ def prior_ok_scores(journal_text, model, exclude_date, exclude_run_id):
     "Most recent" therefore orders by (date, run_id or "") rather than date
     alone, so two runs on one date resolve deterministically to the later one.
     A legacy record has no run_id and sorts as "" — before any real run_id on
-    the same date, which is the right precedence for a pre-#1542 section.
+    the same date, which is the right precedence for a pre-#1542 section. The
+    self-baseline guarantee is therefore about post-#1542 sections only: a
+    legacy date-only section is never the one being replaced (the replace
+    pattern cannot match it), so re-running that cycle compares the new
+    section against the legacy one — Δ ≈ 0 against what is effectively itself.
+    That falls out of keeping legacy sections alive, and clears as soon as the
+    date has one run_id-keyed section.
 
     An ok record missing any of the 5 score axes is skipped as a baseline — an
     old pre-`development` record carries only 4 axes, a different total scale,

--- a/.claude/skills/scenario-refine/scripts/append_audit.py
+++ b/.claude/skills/scenario-refine/scripts/append_audit.py
@@ -2,9 +2,9 @@
 """Append one /scenario-refine audit section to the local journal.
 
 This is a FORK of `.claude/skills/scenario-factory/scripts/append_digest.py`:
-it reuses that script's 2-marker / date-idempotency / bootstrap structure but
-in its own `audit-digest:` marker namespace, and ADDS two things the factory
-digest does not need:
+it reuses that script's 2-marker / (date, run_id)-idempotency / flock /
+bootstrap structure but in its own `audit-digest:` marker namespace, and ADDS
+two things the factory digest does not need:
 
   1. A machine-readable `<!-- audit-data: {...} -->` comment per section — the
      robust source of truth for both this script's baseline delta and
@@ -19,6 +19,19 @@ scripts are expected to drift only in those respects. If the shared 2-marker
 core ever needs a real fix, fix both.
 
 usage: append_audit.py --results <results.json> --journal <audit-digest.md>
+         (results.json must carry `run_id` — the section key is (date, run_id))
+
+If a section for the same (date, run_id) already exists between the markers it
+is REPLACED (so re-running a partially-failed cycle is safe) and a warning goes
+to stderr. Two cycles sharing a date but not a run_id keep SEPARATE sections —
+before #1542 the key was the date alone and the second run of a day silently
+wiped the first run's audit record. A legacy date-only `## <date>` heading
+never matches the replace pattern, so pre-#1542 sections in an existing local
+journal survive untouched.
+
+The journal read-modify-write runs under an exclusive flock on
+`<journal>.lock`: sibling runs sharing a main checkout would otherwise
+interleave and lose a whole section regardless of key.
 
 The journal is a LOCAL log (gitignored — not committed). If absent it is
 bootstrapped from a scaffold. Promotion of a winning scenario (preset or
@@ -29,6 +42,13 @@ Results JSON schema (composed by the /scenario-refine session):
 
 {
   "date": "YYYY-MM-DD",
+  "run_id": "01:23:45",   // REQUIRED. Recommended value: the cycle's HH:MM:SS
+                          // start time — the heading already carries the date,
+                          // so only the clock part is needed to disambiguate.
+                          // Never auto-derived from the clock: a generated
+                          // default would give a re-run of a partially-failed
+                          // cycle a NEW key and duplicate its section instead
+                          // of replacing it.
   "model": "gemma-4-E2B-it-Q4_K_M",
   "notes": "optional free text",
   "scenarios": [
@@ -56,12 +76,20 @@ Results JSON schema (composed by the /scenario-refine session):
 """
 
 import argparse
+import contextlib
+import fcntl
 import json
 import os
 import re
 import sys
+from datetime import datetime
 
 SECTIONS_MARKER = "<!-- audit-digest:sections -->"
+# run_id shape: short, filesystem/markdown-safe, and heading-legible. The
+# clock-shaped subset is additionally range-checked (see validate_run_id).
+# Kept identical to append_digest.py's copy — same operator-facing contract.
+RUN_ID_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9:_-]{0,15}")
+CLOCK_RE = re.compile(r"\d{2}:\d{2}(:\d{2})?")
 PROMOTION_MARKER = "<!-- audit-digest:promotion -->"
 COMMON_AXES = ["coherence", "interaction", "breakdown_free"]
 # `development` is a UNIVERSAL axis (cross-round development / surprise), so it
@@ -94,6 +122,46 @@ Promotion: channels documented in `.claude/skills/scenario-refine/SKILL.md` § P
 """
 
 
+def validate_run_id(run_id):
+    """Return an error string, or None when `run_id` is usable as a section key.
+
+    A clock-shaped value is range-checked so a typo like `99:99` is rejected at
+    append time rather than becoming a permanent, unreachable section key."""
+    if not isinstance(run_id, str) or not RUN_ID_RE.fullmatch(run_id):
+        return (f"results.run_id must match {RUN_ID_RE.pattern} "
+                f"(recommended: the cycle's HH:MM:SS start time), "
+                f"got: {run_id!r}")
+    if CLOCK_RE.fullmatch(run_id):
+        fmt = "%H:%M:%S" if run_id.count(":") == 2 else "%H:%M"
+        try:
+            datetime.strptime(run_id, fmt)
+        except ValueError:
+            return f"results.run_id looks like a clock time but is not one: {run_id!r}"
+    return None
+
+
+@contextlib.contextmanager
+def journal_lock(journal_path):
+    """Exclusive flock on `<journal>.lock` around the whole read-modify-write.
+
+    The (date, run_id) key stops two same-day runs from OVERWRITING each other's
+    section, but not from interleaving: both read the same body, both write, and
+    the loser's section vanishes. The lock file is separate from the journal so
+    the truncating write below can never drop it. Mirrors append_digest.py's
+    digest_lock()."""
+    lock_path = journal_path + ".lock"
+    os.makedirs(os.path.dirname(lock_path) or ".", exist_ok=True)
+    fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o644)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        yield
+    finally:
+        try:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+        finally:
+            os.close(fd)
+
+
 def cell(value):
     """Escape a markdown table cell; em-dash for absent values."""
     if value is None or value == "":
@@ -110,12 +178,21 @@ def total(scores):
     return sum(scores.get(k) or 0 for k in SCORE_KEYS)
 
 
-def prior_ok_scores(journal_text, model, exclude_date):
-    """Most-recent prior ok scores per id (same model), excluding exclude_date.
+def prior_ok_scores(journal_text, model, exclude_date, exclude_run_id):
+    """Most-recent prior ok scores per id (same model), excluding one section.
 
     Reads the machine-readable audit-data comments, not the human tables.
-    Returns {id: scores_dict}. A re-run on the same date excludes that date
-    so the section being replaced never becomes its own baseline.
+    Returns {id: scores_dict}. The exclusion unit is the (date, run_id) SECTION
+    KEY, not the date: only the section this append is about to replace is
+    skipped, so it never becomes its own baseline. A sibling run earlier the
+    same date is a legitimate prior evaluation and stays one — excluding the
+    whole date (the pre-#1542 behaviour) would blank the Δ column for every
+    second run of a day.
+
+    "Most recent" therefore orders by (date, run_id or "") rather than date
+    alone, so two runs on one date resolve deterministically to the later one.
+    A legacy record has no run_id and sorts as "" — before any real run_id on
+    the same date, which is the right precedence for a pre-#1542 section.
 
     An ok record missing any of the 5 score axes is skipped as a baseline — an
     old pre-`development` record carries only 4 axes, a different total scale,
@@ -126,7 +203,7 @@ def prior_ok_scores(journal_text, model, exclude_date):
     run (rather than one line per record) so a journal full of legacy 4-axis
     entries does not flood stderr on every nightly append.
     """
-    best = {}  # id -> (date, scores)
+    best = {}  # id -> ((date, run_id), scores)
     skipped = 0
     for blob in AUDIT_DATA_RE.findall(journal_text):
         try:
@@ -136,8 +213,10 @@ def prior_ok_scores(journal_text, model, exclude_date):
         if data.get("model") != model:
             continue
         date = data.get("date", "")
-        if date == exclude_date:
+        run_id = data.get("run_id") or ""
+        if date == exclude_date and run_id == exclude_run_id:
             continue
+        key = (date, run_id)
         for sid, rec in (data.get("scenarios") or {}).items():
             if rec.get("status") != "ok":
                 continue
@@ -145,8 +224,8 @@ def prior_ok_scores(journal_text, model, exclude_date):
             if len(scores) < len(SCORE_KEYS):
                 skipped += 1
                 continue
-            if sid not in best or date > best[sid][0]:
-                best[sid] = (date, scores)
+            if sid not in best or key > best[sid][0]:
+                best[sid] = (key, scores)
     if skipped:
         # Keep the exact substring "missing score axes" — the self-test greps
         # for it.
@@ -174,8 +253,11 @@ def audit_data_comment(results):
         if s.get("candidate_of"):
             rec["candidate_of"] = s["candidate_of"]
         scenarios[sid] = rec
-    payload = {"date": results["date"], "model": results.get("model", "?"),
-               "scenarios": scenarios}
+    # `run_id` rides alongside `date` so a reader can tell two same-date runs
+    # apart. select_inventory.py reads only `date`, so the extra key is inert
+    # there — and AUDIT_DATA_RE, shared byte-for-byte with it, is unchanged.
+    payload = {"date": results["date"], "run_id": results["run_id"],
+               "model": results.get("model", "?"), "scenarios": scenarios}
     return "<!-- audit-data: " + json.dumps(payload, ensure_ascii=False,
                                             sort_keys=True) + " -->"
 
@@ -207,12 +289,12 @@ def render_section(results, journal_text):
         counts[st] = counts.get(st, 0) + 1
 
     prior = prior_ok_scores(journal_text, results.get("model", "?"),
-                            results["date"])
+                            results["date"], results["run_id"])
     this_run_ok = {s["id"]: s["scores"] for s in scenarios
                    if s.get("status") == "ok" and s.get("scores")}
 
     lines = [
-        f"## {results['date']}",
+        f"## {results['date']} — {results['run_id']}",
         "",
         f"Model: {results.get('model', '?')} | Scenarios: {len(scenarios)} "
         f"(ok {counts['ok']} / failed {counts['failed']} / "
@@ -259,7 +341,21 @@ def main():
         print(f"results.date must be YYYY-MM-DD, got: {results.get('date')!r}",
               file=sys.stderr)
         return 1
+    run_id_err = validate_run_id(results.get("run_id"))
+    if run_id_err:
+        # The journal is the only durable record of a cycle's judging, so an
+        # unattended run that trips this must be recoverable by hand — name the
+        # file the operator has to edit and what to do to it.
+        print(f"append_audit: {run_id_err}", file=sys.stderr)
+        print(f"  add a `run_id` to {args.results} and re-run the append",
+              file=sys.stderr)
+        return 1
 
+    with journal_lock(args.journal):
+        return _append_locked(args, results)
+
+
+def _append_locked(args, results):
     if not os.path.exists(args.journal):
         os.makedirs(os.path.dirname(args.journal) or ".", exist_ok=True)
         with open(args.journal, "w", encoding="utf-8") as f:
@@ -279,17 +375,21 @@ def main():
     body, _, footer = tail.partition(PROMOTION_MARKER)
 
     # Baseline delta reads PRIOR sections, so compute the section against the
-    # body with any same-date section still present (prior_ok_scores excludes
-    # the current date itself), THEN drop the old same-date section.
+    # body with any same-key section still present (prior_ok_scores excludes
+    # that one key itself), THEN drop the old same-key section.
     section = render_section(results, body)
 
+    # (date, run_id) idempotency: drop an existing section with the SAME key.
+    # A legacy date-only `## <date>` heading cannot match this pattern, which
+    # is what keeps pre-#1542 sections alive.
     pattern = re.compile(
-        rf"^## {re.escape(results['date'])}\n.*?(?=^## |\Z)",
+        rf"^## {re.escape(results['date'])} — {re.escape(results['run_id'])}\n"
+        r".*?(?=^## |\Z)",
         re.DOTALL | re.MULTILINE)
     body, replaced = pattern.subn("", body)
     if replaced:
-        print(f"warning: replaced existing section for {results['date']}",
-              file=sys.stderr)
+        print(f"warning: replaced existing section for {results['date']} "
+              f"— {results['run_id']}", file=sys.stderr)
 
     stripped = body.strip("\n")
     body = "\n\n" + section + "\n" + stripped + ("\n\n" if stripped else "\n")
@@ -298,7 +398,7 @@ def main():
         f.write(head + SECTIONS_MARKER + body + PROMOTION_MARKER + footer)
 
     action = "replaced" if replaced else "appended"
-    print(f"{action} section {results['date']} "
+    print(f"{action} section {results['date']} — {results['run_id']} "
           f"({len(results.get('scenarios', []))} scenario(s)) in {args.journal}")
     return 0
 

--- a/.claude/skills/scenario-refine/scripts/append_audit.py
+++ b/.claude/skills/scenario-refine/scripts/append_audit.py
@@ -15,8 +15,10 @@ two things the factory digest does not need:
      A/B improvement candidate — vs its baseline in the SAME run.
 
 The fork is deliberate (different marker namespace, extra columns); the two
-scripts are expected to drift only in those respects. If the shared 2-marker
-core ever needs a real fix, fix both.
+scripts are expected to drift only in those respects. The family is FOUR
+scripts, all now carrying the flock (#1542): factory's append_digest.py, this
+file, model-eval's append_eval.py, and queue-consumer's append_digest.py. If
+the shared core ever needs a real fix, sweep all four.
 
 usage: append_audit.py --results <results.json> --journal <audit-digest.md>
          (results.json must carry `run_id` — the section key is (date, run_id))

--- a/.claude/skills/scenario-refine/tests/fixtures/results_sample.json
+++ b/.claude/skills/scenario-refine/tests/fixtures/results_sample.json
@@ -1,5 +1,6 @@
 {
   "date": "2026-06-21",
+  "run_id": "01:00:00",
   "model": "gemma-4-E2B-it-Q4_K_M",
   "notes": "self-test fixture",
   "scenarios": [

--- a/.claude/skills/scenario-refine/tests/run_tests.sh
+++ b/.claude/skills/scenario-refine/tests/run_tests.sh
@@ -14,6 +14,26 @@ trap 'rm -rf "$TMP"' EXIT
 
 fail() { echo "FAIL: $1" >&2; exit 1; }
 
+# Bounded poll helpers for the flock cases below. Synchronization is by
+# sentinel file / process liveness, never by a sleep margin: a cold python
+# start on a loaded CI runner outruns any fixed margin, and a margin that is
+# too short would fire the "did not write" assertion on a CORRECT
+# implementation. Every poll is capped so a hang fails loudly, not silently.
+await_file() {   # $1 = path to wait for, $2 = failure message
+  i=0
+  until [ -e "$1" ]; do
+    i=$((i + 1)); [ "$i" -le 600 ] || fail "$2 (timed out after 60s)"
+    sleep 0.1
+  done
+}
+await_pid() {    # $1 = pid to wait to become observable, $2 = failure message
+  i=0
+  until kill -0 "$1" 2>/dev/null; do
+    i=$((i + 1)); [ "$i" -le 600 ] || fail "$2 (timed out after 60s)"
+    sleep 0.1
+  done
+}
+
 sel() { # run select_inventory.py against the fixture inventory
   python3 "$SCRIPTS/select_inventory.py" \
     --presets-dir "$INV/presets" \
@@ -84,9 +104,19 @@ python3 "$SCRIPTS/append_audit.py" \
   --results fixtures/results_sample.json --journal "$TMP/journal.md" >/dev/null
 grep -q "^## 2026-06-21 — 01:00:00$" "$TMP/journal.md" || fail "audit: section heading missing"
 
+# The Δ cell is field 11 when the row is split on " | " (the development
+# column shifted it from 10 to 11); its first token is the signed delta, any
+# ⚠️ / ✅ flag follows. Always compare that token for EQUALITY — a bare
+# `grep -- "+1"` also matches +10, a raw score column, or a comment.
+# NR==1: a whole-journal grep returns one row per section, newest first, and
+# these assertions are about the section just appended.
+delta_of() { echo "$1" | awk -F' \\| ' 'NR==1 {print $11}' | awk '{print $1}'; }
+
 # regression: word_wolf prior total 16 (2026-06-20) → new 12 → Δ-4, flagged ⚠️
 WW_ROW=$(grep '^| word_wolf ' "$TMP/journal.md")
-echo "$WW_ROW" | grep -q -- "-4" || fail "audit: word_wolf regression delta -4 missing"
+WW_DELTA=$(delta_of "$WW_ROW")
+[ "$WW_DELTA" = "-4" ] \
+  || fail "audit: word_wolf regression delta must be exactly -4, got '$WW_DELTA'"
 echo "$WW_ROW" | grep -q "⚠️" || fail "audit: regression ⚠️ flag missing"
 
 # A/B candidate: bokete__v2 total 20 vs same-run baseline bokete 18 → vs base +2
@@ -144,8 +174,9 @@ COUNT=$(grep -c "^## 2026-06-21 — 01:00:00$" "$TMP/journal.md")
 grep -q "warning: replaced" "$TMP/warn" || fail "audit: replace warning missing"
 # re-running the same (date, run_id) must NOT use the replaced section as its
 # own baseline — word_wolf still compares to 2026-06-20, so Δ stays -4 (not 0).
-grep '^| word_wolf ' "$TMP/journal.md" | grep -q -- "-4" \
-  || fail "audit: same-key re-run must not self-baseline (Δ should stay -4)"
+RERUN_DELTA=$(delta_of "$(grep '^| word_wolf ' "$TMP/journal.md")")
+[ "$RERUN_DELTA" = "-4" ] \
+  || fail "audit: same-key re-run must not self-baseline (Δ should stay -4, got '$RERUN_DELTA')"
 
 # --- append_audit.py: markers + bootstrap ----------------------------------
 echo "# broken" > "$TMP/broken.md"
@@ -270,9 +301,9 @@ ww_row_of() { # $1 = run_id: the word_wolf row inside that run's section
     '$0 == h {inside=1; next} /^## / {inside=0} inside' "$RK/journal.md" \
     | grep '^| word_wolf '
 }
-RK_WW=$(ww_row_of "02:00:00")
-echo "$RK_WW" | grep -q -- "+1" \
-  || fail "runkey: same-date sibling run must stay available as a Δ baseline, got '$RK_WW'"
+RK_WW=$(delta_of "$(ww_row_of "02:00:00")")
+[ "$RK_WW" = "+1" ] \
+  || fail "runkey: same-date sibling run must stay available as a Δ baseline (expected +1, got '$RK_WW')"
 
 # (b) re-appending the SAME (date, run_id) replaces only that section, and
 # still excludes itself from its own baseline (Δ stays +1, never 0).
@@ -283,9 +314,9 @@ grep -q "warning: replaced" "$RK/warn" || fail "runkey: replace warning missing"
   || fail "runkey: same-key re-append duplicated the section"
 [ "$(grep -c "^## 2026-06-21 — 01:00:00$" "$RK/journal.md")" -eq 1 ] \
   || fail "runkey: sibling run's section disturbed by a same-key re-append"
-RK_WW2=$(ww_row_of "02:00:00")
-echo "$RK_WW2" | grep -q -- "+1" \
-  || fail "runkey: same-key re-append must not self-baseline, got '$RK_WW2'"
+RK_WW2=$(delta_of "$(ww_row_of "02:00:00")")
+[ "$RK_WW2" = "+1" ] \
+  || fail "runkey: same-key re-append must not self-baseline (expected +1, got '$RK_WW2')"
 
 # the newest of two same-date siblings wins the "most recent prior" pick, so a
 # third run resolves deterministically against run 2 (17) → Δ 0, not run 1.
@@ -293,9 +324,9 @@ jq '.run_id = "03:00:00" | .scenarios[0].scores.coherence = 4' \
   fixtures/results_sample.json > "$RK/results_run3.json"
 python3 "$SCRIPTS/append_audit.py" \
   --results "$RK/results_run3.json" --journal "$RK/journal.md" >/dev/null
-RK_WW3=$(ww_row_of "03:00:00")
-echo "$RK_WW3" | grep -q -- "+0" \
-  || fail "runkey: baseline pick must order by (date, run_id), got '$RK_WW3'"
+RK_WW3=$(delta_of "$(ww_row_of "03:00:00")")
+[ "$RK_WW3" = "+0" ] \
+  || fail "runkey: baseline pick must order by (date, run_id) (expected +0, got '$RK_WW3')"
 
 # a legacy date-only heading in an existing local journal survives untouched
 LG="$TMP/legacy"; mkdir -p "$LG"
@@ -335,22 +366,34 @@ cmp -s "$RV/journal.before" "$RV/journal.md" || fail "runid: journal touched by 
 # a whole section. A helper holds the lock while an append is launched.
 LK="$TMP/lock"; mkdir -p "$LK"
 cp fixtures/journal_seed.md "$LK/journal.md"
-python3 - "$LK/journal.md.lock" <<'PY' &
+# The helper takes the flock and only THEN writes a readiness sentinel; the
+# shell waits for that sentinel before launching the append, and releases the
+# helper through a second sentinel once the assertion is done — so the hold
+# always covers the polls without a guessed duration (the 60s inside is a
+# safety cap so a broken test cannot hang CI, not a schedule).
+python3 - "$LK/journal.md.lock" "$LK/held" "$LK/release" <<'PY' &
 import fcntl, os, sys, time
 fd = os.open(sys.argv[1], os.O_CREAT | os.O_RDWR, 0o644)
 fcntl.flock(fd, fcntl.LOCK_EX)
-time.sleep(4)
+open(sys.argv[2], "w").close()   # readiness sentinel: the lock is now HELD
+deadline = time.time() + 60
+while not os.path.exists(sys.argv[3]) and time.time() < deadline:
+    time.sleep(0.05)
 fcntl.flock(fd, fcntl.LOCK_UN)
 os.close(fd)
 PY
 HOLDER_PID=$!
-sleep 1   # generous margin: let the helper acquire before the append starts
+await_file "$LK/held" "lock: helper never acquired the flock"
 python3 "$SCRIPTS/append_audit.py" \
   --results fixtures/results_sample.json --journal "$LK/journal.md" >/dev/null 2>&1 &
 APPEND_PID=$!
-sleep 1
+await_pid "$APPEND_PID" "lock: the append process never came up"
+sleep 0.5   # settle: the holder keeps the lock until the release sentinel
+            # below, so a generous settle costs wall time, never a false
+            # failure — unlike the fixed margin this replaced.
 grep -q "^## 2026-06-21" "$LK/journal.md" \
   && fail "lock: append wrote the journal while the lock was held"
+: > "$LK/release"
 wait "$HOLDER_PID"
 wait "$APPEND_PID" || fail "lock: append failed after the lock was released"
 grep -q "^## 2026-06-21 — 01:00:00$" "$LK/journal.md" \

--- a/.claude/skills/scenario-refine/tests/run_tests.sh
+++ b/.claude/skills/scenario-refine/tests/run_tests.sh
@@ -10,26 +10,29 @@ cd "$(dirname "$0")"
 SCRIPTS=../scripts
 INV=fixtures/inv
 TMP=$(mktemp -d)
-trap 'rm -rf "$TMP"' EXIT
+HOLDER_PID=""
+# The flock cases below run a lock holder with a 60s deadline. A failing
+# assertion must not orphan it: it inherits the harness's stdout, so an
+# orphan can stall a piped CI invocation for the whole deadline.
+cleanup() { [ -n "$HOLDER_PID" ] && kill "$HOLDER_PID" 2>/dev/null; rm -rf "$TMP"; return 0; }
+trap cleanup EXIT
 
 fail() { echo "FAIL: $1" >&2; exit 1; }
 
 # Bounded poll helpers for the flock cases below. Synchronization is by
-# sentinel file / process liveness, never by a sleep margin: a cold python
-# start on a loaded CI runner outruns any fixed margin, and a margin that is
-# too short would fire the "did not write" assertion on a CORRECT
-# implementation. Every poll is capped so a hang fails loudly, not silently.
+# sentinel file: the append is launched through a wrapper that touches a
+# "started" sentinel immediately before exec'ing python, and the holder keeps
+# the lock until the release sentinel. The short settle after the started
+# sentinel IS a sleep margin, but a one-sided one — the lock is still held
+# across it, so a slow python start can only yield a false PASS, never a false
+# failure. What makes the case bite is the liveness assertion immediately
+# before the release (the append must still be running, and not defunct)
+# together with the post-release assertions. Every poll is capped so a hang
+# fails loudly, not silently.
 await_file() {   # $1 = path to wait for, $2 = failure message
-  i=0
+  local i=0
   until [ -e "$1" ]; do
-    i=$((i + 1)); [ "$i" -le 600 ] || fail "$2 (timed out after 60s)"
-    sleep 0.1
-  done
-}
-await_pid() {    # $1 = pid to wait to become observable, $2 = failure message
-  i=0
-  until kill -0 "$1" 2>/dev/null; do
-    i=$((i + 1)); [ "$i" -le 600 ] || fail "$2 (timed out after 60s)"
+    i=$((i + 1)); [ "$i" -le 600 ] || fail "$2 (timed out after ~600 polls)"
     sleep 0.1
   done
 }
@@ -111,6 +114,11 @@ grep -q "^## 2026-06-21 — 01:00:00$" "$TMP/journal.md" || fail "audit: section
 # NR==1: a whole-journal grep returns one row per section, newest first, and
 # these assertions are about the section just appended.
 delta_of() { echo "$1" | awk -F' \\| ' 'NR==1 {print $11}' | awk '{print $1}'; }
+# Whole-cell variant, for a Δ whose text is multi-token and so has no single
+# "delta token" to isolate: "vs base +2 ✅" (A/B candidate) as well as
+# "-4 ⚠️" (regression). Same reason as above — `grep -q "vs base +2"` also
+# matches "vs base +20", and a Δ against a 25-point total can reach ±20.
+delta_cell() { echo "$1" | awk -F' \\| ' 'NR==1 {print $11}'; }
 
 # regression: word_wolf prior total 16 (2026-06-20) → new 12 → Δ-4, flagged ⚠️
 WW_ROW=$(grep '^| word_wolf ' "$TMP/journal.md")
@@ -121,7 +129,9 @@ echo "$WW_ROW" | grep -q "⚠️" || fail "audit: regression ⚠️ flag missing
 
 # A/B candidate: bokete__v2 total 20 vs same-run baseline bokete 18 → vs base +2
 CAND_ROW=$(grep '^| bokete__v2 ' "$TMP/journal.md")
-echo "$CAND_ROW" | grep -q "vs base +2" || fail "audit: A/B delta 'vs base +2' missing"
+CAND_DELTA=$(delta_cell "$CAND_ROW")
+[ "$CAND_DELTA" = "vs base +2 ✅" ] \
+  || fail "audit: A/B delta cell must be exactly 'vs base +2 ✅', got '$CAND_DELTA'"
 echo "$CAND_ROW" | grep -q "✅" || fail "audit: A/B win ✅ missing"
 
 # bokete itself has no prior baseline → Δ em-dash, not a number. Field 11
@@ -370,31 +380,57 @@ cp fixtures/journal_seed.md "$LK/journal.md"
 # shell waits for that sentinel before launching the append, and releases the
 # helper through a second sentinel once the assertion is done — so the hold
 # always covers the polls without a guessed duration (the 60s inside is a
-# safety cap so a broken test cannot hang CI, not a schedule).
+# safety cap so a broken test cannot hang CI, not a schedule — blowing it
+# exits the helper non-zero, which the wait below turns into a FAIL).
 python3 - "$LK/journal.md.lock" "$LK/held" "$LK/release" <<'PY' &
 import fcntl, os, sys, time
 fd = os.open(sys.argv[1], os.O_CREAT | os.O_RDWR, 0o644)
 fcntl.flock(fd, fcntl.LOCK_EX)
 open(sys.argv[2], "w").close()   # readiness sentinel: the lock is now HELD
 deadline = time.time() + 60
-while not os.path.exists(sys.argv[3]) and time.time() < deadline:
+while not os.path.exists(sys.argv[3]):
+    if time.time() >= deadline:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+        os.close(fd)
+        sys.exit("lock helper: release sentinel never appeared")
     time.sleep(0.05)
 fcntl.flock(fd, fcntl.LOCK_UN)
 os.close(fd)
 PY
 HOLDER_PID=$!
 await_file "$LK/held" "lock: helper never acquired the flock"
-python3 "$SCRIPTS/append_audit.py" \
+# bash assigns $! at fork and `kill -0` also succeeds on an unreaped zombie,
+# so neither proves the append got as far as the lock. Launch it through a
+# wrapper that touches a "started" sentinel immediately before exec'ing
+# python (exec keeps $! pointing at the python process itself).
+cat > "$LK/append_wrapper.sh" <<'EOF'
+#!/bin/bash
+# $1 = "started" sentinel; the rest is the command to exec.
+started=$1; shift
+: > "$started"
+exec "$@"
+EOF
+bash "$LK/append_wrapper.sh" "$LK/started" \
+  python3 "$SCRIPTS/append_audit.py" \
   --results fixtures/results_sample.json --journal "$LK/journal.md" >/dev/null 2>&1 &
 APPEND_PID=$!
-await_pid "$APPEND_PID" "lock: the append process never came up"
-sleep 0.5   # settle: the holder keeps the lock until the release sentinel
-            # below, so a generous settle costs wall time, never a false
-            # failure — unlike the fixed margin this replaced.
+await_file "$LK/started" "lock: the append never started"
+sleep 0.5   # one-sided settle: the holder keeps the lock across it, so this
+            # can only cost wall time, never a false failure.
+# ...and the append must still be ALIVE and blocked here. An append that
+# already exited — or that never took the lock at all — would satisfy the
+# "did not write" assertion below vacuously.
+APPEND_STATE=$(ps -o state= -p "$APPEND_PID" 2>/dev/null | tr -d '[:space:]' || true)
+[ -n "$APPEND_STATE" ] \
+  || fail "lock: the append exited instead of blocking on the held lock"
+case "$APPEND_STATE" in
+  Z*) fail "lock: the append is defunct — it exited instead of blocking on the held lock" ;;
+esac
 grep -q "^## 2026-06-21" "$LK/journal.md" \
   && fail "lock: append wrote the journal while the lock was held"
 : > "$LK/release"
-wait "$HOLDER_PID"
+wait "$HOLDER_PID" || fail "lock: holder timed out waiting for the release sentinel"
+HOLDER_PID=""
 wait "$APPEND_PID" || fail "lock: append failed after the lock was released"
 grep -q "^## 2026-06-21 — 01:00:00$" "$LK/journal.md" \
   || fail "lock: section missing after the lock was released"

--- a/.claude/skills/scenario-refine/tests/run_tests.sh
+++ b/.claude/skills/scenario-refine/tests/run_tests.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 # Self-test for the scenario-refine helper scripts. No Swift toolchain or
 # model needed — exercises inventory selection (rotation / category resolution
-# / ja-en tiering) and audit-journal appending (date idempotency / baseline
-# delta / failed-run exclusion) against fixtures.
+# / ja-en tiering) and audit-journal appending ((date, run_id) idempotency /
+# baseline delta / failed-run exclusion) against fixtures.
 #
 # usage: bash .claude/skills/scenario-refine/tests/run_tests.sh
 set -eu
@@ -82,7 +82,7 @@ echo "$JE" | jq -e 'length >= 6' >/dev/null || fail "absent journal should still
 cp fixtures/journal_seed.md "$TMP/journal.md"
 python3 "$SCRIPTS/append_audit.py" \
   --results fixtures/results_sample.json --journal "$TMP/journal.md" >/dev/null
-grep -q "^## 2026-06-21$" "$TMP/journal.md" || fail "audit: section heading missing"
+grep -q "^## 2026-06-21 — 01:00:00$" "$TMP/journal.md" || fail "audit: section heading missing"
 
 # regression: word_wolf prior total 16 (2026-06-20) → new 12 → Δ-4, flagged ⚠️
 WW_ROW=$(grep '^| word_wolf ' "$TMP/journal.md")
@@ -136,16 +136,16 @@ RT=$(python3 "$SCRIPTS/select_inventory.py" \
 RT_WW=$(echo "$RT" | jq -r '.[] | select(.id=="word_wolf") | .last_evaluated')
 [ "$RT_WW" = "2026-06-21" ] || fail "round-trip: word_wolf should read evaluated 2026-06-21, got $RT_WW"
 
-# --- append_audit.py: date idempotency -------------------------------------
+# --- append_audit.py: (date, run_id) idempotency ----------------------------
 python3 "$SCRIPTS/append_audit.py" \
   --results fixtures/results_sample.json --journal "$TMP/journal.md" >/dev/null 2>"$TMP/warn"
-COUNT=$(grep -c "^## 2026-06-21$" "$TMP/journal.md")
+COUNT=$(grep -c "^## 2026-06-21 — 01:00:00$" "$TMP/journal.md")
 [ "$COUNT" -eq 1 ] || fail "audit: re-append duplicated the section ($COUNT)"
 grep -q "warning: replaced" "$TMP/warn" || fail "audit: replace warning missing"
-# re-running same date must NOT use the replaced same-date section as its own
-# baseline — word_wolf still compares to 2026-06-20, so Δ stays -4 (not 0).
+# re-running the same (date, run_id) must NOT use the replaced section as its
+# own baseline — word_wolf still compares to 2026-06-20, so Δ stays -4 (not 0).
 grep '^| word_wolf ' "$TMP/journal.md" | grep -q -- "-4" \
-  || fail "audit: same-date re-run must not self-baseline (Δ should stay -4)"
+  || fail "audit: same-key re-run must not self-baseline (Δ should stay -4)"
 
 # --- append_audit.py: markers + bootstrap ----------------------------------
 echo "# broken" > "$TMP/broken.md"
@@ -158,7 +158,7 @@ python3 "$SCRIPTS/append_audit.py" \
   || fail "audit: absent file should bootstrap, not error"
 grep -q "audit-digest:sections" "$TMP/bootstrap.md" || fail "bootstrap: sections marker missing"
 grep -q "audit-digest:promotion" "$TMP/bootstrap.md" || fail "bootstrap: promotion marker missing"
-grep -q "^## 2026-06-21$" "$TMP/bootstrap.md" || fail "bootstrap: section not appended"
+grep -q "^## 2026-06-21 — 01:00:00$" "$TMP/bootstrap.md" || fail "bootstrap: section not appended"
 tail -1 "$TMP/bootstrap.md" | grep -q "^Promotion:" || fail "bootstrap: promotion line not last"
 
 # --- append_audit.py: malformed prior ok record warns (not silent) ---------
@@ -215,6 +215,7 @@ MIG_COUNT=$(grep -c "missing score axes" "$TMP/migwarn")
 cat > "$TMP/nulldev.json" <<'EOF'
 {
   "date": "2026-06-22",
+  "run_id": "01:00:00",
   "model": "gemma-4-E2B-it-Q4_K_M",
   "scenarios": [
     {"id": "single_round_v1", "name": "SR", "channel": "preset",
@@ -231,5 +232,128 @@ python3 "$SCRIPTS/append_audit.py" \
 ND_ROW=$(grep '^| single_round_v1 ' "$TMP/nulldev.md")
 ND_DEV=$(echo "$ND_ROW" | awk -F' \\| ' '{print $9}')
 [ "$ND_DEV" = "–" ] || fail "null development must render em-dash in (d) column, got '$ND_DEV'"
+
+# --- append_audit.py: (date, run_id) section key (#1542) --------------------
+# Two /scenario-refine cycles can share a date in the same main checkout (a
+# re-run after a fix, a second nightly pass). Before #1542 the second append
+# silently wiped the first run's audit record — the journal is the only
+# durable one — so these cases pin the compound key.
+RK="$TMP/runkey"; mkdir -p "$RK"
+cp fixtures/journal_seed.md "$RK/journal.md"
+# run 2: same date, later run_id, word_wolf one point better (total 17).
+jq '.run_id = "02:00:00" | .scenarios[0].scores.coherence = 4' \
+  fixtures/results_sample.json > "$RK/results_run2.json"
+
+# (a) REGRESSION TEST FOR #1542: same date, different run_ids → both survive.
+python3 "$SCRIPTS/append_audit.py" \
+  --results fixtures/results_sample.json --journal "$RK/journal.md" >/dev/null
+python3 "$SCRIPTS/append_audit.py" \
+  --results "$RK/results_run2.json" --journal "$RK/journal.md" >/dev/null
+grep -q "^## 2026-06-21 — 01:00:00$" "$RK/journal.md" \
+  || fail "runkey: first run's section wiped by a same-date second run (#1542)"
+grep -q "^## 2026-06-21 — 02:00:00$" "$RK/journal.md" \
+  || fail "runkey: second run's section missing"
+[ "$(grep -c '<!-- audit-data: ' "$RK/journal.md")" -eq 3 ] \
+  || fail "runkey: expected 3 audit-data comments (seed + 2 runs)"
+# run_id rides in the audit-data payload alongside date
+grep -o '<!-- audit-data: .* -->' "$RK/journal.md" \
+  | sed 's/^<!-- audit-data: //; s/ -->$//' \
+  | jq -es 'map(select(.run_id=="02:00:00")) | length == 1' >/dev/null \
+  || fail "runkey: run_id missing from the audit-data payload"
+
+# (d) refine-specific: a sibling run EARLIER the same date is a legitimate Δ
+# baseline — the exclusion unit is (date, run_id), not the whole date. run 2's
+# word_wolf (17) is scored against run 1 (16) → +1, not against 2026-06-20
+# (20, which would give -3).
+ww_row_of() { # $1 = run_id: the word_wolf row inside that run's section
+  awk -v h="## 2026-06-21 — $1" \
+    '$0 == h {inside=1; next} /^## / {inside=0} inside' "$RK/journal.md" \
+    | grep '^| word_wolf '
+}
+RK_WW=$(ww_row_of "02:00:00")
+echo "$RK_WW" | grep -q -- "+1" \
+  || fail "runkey: same-date sibling run must stay available as a Δ baseline, got '$RK_WW'"
+
+# (b) re-appending the SAME (date, run_id) replaces only that section, and
+# still excludes itself from its own baseline (Δ stays +1, never 0).
+python3 "$SCRIPTS/append_audit.py" \
+  --results "$RK/results_run2.json" --journal "$RK/journal.md" >/dev/null 2>"$RK/warn"
+grep -q "warning: replaced" "$RK/warn" || fail "runkey: replace warning missing"
+[ "$(grep -c "^## 2026-06-21 — 02:00:00$" "$RK/journal.md")" -eq 1 ] \
+  || fail "runkey: same-key re-append duplicated the section"
+[ "$(grep -c "^## 2026-06-21 — 01:00:00$" "$RK/journal.md")" -eq 1 ] \
+  || fail "runkey: sibling run's section disturbed by a same-key re-append"
+RK_WW2=$(ww_row_of "02:00:00")
+echo "$RK_WW2" | grep -q -- "+1" \
+  || fail "runkey: same-key re-append must not self-baseline, got '$RK_WW2'"
+
+# the newest of two same-date siblings wins the "most recent prior" pick, so a
+# third run resolves deterministically against run 2 (17) → Δ 0, not run 1.
+jq '.run_id = "03:00:00" | .scenarios[0].scores.coherence = 4' \
+  fixtures/results_sample.json > "$RK/results_run3.json"
+python3 "$SCRIPTS/append_audit.py" \
+  --results "$RK/results_run3.json" --journal "$RK/journal.md" >/dev/null
+RK_WW3=$(ww_row_of "03:00:00")
+echo "$RK_WW3" | grep -q -- "+0" \
+  || fail "runkey: baseline pick must order by (date, run_id), got '$RK_WW3'"
+
+# a legacy date-only heading in an existing local journal survives untouched
+LG="$TMP/legacy"; mkdir -p "$LG"
+cp fixtures/journal_seed.md "$LG/journal.md"
+jq '.run_id = "01:00:00" | .date = "2026-06-20"' \
+  fixtures/results_sample.json > "$LG/results_same_date.json"
+python3 "$SCRIPTS/append_audit.py" \
+  --results "$LG/results_same_date.json" --journal "$LG/journal.md" >/dev/null
+grep -q "^## 2026-06-20$" "$LG/journal.md" \
+  || fail "legacy: pre-#1542 date-only section must survive an append on its date"
+grep -q "^## 2026-06-20 — 01:00:00$" "$LG/journal.md" \
+  || fail "legacy: new section missing"
+
+# (c) run_id is REQUIRED and shape-checked; a rejected results JSON must leave
+# the journal byte-identical (an unattended run has to be recoverable by hand).
+RV="$TMP/runid_valid"; mkdir -p "$RV"
+cp "$RK/journal.md" "$RV/journal.md"
+cp "$RV/journal.md" "$RV/journal.before"
+jq 'del(.run_id)' fixtures/results_sample.json > "$RV/no_run_id.json"
+if python3 "$SCRIPTS/append_audit.py" \
+  --results "$RV/no_run_id.json" --journal "$RV/journal.md" 2>"$RV/err"; then
+  fail "runid: missing run_id should be a hard error"
+fi
+grep -q "run_id" "$RV/err" || fail "runid: error message must name run_id"
+grep -q "no_run_id.json" "$RV/err" || fail "runid: error message must name the results path"
+cmp -s "$RV/journal.before" "$RV/journal.md" || fail "runid: journal touched by a rejected append"
+# 99:99 has the right shape but is not a real clock time
+jq '.run_id = "99:99"' fixtures/results_sample.json > "$RV/bad_clock.json"
+if python3 "$SCRIPTS/append_audit.py" \
+  --results "$RV/bad_clock.json" --journal "$RV/journal.md" 2>/dev/null; then
+  fail "runid: 99:99 should be rejected as a non-clock run_id"
+fi
+cmp -s "$RV/journal.before" "$RV/journal.md" || fail "runid: journal touched by an invalid run_id"
+
+# (e) the append really takes an exclusive flock on <journal>.lock — the
+# compound key alone does not stop a concurrent read-modify-write from losing
+# a whole section. A helper holds the lock while an append is launched.
+LK="$TMP/lock"; mkdir -p "$LK"
+cp fixtures/journal_seed.md "$LK/journal.md"
+python3 - "$LK/journal.md.lock" <<'PY' &
+import fcntl, os, sys, time
+fd = os.open(sys.argv[1], os.O_CREAT | os.O_RDWR, 0o644)
+fcntl.flock(fd, fcntl.LOCK_EX)
+time.sleep(4)
+fcntl.flock(fd, fcntl.LOCK_UN)
+os.close(fd)
+PY
+HOLDER_PID=$!
+sleep 1   # generous margin: let the helper acquire before the append starts
+python3 "$SCRIPTS/append_audit.py" \
+  --results fixtures/results_sample.json --journal "$LK/journal.md" >/dev/null 2>&1 &
+APPEND_PID=$!
+sleep 1
+grep -q "^## 2026-06-21" "$LK/journal.md" \
+  && fail "lock: append wrote the journal while the lock was held"
+wait "$HOLDER_PID"
+wait "$APPEND_PID" || fail "lock: append failed after the lock was released"
+grep -q "^## 2026-06-21 — 01:00:00$" "$LK/journal.md" \
+  || fail "lock: section missing after the lock was released"
 
 echo "ALL TESTS PASSED"

--- a/.gitignore
+++ b/.gitignore
@@ -88,6 +88,9 @@ data/factory/audit-digest.md
 # append_audit.py's flock target, serializing same-date sibling runs (#1542)
 data/factory/audit-digest.md.lock
 data/queue/digest.md
+# append_digest.py's flock target, serializing runs that share the
+# main checkout (#1542)
+data/queue/digest.md.lock
 data/factory/lessons-inbox.md
 data/factory/incubator.md
 

--- a/.gitignore
+++ b/.gitignore
@@ -85,6 +85,8 @@ data/factory/digest.md
 data/factory/digest.md.lock
 data/factory/digest-index.jsonl
 data/factory/audit-digest.md
+# append_audit.py's flock target, serializing same-date sibling runs (#1542)
+data/factory/audit-digest.md.lock
 data/queue/digest.md
 data/factory/lessons-inbox.md
 data/factory/incubator.md

--- a/.gitignore
+++ b/.gitignore
@@ -104,6 +104,8 @@ data/highlight-runs/
 # if absent.
 data/models/eval-runs/
 data/models/eval-digest.md
+# append_eval.py's flock target, serializing same-day sibling runs (#1542)
+data/models/eval-digest.md.lock
 
 # Per-user Claude Code settings — permission grants and opt-in hooks such as
 # the worktree pruner (wiring: the header of scripts/prune-stale-worktrees.sh).

--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,8 @@ data/factory/improvements/
 # checkout's working tree stays clean; each skill's append_digest.py
 # bootstraps the file from a scaffold if absent.
 data/factory/digest.md
+# append_digest.py's flock target, serializing same-date sibling runs (#1542)
+data/factory/digest.md.lock
 data/factory/digest-index.jsonl
 data/factory/audit-digest.md
 data/queue/digest.md


### PR DESCRIPTION
## Summary

並行 run が同じ main checkout を共有すると、`append_digest.py` 系が **日付キーで REPLACE** するため digest セクションが後勝ちで相互クロバーしていた。生成 YAML と run log は残るが judging journal は片方だけ消える（#1542）。

- **セクションキーを `(date, run_id)` に複合化** — 見出しは `## <date> — <run_id>`、`append_eval.py` の `(date, profile_id)` 前例に揃えた。同一 `(date, run_id)` の再追記だけが REPLACE するので、部分失敗サイクルの再実行の冪等性は維持。
- **`run_id` は results JSON の必須フィールド**（時計から自動生成しない）。自動生成すると再実行が新しいキーを持ち、自分のセクションを置換せず複製してしまう。粒度は分ではなく `HH:MM:SS`／スラグ許容 — 分粒度だと「両方 01:30 起動」で衝突が再現するため。
- **後方互換** — 既存ローカル digest のレガシー日付のみ見出しは replace パターンに一致しないので生き残り、`--rebuild-index` も引き続きパースする（`run_id: null`）。サイドカー `digest-index.jsonl` も `(date, run_id)` で追従。
- **`fcntl.flock` を 4 フォーク全部に** — キー分離は上書きを防ぐが read-modify-write のインターリーブは防がないため。`append_eval.py` の「共有コアを直したら全フォーク掃け」規約に従い、`queue-consumer/append_digest.py`（main checkout を共有ターゲットにする append-only ログで最も露出が大きい）にも適用した。

## Test plan

- `bash .claude/skills/{scenario-factory,scenario-refine,model-eval,queue-consumer}/tests/run_tests.sh` — 全て `ALL TESTS PASSED`（CI は `scripts/tests/*-test.sh` 経由で同じものを回す）
- `bash scripts/tests/skill-harness-wiring-test.sh` — PASS
- 新規ケース: #1542 の回帰テスト（同日・異 run_id で両セクション生存）、同一キー再追記、`run_id` 欠落／`99:99` 拒否、レガシー混在での rebuild、flock が実際に効いていること（sentinel 同期＋生存判定で、遅い起動でも空振り PASS しない）
- 各ケースは実装を壊して FAIL することを確認済み（flock 無効化・Δ 値改竄・rebuild の先行書き込み）
- **xcodebuild / SwiftLint はスキップ** — `git diff --name-only main...HEAD | scripts/precommit-gate-classify.sh` が build/lint いずれのトークンも返さない（Swift ソース非変更）。CI の path-gating も同じスクリプトを使う。

## Review

Reviewer: **Opus**（`.claude/**` は sensitive base）。1st pass PASS（Warning 4）、fix 差分の 2nd pass は 3 分割して全て PASS（Warning 計 7）。全件適用、却下は 1 件のみ:

- **却下** — rebuild-index の `--skip-unparsable-sections` 新フラグ追加。issue の範囲外の CLI 追加なので、代わりにエラー文が具体的な復旧手順（見出しを `## <date> — HH:MM:SS` に直すか節を削除して再実行）を出す形にした。
- 主な適用: queue-consumer への flock 波及（4 番目のフォーク）、lock テストの sleep マージン依存の解消、Δ 列アサーションの列抽出＋等価比較化、rebuild-index の見出し厳格化と診断文の修正、RUN_ID 復元手順の曖昧性除去（両復元元が日付キーのため、兄弟 run の値を誤って復元するとその兄弟の節を消す — 曖昧なら復元せず採番する方針に）。

## Device QA

実機QA不要 — エージェント運用ツール（Python/シェル）と skill ドキュメントのみで、アプリのコードパスに変更なし。

Closes #1542
