### PR TITLE
✨ feat: ADR-023 Stage 3 — ScenarioLoader ingest + top-level mapping port (PR C2a)

### DIFF
--- a/.claude/rules/engine.md
+++ b/.claude/rules/engine.md
@@ -15,10 +15,15 @@ omission. Four do not.
   breaks only once `shared/models/.../PhaseType.kt` gains the case, and no gate
   ties the two enums together (the ADR-023 ledger covers `Engine/**` + `LLM/**`
   only). Add the Swift case alone and the Kotlin lane stays green while the enums
-  diverge. `ScenarioLoader.kt`'s `type:` lookup is **not** a third hand-maintained
-  map — it derives from `PhaseType.serializer().descriptor` via its
-  `serialNameLookup` helper, so a new case is picked up automatically and needs
-  no edit there (phase-field mapping is a separate, still-unported concern, C2b).
+  diverge. `ScenarioLoader.kt`'s `type:` lookup is **not** another hand-maintained
+  map alongside `PhaseDispatcher.defaultHandlers()` and
+  `ConditionalHandler.subHandlers` (`kmp-interop.md` Pattern 4) — it derives from
+  `PhaseType.serializer().descriptor` via its `serialNameLookup` helper, so a new
+  case is picked up automatically and needs no edit there. The trap moves rather
+  than vanishing: the descriptor falls back to the **declaration** name when
+  `@SerialName` is absent, so a Kotlin case added without its annotation resolves
+  as `SPEAK_ALL` rather than `speak_all`, and `serialNameLookup`'s count check
+  cannot see it. (Phase-field mapping is a separate, still-unported concern, C2b.)
 - **Conditional-branch policy.** `ScenarioValidator.validateBranch` and
   `ConditionalHandler.subHandlers` are not `PhaseType`-exhaustive, so decide
   explicitly: *allow* (register in `subHandlers`) or *reject* (a

--- a/.claude/rules/engine.md
+++ b/.claude/rules/engine.md
@@ -15,7 +15,10 @@ omission. Four do not.
   breaks only once `shared/models/.../PhaseType.kt` gains the case, and no gate
   ties the two enums together (the ADR-023 ledger covers `Engine/**` + `LLM/**`
   only). Add the Swift case alone and the Kotlin lane stays green while the enums
-  diverge.
+  diverge. `ScenarioLoader.kt`'s `type:` lookup is **not** a third hand-maintained
+  map — it derives from `PhaseType.serializer().descriptor` via its
+  `serialNameLookup` helper, so a new case is picked up automatically and needs
+  no edit there (phase-field mapping is a separate, still-unported concern, C2b).
 - **Conditional-branch policy.** `ScenarioValidator.validateBranch` and
   `ConditionalHandler.subHandlers` are not `PhaseType`-exhaustive, so decide
   explicitly: *allow* (register in `subHandlers`) or *reject* (a

--- a/Pastura/Pastura/Engine/ScenarioLoader.swift
+++ b/Pastura/Pastura/Engine/ScenarioLoader.swift
@@ -55,10 +55,19 @@ nonisolated public struct ScenarioLoader: Sendable {  // swiftlint:disable:this 
   ///
   /// **Partially dual-landed with
   /// `shared/engine/src/commonMain/kotlin/com/pastura/engine/ScenarioLoader.kt`**
-  /// (ADR-023 §4 C2a) — the YAML-ingest and top-level-mapping change here
-  /// needs mirroring there. Phase specialisation (`output`, `target`, `pairing`,
-  /// `logic`, `then`/`else`, `action_deltas`, `payoff`) is not yet ported (C2b);
-  /// a change confined to one of those fields has no Kotlin side to mirror yet.
+  /// (spelled out so a move leaves a greppable string behind) — change both
+  /// (ADR-023 §4, PR C2a). This file's row in `shared/adr-023-port-ledger.tsv`
+  /// is `SPLIT` naming that path alongside `InferenceEstimator.kt`, and the
+  /// coverage gate verifies both paths are tracked — it cannot verify that an
+  /// edit here was mirrored, so the pairing is yours to honour.
+  ///
+  /// **Delete the next sentence when C2b lands**, together with the Kotlin
+  /// file's `PORT IN PROGRESS` KDoc section; both are pinned by
+  /// `ScenarioLoaderTests.phaseSpecialisationIsStillUnmapped`, which reddens the
+  /// moment those fields start being mapped. Phase specialisation (`output`,
+  /// `target`, `pairing`, `logic`, `then`/`else`, `action_deltas`, `payoff`) is
+  /// not yet ported, so a change confined to one of those fields has no Kotlin
+  /// side to mirror yet.
   public func load(yaml: String) throws -> Scenario {
     let stripped = stripCodeFences(yaml)
 

--- a/Pastura/Pastura/Engine/ScenarioLoader.swift
+++ b/Pastura/Pastura/Engine/ScenarioLoader.swift
@@ -52,6 +52,13 @@ nonisolated public struct ScenarioLoader: Sendable {  // swiftlint:disable:this 
   /// - Throws: ``SimulationError/scenarioValidationFailed(_:)`` on a YAML
   ///   parse error or a construct-time invariant violation (wrong field type,
   ///   unknown `language`, persona/agent mismatch, malformed phase shape).
+  ///
+  /// **Partially dual-landed with
+  /// `shared/engine/src/commonMain/kotlin/com/pastura/engine/ScenarioLoader.kt`**
+  /// (ADR-023 §4 C2a) — the YAML-ingest and top-level-mapping change here
+  /// needs mirroring there. Phase specialisation (`output`, `target`, `pairing`,
+  /// `logic`, `then`/`else`, `action_deltas`, `payoff`) is not yet ported (C2b);
+  /// a change confined to one of those fields has no Kotlin side to mirror yet.
   public func load(yaml: String) throws -> Scenario {
     let stripped = stripCodeFences(yaml)
 

--- a/docs/decisions/ADR-023.md
+++ b/docs/decisions/ADR-023.md
@@ -256,12 +256,14 @@ precisely how §4 went stale in the first place.)
 - `StringStateMachine` → **`FOLDED`** into `JSONResponseParser.kt`, which carries the scan inline
   rather than as a separate type.
 - `ScenarioLoader` → **`SPLIT`** (§13): `estimateInferenceCount` / `estimatePhase` landed as
-  `InferenceEstimator.kt` (#1464, `6341951a`, 2026-08-14); the remainder — YAML ingest and
-  structural mapping (`load(yaml:)`, `mapToScenario` and its helpers) — is still to be ported
-  under its own name. The ledger row names `InferenceEstimator.kt` today and gains
-  `ScenarioLoader.kt` when that lands. No board row tracks the remainder
-  (`docs/kmp-migration-status.md`'s machine-checked section is handler-only), so this bullet is
-  the record that it is outstanding.
+  `InferenceEstimator.kt` (#1464, `6341951a`, 2026-08-14); YAML ingest and top-level structural
+  mapping (`load(yaml:)`, `mapToScenario`, `mapPersona`, `collectExtraData`, and the three generic
+  parse helpers) landed as `ScenarioLoader.kt` (#1558, PR C2a, 2026-08-26), and the ledger row now
+  names both. **Still outstanding: phase specialisation** — every `mapPhase` field needing a
+  dedicated helper (`output`, `target`, `pairing`, `logic`, `then` / `else`, `action_deltas`,
+  `payoff`), deferred to PR C2b. `docs/kmp-migration-status.md`'s hand-maintained row carries that
+  split in prose, but its machine-checked section is handler-only, so this bullet remains the
+  record that the remainder is outstanding.
 
 ### How this section went stale, and what changed
 
@@ -1109,7 +1111,8 @@ here).
   relationship, not how far along it is. A row flips `PORT` → `SPLIT` when the first
   differently-named Kotlin file lands, and stays `SPLIT` after the rest follows. Progress keeps its
   existing homes (#501, `docs/kmp-migration-status.md`); the §4 bullet records which part of
-  `ScenarioLoader` is outstanding because no board row does.
+  `ScenarioLoader` is outstanding, because no *machine-checked* board row does — that section is
+  handler-only, so the status doc's loader row is hand-maintained prose that can drift from it.
 - **Column 3 lists every Kotlin file the content has landed in** — including the same-named one
   once it exists — so a reader of the row sees the whole dual-landing set without knowing the
   naming convention.

--- a/docs/kmp-migration-status.md
+++ b/docs/kmp-migration-status.md
@@ -45,7 +45,7 @@ Legend: ✅ done · 🔄 in progress · 🟡 partial · ⬜ not started.
 | Wave A — non-handler run-path (scoring, mechanisms, prompt/LLM glue) | ✅ done | #1207 #1212 #1217 |
 | Wave B — 14 phase handlers | ✅ 14/14 | checklist ↓ |
 | code-phase track | ✅ done | CP1 #1226 · CP2 #1230 · CP3 #1232 |
-| Loader / validator port + `detector`·`logger` wiring | 🟡 partial | validator prerequisites in ([#1464](https://github.com/tyabu12/pastura/issues/1464)); validator fully ported — run gate + commit gate ([#1552](https://github.com/tyabu12/pastura/issues/1552) B1/B2); loader / linter / preflight wiring left · [ADR-023](decisions/ADR-023.md) §4 · #501 |
+| Loader / validator port + `detector`·`logger` wiring | 🟡 partial | validator prerequisites in ([#1464](https://github.com/tyabu12/pastura/issues/1464)); validator fully ported — run gate + commit gate ([#1552](https://github.com/tyabu12/pastura/issues/1552) B1/B2); loader half-ported — YAML ingest + top-level mapping landed ([#1558](https://github.com/tyabu12/pastura/issues/1558) C2a), phase specialisation deferred (C2b); linter / preflight wiring left · [ADR-023](decisions/ADR-023.md) §4 · #501 |
 
 ### Wave B handler checklist
 

--- a/docs/kmp-migration-status.md
+++ b/docs/kmp-migration-status.md
@@ -45,7 +45,7 @@ Legend: ✅ done · 🔄 in progress · 🟡 partial · ⬜ not started.
 | Wave A — non-handler run-path (scoring, mechanisms, prompt/LLM glue) | ✅ done | #1207 #1212 #1217 |
 | Wave B — 14 phase handlers | ✅ 14/14 | checklist ↓ |
 | code-phase track | ✅ done | CP1 #1226 · CP2 #1230 · CP3 #1232 |
-| Loader / validator port + `detector`·`logger` wiring | 🟡 partial | validator prerequisites in ([#1464](https://github.com/tyabu12/pastura/issues/1464)); validator fully ported — run gate + commit gate ([#1552](https://github.com/tyabu12/pastura/issues/1552) B1/B2); loader half-ported — YAML ingest + top-level mapping landed ([#1558](https://github.com/tyabu12/pastura/issues/1558) C2a), phase specialisation deferred (C2b); linter / preflight wiring left · [ADR-023](decisions/ADR-023.md) §4 · #501 |
+| Loader / validator port + `detector`·`logger` wiring | 🟡 partial | validator prerequisites in ([#1464](https://github.com/tyabu12/pastura/issues/1464)); validator fully ported — run gate + commit gate ([#1552](https://github.com/tyabu12/pastura/issues/1552) B1/B2); loader half-ported — YAML ingest + top-level mapping landed ([#1558](https://github.com/tyabu12/pastura/issues/1558) C2a), phase specialisation deferred (C2b), and like the validator it is **not wired** yet; linter / preflight wiring left · [ADR-023](decisions/ADR-023.md) §4 · #501 |
 
 ### Wave B handler checklist
 

--- a/shared/adr-023-port-ledger.tsv
+++ b/shared/adr-023-port-ledger.tsv
@@ -54,7 +54,7 @@ Pastura/Pastura/Engine/PromptBuilder+Injection.swift	PORT
 Pastura/Pastura/Engine/PromptBuilder+PrivateSections.swift	PORT
 Pastura/Pastura/Engine/PromptPlaceholders.swift	PORT
 Pastura/Pastura/Engine/RelationshipVerbalizer.swift	PORT
-Pastura/Pastura/Engine/ScenarioLoader.swift	SPLIT	shared/engine/src/commonMain/kotlin/com/pastura/engine/InferenceEstimator.kt
+Pastura/Pastura/Engine/ScenarioLoader.swift	SPLIT	shared/engine/src/commonMain/kotlin/com/pastura/engine/InferenceEstimator.kt,shared/engine/src/commonMain/kotlin/com/pastura/engine/ScenarioLoader.kt
 Pastura/Pastura/Engine/ScenarioSemanticLinter.swift	PORT
 Pastura/Pastura/Engine/ScenarioSemanticLinter+Conditions.swift	PORT
 Pastura/Pastura/Engine/ScenarioSemanticLinter+Config.swift	PORT

--- a/shared/engine/build.gradle.kts
+++ b/shared/engine/build.gradle.kts
@@ -337,6 +337,7 @@ tasks.matching {
 val exportedThrowingSelectors = mapOf(
     "evaluate(expression:state:scenario:)" to "ConditionEvaluator.evaluate",
     "parse(expression:)" to "ConditionEvaluator.parse",
+    "load(yaml:)" to "ScenarioLoader.load",
     "validate(scenario:)" to "ScenarioValidator.validate",
     "validateForCommit(scenario:)" to "ScenarioValidator.validateForCommit",
     "require(key:)" to "TurnOutput.require (shared/models, re-exported)",

--- a/shared/engine/build.gradle.kts
+++ b/shared/engine/build.gradle.kts
@@ -7,8 +7,10 @@ import org.jetbrains.kotlin.gradle.plugin.mpp.apple.XCFramework
 //
 // Deliberately minimal vs `shared/models`:
 //   - No `kotlin-serialization` PLUGIN and no `snakeyaml-engine-kmp` — the engine
-//     run-path declares no `@Serializable` types of its own and does not parse
-//     YAML (that is Models' `YamlCodec`). The plugin is codegen for
+//     run-path declares no `@Serializable` types of its own, and YAML TEXT only
+//     ever enters this module through Models' `YamlCodec` (`ScenarioLoader.kt`
+//     ingests YAML but parses it via that call, not a snakeyaml dependency of
+//     its own). The plugin is codegen for
 //     `@Serializable`; `JSONResponseParser` only needs the RUNTIME library to
 //     walk a `JsonElement`, so the library is a dependency and the plugin stays
 //     out. Models' own dep is `implementation`, so it does not reach here

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/ScenarioLoader.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/ScenarioLoader.kt
@@ -45,6 +45,11 @@ import kotlinx.serialization.json.JsonPrimitive
  * them therefore loads with that field silently `null` here while Swift maps it
  * — which is why nothing calls this loader yet (see below).
  *
+ * `ScenarioLoaderTests.phaseSpecialisationIsStillUnmapped` pins that list from
+ * the test side and is written to go **red** the moment any of the seven starts
+ * being mapped, so this section cannot outlive the gap it describes. Delete
+ * both together.
+ *
  * ## Not wired into the engine
  *
  * Nothing in `shared/engine` calls this, deliberately — the same posture as

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/ScenarioLoader.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/ScenarioLoader.kt
@@ -1,0 +1,732 @@
+package com.pastura.engine
+
+import com.pastura.models.AnyCodableValue
+import com.pastura.models.Persona
+import com.pastura.models.Phase
+import com.pastura.models.PhaseType
+import com.pastura.models.Scenario
+import com.pastura.models.ScenarioValidationMessage
+import com.pastura.models.SimulationError
+import com.pastura.models.YamlCodec
+import com.pastura.models.YamlDecodeError
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+
+/**
+ * Parses YAML scenario definitions into [Scenario] models.
+ *
+ * Kotlin port of the YAML-ingest and top-level-mapping half of
+ * `Pastura/Pastura/Engine/ScenarioLoader.swift` (ADR-023 §4, the "Load +
+ * validate" row). The Swift file's `estimateInferenceCount` / `estimatePhase`
+ * pair landed separately as [InferenceEstimator], so `ScenarioLoader.swift` is a
+ * **1 Swift file → 2+ Kotlin files** `SPLIT` row in
+ * `shared/adr-023-port-ledger.tsv`; the coverage gate verifies those paths are
+ * tracked, not that an edit on either side was mirrored.
+ *
+ * Like the Swift original, [load] enforces structural mapping plus a narrow band
+ * of construct-time invariants (accepted-`language` / `simulation_language`
+ * membership, `personas` count matching `agents`) and does **not** run
+ * [ScenarioValidator]'s execution-limit / inference-cap / phase-semantic gate —
+ * the returned scenario is well-formed but not yet known to be runnable.
+ *
+ * ## PORT IN PROGRESS — phase specialisation is not here yet (C2b)
+ *
+ * [mapPhase] maps exactly the phase fields reachable through the three generic
+ * parse helpers. Every field needing a dedicated helper is still unmapped and is
+ * passed to the [Phase] constructor as an explicit `null, // C2b`:
+ * `output` (`parseOutputSchema`), `target` (`parseAssignTarget`),
+ * `pairing` (`parsePairing`), `logic` (`parseLogic`), `then` / `else`
+ * (`mapBranch`, the depth-1 conditional), `action_deltas`
+ * (`parseActionDeltas`) and `payoff` (`parsePayoff`). A scenario using any of
+ * them therefore loads with that field silently `null` here while Swift maps it
+ * — which is why nothing calls this loader yet (see below).
+ *
+ * ## Not wired into the engine
+ *
+ * Nothing in `shared/engine` calls this, deliberately — the same posture as
+ * [ScenarioValidator]. ADR-023 §4 puts the preflight gate on the validator
+ * **and** `ScenarioSemanticLinter` (ADR-024) together, and the linter is
+ * unported, so `DivergenceLedger.DivergenceClass.VALIDATOR_UNPORTED` still
+ * stands.
+ *
+ * ## Why a hand-written walk over [JsonElement]
+ *
+ * The tree comes from `YamlCodec.default().decode(yaml)`; the mapping below is
+ * hand-written rather than `Json.decodeFromJsonElement(Scenario.serializer(), …)`.
+ * A serializer-driven decode would fork parity twice over: its wire keys are
+ * camelCase (`Scenario`'s KDoc — preset YAML is snake_case), and its errors and
+ * strictness are kotlinx's, not the Swift loader's
+ * [ScenarioValidationMessage] vocabulary that the iOS UI renders today.
+ *
+ * ## Known divergences from Swift
+ *
+ * All are **documented, not ledgered**, on PR B1's standing reason: a scenario
+ * this loader rejects produces no run and therefore no parity transcript to
+ * compare (`DivergenceClass.VALIDATOR_UNPORTED`).
+ *
+ * 1. **Two YAML-1.1 typed scalars are accepted on one side and rejected on the
+ *    other.** Measured on both engines: `12:30:00` (sexagesimal) resolves to
+ *    `Int 45000` under Yams and stays a `String` under snakeyaml-engine's YAML
+ *    1.2 core schema; `2026-08-26` resolves to a `Date` under Yams and stays a
+ *    `String` here. So for a `String`-typed field Swift **rejects** what Kotlin
+ *    **accepts**, and for an `Int`-typed field the polarity flips. Deliberately
+ *    **not** closed: closing it means regex-sniffing every plain scalar for ISO
+ *    dates and sexagesimals, which risks rejecting legitimate curator text, for
+ *    an input shape no bundled preset or gallery scenario uses.
+ * 2. **YAML-1.1 boolean tokens are re-accepted loader-locally.** `yes` / `no` /
+ *    `on` / `off` (and their `Yes` / `YES` case variants) resolve to `Bool`
+ *    under Yams and to `String` here, so [YamlType.BOOL] maps that token set
+ *    back to a boolean where a boolean is expected. `y` / `n` are **excluded**:
+ *    both engines already agree they are `String` (libyaml's bool set does not
+ *    contain them), so accepting them would open a *new* divergence rather than
+ *    close one. This is the loader's decision alone — `YamlCodec`'s YAML 1.2
+ *    contract and its `LoadSettings` are untouched. The cost is one narrow
+ *    over-acceptance: snakeyaml erases the quoted/plain distinction for these
+ *    tokens, so a **quoted** `"yes"` is also read as a boolean here while Swift
+ *    keeps it a `String`.
+ * 3. **Type-name rendering.** The `expected:` / `got:` fragments come from
+ *    [YamlType.rendered] and [renderActualType] — see [renderActualType] for
+ *    where they part company with Swift's `String(describing: type(of:))`.
+ * 4. **`Int` is 32-bit here and 64-bit in Swift.** An integral scalar outside
+ *    `Int.MIN_VALUE..Int.MAX_VALUE` is a [ScenarioValidationMessage.FieldWrongType]
+ *    rather than an accepted value. Truncating instead would be worse than a
+ *    divergence — it would silently run a different scenario.
+ * 5. **Whitespace trimming.** Swift trims `.whitespacesAndNewlines` (a Unicode
+ *    character set), Kotlin `trim()` trims `Char.isWhitespace()`. The two
+ *    disagree on a handful of exotic code points, so a persona `secret:` padded
+ *    with one of them could normalize to `null` on one side only. Same family as
+ *    [ScenarioValidator]'s divergence 3.
+ *
+ * ## `validationError` is re-declared here on purpose
+ *
+ * `ScenarioValidator.kt` has its own file-private `validationError`, and so does
+ * this file — mirroring the Swift originals, where each of `ScenarioLoader.swift`
+ * and `ScenarioValidator.swift` declares a file-private helper of that name. It
+ * is duplication by design, not a missed extraction: a shared module-scope
+ * helper would be a third public-ish surface in `com.pastura.engine` for two call
+ * sites of one line.
+ */
+public class ScenarioLoader {
+
+    /**
+     * Parses [yaml] into a [Scenario].
+     *
+     * The **only** `public` member of this file. Every helper below is
+     * `internal` or `private`, so no `kotlinx.serialization` type reaches the
+     * exported Obj-C header — which nothing would otherwise catch: a leaked
+     * type does not fail the K/N link (see `shared/engine/build.gradle.kts` on
+     * the 48 leaked coroutine symbols measured under BUILD SUCCESSFUL) and
+     * `verifyEngineFrameworkSurface` inspects coroutine types only.
+     *
+     * `@Throws` is load-bearing at the K/N boundary, not decoration: a Kotlin
+     * exception thrown from an **un-annotated** exported function is not
+     * surfaced to Swift as a catchable error — it terminates the calling
+     * process (`.claude/rules/kmp-interop.md` Pattern 5). This declaration's
+     * `swift_name("load(yaml:)")` is pinned in `exportedThrowingSelectors`,
+     * which asserts the generated header really carries the `error:` parameter.
+     *
+     * Code fences are stripped first, so LLM-generated YAML wrapped in
+     * ```` ```yaml ```` parses without pre-cleaning by the caller.
+     *
+     * @param yaml raw YAML text, possibly wrapped in markdown code fences.
+     * @return a structurally-mapped [Scenario] (not run-validated).
+     * @throws SimulationException carrying
+     *   [SimulationError.ScenarioValidationFailed] on a YAML parse error or a
+     *   construct-time invariant violation (wrong field type, unknown
+     *   `language`, persona/agent mismatch, malformed phase shape).
+     */
+    @Throws(SimulationException::class)
+    public fun load(yaml: String): Scenario {
+        val stripped = stripCodeFences(yaml)
+
+        // Both halves of Swift's `guard let raw = try? Yams.load(...), let dict
+        // = raw as? [String: Any]` fold to the same message: a decode failure,
+        // and a root that is not a mapping. An empty or blank document decodes
+        // to JsonNull and a sequence root to JsonArray, so both land here too.
+        // The parser's own reason is deliberately dropped:
+        // `InvalidYAMLFormat` is a fixed localized string on both sides, so
+        // folding a snakeyaml-specific message into it would diverge from Swift
+        // while telling the curator nothing they can act on.
+        val root: JsonElement = try {
+            YamlCodec.default().decode(stripped)
+        } catch (error: YamlDecodeError) {
+            throw validationError(ScenarioValidationMessage.InvalidYAMLFormat)
+        }
+        val dict = root as? JsonObject
+            ?: throw validationError(ScenarioValidationMessage.InvalidYAMLFormat)
+
+        return mapToScenario(dict)
+    }
+
+    // MARK: - Private
+
+    /** Removes markdown code fences that LLMs sometimes wrap around YAML. */
+    private fun stripCodeFences(text: String): String =
+        text.split("\n").filterNot { it.trim().startsWith("```") }.joinToString("\n")
+
+    /**
+     * Extracts a required field of exact type [T] from a YAML mapping.
+     *
+     * Distinguishes *missing* from *present-but-wrong-type* so users can tell
+     * whether to add the field or re-type it, and names the actual decoded type
+     * so `agents: "2"` reports `field 'agents' must be Int, got String` instead
+     * of a misleading "missing required field".
+     *
+     * An **explicit** `key: ~` / `key: null` / bare `key:` decodes to [JsonNull],
+     * which is a present key holding a value of the wrong type — never an absent
+     * one. That asymmetry is the point: reading it as absent is exactly the
+     * silent-coerce class tracked in #130, and it matches Swift, where `NSNull`
+     * fails every `as? T`.
+     *
+     * No type coercion beyond the one [YamlType.BOOL] documents.
+     */
+    private fun <T> parseRequired(
+        dict: JsonObject,
+        key: String,
+        label: String,
+        type: YamlType<T>,
+    ): T {
+        val raw = dict[key]
+            ?: throw validationError(
+                ScenarioValidationMessage.MissingRequiredField(label = label, key = key),
+            )
+        return type.cast(raw) ?: throw validationError(
+            ScenarioValidationMessage.FieldWrongType(
+                label = label,
+                key = key,
+                expected = type.rendered,
+                got = renderActualType(raw),
+            ),
+        )
+    }
+
+    /**
+     * Extracts an optional field of exact type [T] from a YAML mapping.
+     *
+     * Returns `null` when the key is **absent**. Throws when it is
+     * present-but-wrong-type — unlike a bare `as?`, which would coerce to `null`
+     * and let the caller's default silently kick in (#130). See [parseRequired]
+     * for why an explicit `key: ~` throws rather than reading as absent.
+     */
+    private fun <T> parseOptional(
+        dict: JsonObject,
+        key: String,
+        label: String,
+        type: YamlType<T>,
+    ): T? {
+        val raw = dict[key] ?: return null
+        return type.cast(raw) ?: throw validationError(
+            ScenarioValidationMessage.FieldWrongType(
+                label = label,
+                key = key,
+                expected = type.rendered,
+                got = renderActualType(raw),
+            ),
+        )
+    }
+
+    /**
+     * Extracts an optional `Double` field, accepting an integral scalar and
+     * widening it.
+     *
+     * Intentional exception to the project-wide #130 strict-no-coerce stance.
+     * The `event_inject` phase's `probability` is the first natural-decimal
+     * `Double?` field on [Phase], and in YAML the boundary cases are most
+     * ergonomically written `0` / `1`; forcing `0.0` / `1.0` would surface a
+     * parser bridging quirk for no curator-visible benefit.
+     *
+     * The window is strictly integral → `Double`, not "anything resembling a
+     * number": a quoted scalar, a boolean, or any collection throws
+     * [ScenarioValidationMessage.FieldNotDoubleOrInt]. Booleans are excluded
+     * explicitly because Swift's `as? Int` launders one, which is the
+     * type-laundering bug this whole helper family exists to prevent.
+     */
+    private fun parseOptionalDoubleAcceptingInt(
+        dict: JsonObject,
+        key: String,
+        label: String,
+    ): Double? {
+        val raw = dict[key] ?: return null
+        val number = (raw as? JsonPrimitive)
+            ?.takeIf { it !is JsonNull && !it.isString && !it.isYamlBooleanLiteral() }
+            ?.content
+            ?.toDoubleOrNull()
+        return number ?: throw validationError(
+            ScenarioValidationMessage.FieldNotDoubleOrInt(
+                label = label,
+                key = key,
+                got = renderActualType(raw),
+            ),
+        )
+    }
+
+    /** Maps a raw YAML mapping to a [Scenario]. */
+    private fun mapToScenario(dict: JsonObject): Scenario {
+        val id = parseRequired(dict, "id", SCENARIO_LABEL, YamlType.STRING)
+        val name = parseRequired(dict, "name", SCENARIO_LABEL, YamlType.STRING)
+        val description = parseRequired(dict, "description", SCENARIO_LABEL, YamlType.STRING)
+        val language = parseRequired(dict, "language", SCENARIO_LABEL, YamlType.STRING)
+        if (language !in Scenario.ACCEPTED_LANGUAGES) {
+            throw validationError(
+                ScenarioValidationMessage.LanguageNotAccepted(
+                    allowed = acceptedLanguagesList(),
+                    got = language,
+                ),
+            )
+        }
+        val simulationLanguage =
+            parseOptional(dict, "simulation_language", SCENARIO_LABEL, YamlType.STRING)
+        if (simulationLanguage != null && simulationLanguage !in Scenario.ACCEPTED_LANGUAGES) {
+            throw validationError(
+                ScenarioValidationMessage.SimulationLanguageYAMLNotAccepted(
+                    allowed = acceptedLanguagesList(),
+                    got = simulationLanguage,
+                ),
+            )
+        }
+        val agentCount = parseRequired(dict, "agents", SCENARIO_LABEL, YamlType.INT)
+        val rounds = parseRequired(dict, "rounds", SCENARIO_LABEL, YamlType.INT)
+        val context = parseRequired(dict, "context", SCENARIO_LABEL, YamlType.STRING)
+        // Optional prompt-side conversation-log cap (#907). Strict-Int parse
+        // (mirrors `agents` / `rounds`): a quoted number or other type errors
+        // rather than silently coercing. The `>= 1` bound is ScenarioValidator's.
+        val logWindow = parseOptional(dict, "log_window", SCENARIO_LABEL, YamlType.INT)
+
+        val personasRaw = parseRequired(dict, "personas", SCENARIO_LABEL, YamlType.OBJECT_LIST)
+        val phasesRaw = parseRequired(dict, "phases", SCENARIO_LABEL, YamlType.OBJECT_LIST)
+
+        val personas = personasRaw.map { mapPersona(it) }
+        if (personas.size != agentCount) {
+            throw validationError(
+                ScenarioValidationMessage.AgentsPersonasCountMismatch(
+                    agentCount = agentCount,
+                    personaCount = personas.size,
+                ),
+            )
+        }
+
+        val phases = phasesRaw.mapIndexed { index, raw -> mapPhase(raw, index) }
+
+        return Scenario(
+            id = id,
+            name = name,
+            description = description,
+            language = language,
+            simulationLanguage = simulationLanguage,
+            agentCount = agentCount,
+            rounds = rounds,
+            logWindow = logWindow,
+            context = context,
+            personas = personas,
+            phases = phases,
+            extraData = collectExtraData(dict),
+        )
+    }
+
+    /**
+     * Collects non-standard top-level keys as extra data. Throws on unsupported
+     * shapes rather than silently dropping them — a typo like `count: 42`
+     * (auto-typed integral) used to disappear from the returned map.
+     */
+    private fun collectExtraData(dict: JsonObject): Map<String, AnyCodableValue> =
+        dict.entries
+            .filterNot { it.key in STANDARD_KEYS }
+            .associate { (key, value) -> key to convertToAnyCodableValue(value, key) }
+
+    private fun mapPersona(dict: JsonObject): Persona {
+        val name = parseRequired(dict, "name", PERSONA_LABEL, YamlType.STRING)
+        val description =
+            parseOptional(dict, "description", PERSONA_LABEL, YamlType.STRING) ?: ""
+        // Empty ≡ absent everywhere (#914): normalizing here keeps the Swift
+        // patcher's `reparsed == visual` safety net from permanently falling
+        // back on a scenario authored with `secret: ""`. Trim before the check
+        // so this matches the editor boundary's rule (`EditablePersona
+        // .toPersona()`) — a whitespace-only secret would otherwise survive here
+        // but map to null there, rendering a header-only prompt section.
+        val secret = parseOptional(dict, "secret", PERSONA_LABEL, YamlType.STRING)?.trim()
+        return Persona(
+            name = name,
+            description = description,
+            secret = if (secret.isNullOrEmpty()) null else secret,
+        )
+    }
+
+    private fun mapPhase(dict: JsonObject, index: Int): Phase =
+        mapPhase(dict, label = "Phase $index", depth = 0)
+
+    /**
+     * Maps one phase mapping.
+     *
+     * [label] is used in error messages: top-level calls pass `"Phase K"`, and
+     * C2b's nested calls will pass `"Phase K.then[N]"` / `"Phase K.else[N]"` so
+     * the user can locate the offending sub-phase in their YAML. [depth] is `0`
+     * at top level; `>= 1` rejects a nested `conditional` at parse time, which
+     * defends the depth-1 rule before [ScenarioValidator] sees the scenario.
+     *
+     * **[depth] has no non-zero caller yet** — `then:` / `else:` descent is
+     * C2b's `mapBranch`. The parameter and its check are ported now so that
+     * diff adds only the recursion.
+     */
+    private fun mapPhase(dict: JsonObject, label: String, depth: Int): Phase {
+        val phaseType = parsePhaseType(dict, label, depth)
+
+        val prompt = parseOptional(dict, "prompt", label, YamlType.STRING)
+        val template = parseOptional(dict, "template", label, YamlType.STRING)
+        val source = parseOptional(dict, "source", label, YamlType.STRING)
+        val excludeSelf = parseOptional(dict, "exclude_self", label, YamlType.BOOL)
+        val options = parseOptional(dict, "options", label, YamlType.STRING_LIST)
+
+        // speak_each `rounds:` → subRounds (the scenario-level `rounds` is a
+        // different key on a different mapping).
+        val subRounds = parseOptional(dict, "rounds", label, YamlType.INT)
+
+        // Conditional-specific `if:` expression. `then:` / `else:` are C2b.
+        val condition = parseOptional(dict, "if", label, YamlType.STRING)
+
+        // event_inject-specific fields. `probability` accepts an integral scalar
+        // so the boundary literals `0` / `1` round-trip naturally; `as:` names
+        // the variable the handler writes.
+        val probability = parseOptionalDoubleAcceptingInt(dict, "probability", label)
+        val eventVariable = parseOptional(dict, "as", label, YamlType.STRING)
+        // Draw-without-replacement opt-in (#1006). Generic Bool path like
+        // `exclude_self`; no validation needed — a bool is always well-formed.
+        val noRepeat = parseOptional(dict, "no_repeat", label, YamlType.BOOL)
+
+        // relationship_update-specific (#910). YAML-only — no visual editing UI
+        // in v1 — but it round-trips through the editor's dual buffer.
+        val voteAgainst = parseOptional(dict, "vote_against", label, YamlType.INT)
+
+        // Per-phase statement brevity override (#881). The 1..6 range is
+        // ScenarioValidator's, not the loader's — `load` stays non-validating.
+        val maxSentences = parseOptional(dict, "max_sentences", label, YamlType.INT)
+
+        // narrate-specific (#909): a short voice/persona descriptor for the
+        // commentator. Absent falls back to the Engine-owned default template.
+        val narrator = parseOptional(dict, "narrator", label, YamlType.STRING)
+
+        // Every argument is named and present, including the seven this port
+        // does not map yet, so C2b's diff lands exactly on the gap rather than
+        // adding lines around it.
+        return Phase(
+            type = phaseType,
+            prompt = prompt,
+            outputSchema = null, // C2b
+            options = options,
+            pairing = null, // C2b
+            logic = null, // C2b
+            template = template,
+            source = source,
+            target = null, // C2b
+            excludeSelf = excludeSelf,
+            subRounds = subRounds,
+            maxSentences = maxSentences,
+            condition = condition,
+            thenPhases = null, // C2b
+            elsePhases = null, // C2b
+            probability = probability,
+            eventVariable = eventVariable,
+            voteAgainst = voteAgainst,
+            actionDeltas = null, // C2b
+            noRepeat = noRepeat,
+            narrator = narrator,
+            payoff = null, // C2b
+        )
+    }
+
+    /**
+     * Resolves the `type:` key against [PhaseType]'s `@SerialName` values.
+     *
+     * A missing key and a non-string one deliberately collapse to the same
+     * [ScenarioValidationMessage.PhaseMissingType], mirroring the Swift
+     * original's single `guard let … as? String` — the loader's only place where
+     * missing and wrong-type are *not* distinguished.
+     */
+    private fun parsePhaseType(dict: JsonObject, label: String, depth: Int): PhaseType {
+        val typeString = YamlType.STRING.cast(dict["type"] ?: JsonNull)
+            ?: throw validationError(ScenarioValidationMessage.PhaseMissingType(label))
+        val phaseType = PHASE_TYPES_BY_YAML_NAME[typeString]
+            ?: throw validationError(
+                ScenarioValidationMessage.PhaseInvalidType(label = label, value = typeString),
+            )
+        if (phaseType == PhaseType.CONDITIONAL && depth > 0) {
+            throw validationError(ScenarioValidationMessage.NestedConditionalNotAllowed(label))
+        }
+        return phaseType
+    }
+
+    /**
+     * Converts a raw YAML value to an [AnyCodableValue], throwing on an
+     * unsupported shape rather than dropping the field or coercing it into a
+     * surprising string. [AnyCodableValue] is String-leaf; a curator wanting a
+     * numeric top-level scalar quotes it (`count: "42"`).
+     *
+     * Shape order mirrors Swift's cast ladder, and the first rung is
+     * load-bearing for the empty case: Swift's `arr as? [[String: String]]`
+     * succeeds on `[]`, so an empty list becomes
+     * [AnyCodableValue.ArrayOfDictionariesValue], not [AnyCodableValue.ArrayValue].
+     * The vacuous `all` below reproduces that.
+     */
+    private fun convertToAnyCodableValue(value: JsonElement, key: String): AnyCodableValue {
+        if (value is JsonPrimitive && value !is JsonNull && value.isString) {
+            return AnyCodableValue.StringValue(value.content)
+        }
+        if (value is JsonArray) {
+            if (value.all { it is JsonObject }) {
+                val rows = value.map { element ->
+                    val row = element as JsonObject
+                    row.entries.associate { (rowKey, rowValue) ->
+                        rowKey to (
+                            rowValue.stringContentOrNull()
+                                // Array of dicts where a value is not a String —
+                                // this used to stringify silently, hiding typos
+                                // like `majority: 1`.
+                                ?: throw validationError(
+                                    ScenarioValidationMessage
+                                        .ExtraDataArrayOfDictNotString(key),
+                                )
+                            )
+                    }
+                }
+                return AnyCodableValue.ArrayOfDictionariesValue(rows)
+            }
+            val strings = value.map { it.stringContentOrNull() }
+            if (strings.all { it != null }) {
+                return AnyCodableValue.ArrayValue(strings.filterNotNull())
+            }
+            throw validationError(ScenarioValidationMessage.ExtraDataMixedArray(key))
+        }
+        if (value is JsonObject) {
+            return AnyCodableValue.DictionaryValue(
+                value.entries.associate { (entryKey, entryValue) ->
+                    entryKey to (
+                        entryValue.stringContentOrNull()
+                            ?: throw validationError(
+                                ScenarioValidationMessage.ExtraDataDictNotString(key),
+                            )
+                        )
+                },
+            )
+        }
+        throw validationError(
+            ScenarioValidationMessage.ExtraDataUnsupportedType(
+                key = key,
+                got = renderActualType(value),
+                shapes = SUPPORTED_EXTRA_DATA_SHAPES,
+            ),
+        )
+    }
+
+    private fun acceptedLanguagesList(): String =
+        Scenario.ACCEPTED_LANGUAGES.sorted().joinToString(", ")
+
+    private companion object {
+        private const val SCENARIO_LABEL = "Scenario"
+        private const val PERSONA_LABEL = "Persona"
+
+        /** Byte-identical to the Swift original's `supportedExtraDataShapes`. */
+        private const val SUPPORTED_EXTRA_DATA_SHAPES =
+            "String, [String], [String: String], or [[String: String]]"
+
+        /** Top-level keys mapped onto [Scenario] rather than collected as extra data. */
+        private val STANDARD_KEYS: Set<String> = setOf(
+            "id", "name", "description", "language", "simulation_language",
+            "agents", "rounds", "context", "personas", "phases", "log_window",
+        )
+
+        private val PHASE_TYPES_BY_YAML_NAME: Map<String, PhaseType> =
+            serialNameLookup(PhaseType.serializer(), PhaseType.entries)
+    }
+}
+
+/**
+ * A YAML value shape the loader accepts, pairing the name it renders in an
+ * `expected:` fragment with the cast that produces it.
+ *
+ * One type per Swift generic argument the loader instantiates `parseRequired` /
+ * `parseOptional` with. `cast` returns `null` for "not this shape" and lets the
+ * caller build the error, so the missing-vs-wrong-type distinction stays in one
+ * place.
+ *
+ * `internal`, like every helper here: only [ScenarioLoader.load] is `public`, so
+ * no `kotlinx.serialization` type reaches the exported Obj-C header.
+ */
+internal class YamlType<T> private constructor(
+    /** The `expected:` fragment, mirroring Swift's `String(describing: T.self)`. */
+    val rendered: String,
+    /** Returns the typed value, or `null` when [element] is a different shape. */
+    val cast: (JsonElement) -> T?,
+) {
+    internal companion object {
+        val STRING: YamlType<String> = YamlType("String") { it.stringContentOrNull() }
+
+        /**
+         * A **32-bit** integral scalar. A value that parses as a `Long` but falls
+         * outside `Int` range casts to `null` and therefore throws — Swift's
+         * `Int` is 64-bit and accepts it, but truncating here would run a
+         * different scenario than the author wrote. [renderActualType] renders
+         * such a value `Int64` so the resulting message is not the bewildering
+         * "must be Int, got Int".
+         */
+        val INT: YamlType<Int> = YamlType("Int") { element ->
+            (element as? JsonPrimitive)
+                ?.takeIf { it !is JsonNull && !it.isString && !it.isYamlBooleanLiteral() }
+                ?.content
+                ?.toLongOrNull()
+                ?.takeIf { it in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong() }
+                ?.toInt()
+        }
+
+        /**
+         * A boolean, including the YAML 1.1 tokens snakeyaml-engine's 1.2 core
+         * schema leaves as strings. See the class KDoc of [ScenarioLoader],
+         * divergence 2, for why the token set stops where it does.
+         */
+        val BOOL: YamlType<Boolean> = YamlType("Bool") { element ->
+            val primitive = (element as? JsonPrimitive)?.takeIf { it !is JsonNull }
+            when {
+                primitive == null -> null
+                primitive.isString -> YAML_11_BOOLEAN_TOKENS[primitive.content]
+                else -> primitive.content.toBooleanStrictOrNull()
+            }
+        }
+
+        /**
+         * A list of strings — **whole-collection** semantics, matching Swift's
+         * `as? [String]`: one non-string element fails the entire cast, so the
+         * error names the list's key rather than the offending element's.
+         */
+        val STRING_LIST: YamlType<List<String>> = YamlType("Array<String>") { element ->
+            (element as? JsonArray)
+                ?.map { it.stringContentOrNull() }
+                ?.takeIf { values -> values.all { it != null } }
+                ?.filterNotNull()
+        }
+
+        /**
+         * A list of mappings — whole-collection semantics like [STRING_LIST].
+         * One non-mapping element makes `personas:` / `phases:` wrong-typed as a
+         * whole, exactly as Swift's `as? [[String: Any]]` does.
+         */
+        val OBJECT_LIST: YamlType<List<JsonObject>> =
+            YamlType("Array<Dictionary<String, Any>>") { element ->
+                (element as? JsonArray)
+                    ?.takeIf { list -> list.all { it is JsonObject } }
+                    ?.map { it as JsonObject }
+            }
+
+        /**
+         * The YAML 1.1 boolean tokens re-accepted loader-locally. `y` / `n` are
+         * deliberately absent — both engines already agree they are strings.
+         */
+        private val YAML_11_BOOLEAN_TOKENS: Map<String, Boolean> = mapOf(
+            "yes" to true, "Yes" to true, "YES" to true,
+            "on" to true, "On" to true, "ON" to true,
+            "no" to false, "No" to false, "NO" to false,
+            "off" to false, "Off" to false, "OFF" to false,
+        )
+    }
+}
+
+/**
+ * Builds a `@SerialName` → enum-entry lookup from [serializer]'s descriptor.
+ *
+ * Kotlin enums carry their YAML spelling **only** as `@SerialName` — there is no
+ * `rawValue` to reverse the way Swift's `PhaseType(rawValue:)` does. Deriving the
+ * table from the descriptor rather than hand-writing a `when` keeps it
+ * mechanically tied to the annotation, so a renamed or newly added case cannot
+ * drift out of the loader (`.claude/rules/engine.md` § "Kotlin enum mirror" — the
+ * mirrors that no compiler catches). Same source and same reasoning as the
+ * forward direction, `PhaseType.serialName()` in `PhaseDispatcher.kt`; this is
+ * generic because C2b needs it for three more enums, none of which has a
+ * `serialName()` extension.
+ *
+ * [entries] must be the enum's `entries` list: an enum serial descriptor names
+ * its elements in declaration order, so index *i* is `entries[i]`. The
+ * [require] guards the one way that could stop being true.
+ *
+ * Reused by C2b for `target:` / `pairing:` / `logic:`.
+ */
+internal fun <T : Enum<T>> serialNameLookup(
+    serializer: KSerializer<T>,
+    entries: List<T>,
+): Map<String, T> {
+    val descriptor = serializer.descriptor
+    require(descriptor.elementsCount == entries.size) {
+        "${descriptor.serialName}: descriptor has ${descriptor.elementsCount} elements " +
+            "but the enum has ${entries.size} entries"
+    }
+    return entries.indices.associate { index -> descriptor.getElementName(index) to entries[index] }
+}
+
+/**
+ * Renders the `got:` fragment for [element].
+ *
+ * The **single** place a decoded YAML value becomes a type name, so the loader's
+ * whole error vocabulary moves together. It targets Swift's
+ * `String(describing: type(of:))` output over the Yams-bridged values, and
+ * reaches it for every shape but two:
+ *
+ * - an explicit `null` renders `Null` here and `NSNull` in Swift;
+ * - an integral scalar outside 32-bit range renders `Int64` here, where Swift
+ *   simply says `Int` and accepts the value.
+ *
+ * Both are message text only, and message text from a *rejected* scenario, which
+ * is why this is documented rather than ledgered (see the class KDoc of
+ * [ScenarioLoader]).
+ */
+internal fun renderActualType(element: JsonElement): String = when (element) {
+    is JsonNull -> "Null"
+    is JsonObject -> "Dictionary<String, Any>"
+    is JsonArray -> "Array<Any>"
+    is JsonPrimitive -> when {
+        element.isString -> "String"
+        element.isYamlBooleanLiteral() -> "Bool"
+        element.content.toLongOrNull()
+            ?.let { it in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong() } == true -> "Int"
+        element.content.toLongOrNull() != null -> "Int64"
+        element.content.toDoubleOrNull() != null -> "Double"
+        // Unreachable for snakeyaml output — an unquoted scalar it could not
+        // resolve arrives as a string primitive, caught by the first branch.
+        else -> "String"
+    }
+}
+
+/**
+ * The value of a **quoted-or-plain YAML string** scalar, or `null` for every
+ * other shape.
+ *
+ * `isString` is the quoted/plain fidelity both engines preserve: a plain `3`
+ * arrives as a non-string primitive and fails this, matching Swift's `as? String`
+ * on the `Int` Yams bridges it to. Guarding on it is not optional —
+ * `JsonPrimitive.content` is defined for numbers and booleans too, so omitting
+ * the check would re-introduce exactly the silent coercion of #130.
+ */
+private fun JsonElement.stringContentOrNull(): String? =
+    (this as? JsonPrimitive)?.takeIf { it !is JsonNull && it.isString }?.content
+
+/**
+ * Whether this primitive is an unquoted `true` / `false`.
+ *
+ * Kotlin's `booleanOrNull` ignores `isString`, so it would report a **quoted**
+ * `"true"` as a boolean; this is the `isString`-aware form the loader needs to
+ * keep `exclude_self: "true"` a type error.
+ */
+private fun JsonPrimitive.isYamlBooleanLiteral(): Boolean =
+    !isString && (content == "true" || content == "false")
+
+/**
+ * Wraps a [ScenarioValidationMessage] in
+ * [SimulationError.ScenarioValidationFailed], rendering it at the Models layer so
+ * the loader carries no string formatting of its own.
+ *
+ * File-scope rather than a method, mirroring the Swift original — and
+ * deliberately a *second* declaration of this name in `com.pastura.engine`:
+ * `ScenarioValidator.kt` has its own file-private one, exactly as the two Swift
+ * files do. See the class KDoc of [ScenarioLoader].
+ */
+private fun validationError(message: ScenarioValidationMessage): SimulationException =
+    SimulationException(SimulationError.ScenarioValidationFailed(message.render()))

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/ScenarioLoader.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/ScenarioLoader.kt
@@ -47,8 +47,12 @@ import kotlinx.serialization.json.JsonPrimitive
  *
  * `ScenarioLoaderTests.phaseSpecialisationIsStillUnmapped` pins that list from
  * the test side and is written to go **red** the moment any of the seven starts
- * being mapped, so this section cannot outlive the gap it describes. Delete
- * both together.
+ * being mapped, so this section cannot outlive the gap it describes. **Three
+ * artefacts describe this gap and must be deleted together**: that pin, this
+ * section, and the "delete the next sentence when C2b lands" paragraph on
+ * `ScenarioLoader.swift`'s `load(yaml:)` — the Swift one is the dangerous
+ * straggler, because a stale "no Kotlin side to mirror yet" tells the next
+ * editor to skip a mirror that by then exists.
  *
  * ## Not wired into the engine
  *
@@ -73,15 +77,18 @@ import kotlinx.serialization.json.JsonPrimitive
  * this loader rejects produces no run and therefore no parity transcript to
  * compare (`DivergenceClass.VALIDATOR_UNPORTED`).
  *
- * 1. **Two YAML-1.1 typed scalars are accepted on one side and rejected on the
- *    other.** Measured on both engines: `12:30:00` (sexagesimal) resolves to
- *    `Int 45000` under Yams and stays a `String` under snakeyaml-engine's YAML
- *    1.2 core schema; `2026-08-26` resolves to a `Date` under Yams and stays a
- *    `String` here. So for a `String`-typed field Swift **rejects** what Kotlin
- *    **accepts**, and for an `Int`-typed field the polarity flips. Deliberately
- *    **not** closed: closing it means regex-sniffing every plain scalar for ISO
- *    dates and sexagesimals, which risks rejecting legitimate curator text, for
- *    an input shape no bundled preset or gallery scenario uses.
+ * 1. **Two YAML-1.1 typed scalars resolve differently.** Measured on both
+ *    engines: `12:30:00` (sexagesimal) resolves to `Int 45000` under Yams and
+ *    stays a `String` under snakeyaml-engine's YAML 1.2 core schema;
+ *    `2026-08-26` resolves to a `Date` under Yams and stays a `String` here.
+ *    The consequences are **not** symmetric, so state them per scalar rather
+ *    than as one rule: in a `String`-typed field both are rejected by Swift and
+ *    accepted here; in an `Int`-typed field `12:30:00` is accepted by Swift and
+ *    rejected here, while `2026-08-26` is rejected by **both** (a `Date` fails
+ *    `as? Int` too) and only the `got:` fragment differs. Deliberately **not**
+ *    closed: closing it means regex-sniffing every plain scalar for ISO dates
+ *    and sexagesimals, which risks rejecting legitimate curator text, for an
+ *    input shape no bundled preset or gallery scenario uses.
  * 2. **YAML-1.1 boolean tokens are re-accepted loader-locally.** `yes` / `no` /
  *    `on` / `off` (and their `Yes` / `YES` case variants) resolve to `Bool`
  *    under Yams and to `String` here, so [YamlType.BOOL] maps that token set
@@ -89,22 +96,45 @@ import kotlinx.serialization.json.JsonPrimitive
  *    both engines already agree they are `String` (libyaml's bool set does not
  *    contain them), so accepting them would open a *new* divergence rather than
  *    close one. This is the loader's decision alone — `YamlCodec`'s YAML 1.2
- *    contract and its `LoadSettings` are untouched. The cost is one narrow
- *    over-acceptance: snakeyaml erases the quoted/plain distinction for these
- *    tokens, so a **quoted** `"yes"` is also read as a boolean here while Swift
- *    keeps it a `String`.
+ *    contract and its `LoadSettings` are untouched.
+ *
+ *    The cost is two over-acceptances, in **opposite** directions, because the
+ *    token map is consulted only by [YamlType.BOOL]:
+ *    - a **quoted** `"yes"` in a `Bool` field reads as a boolean here (snakeyaml
+ *      erases the quoted/plain distinction for a token it resolves to `String`)
+ *      while Swift keeps it a `String` and rejects;
+ *    - a **plain** `yes` in a `String`-typed field — `narrator: no`,
+ *      `options: [yes, no]` — stays a string here and is accepted, while Yams
+ *      hands Swift a `Bool` whose `as? String` / `as? [String]` fails and the
+ *      scenario is rejected. This is the likelier one in real curator YAML.
+ *
+ *    `ScenarioLoaderTests.divergesOnQuotedYesExcludeSelf` pins the first of the
+ *    two, so the behaviour cannot drift without this entry being revisited.
  * 3. **Type-name rendering.** The `expected:` / `got:` fragments come from
  *    [YamlType.rendered] and [renderActualType] — see [renderActualType] for
  *    where they part company with Swift's `String(describing: type(of:))`.
- * 4. **`Int` is 32-bit here and 64-bit in Swift.** An integral scalar outside
- *    `Int.MIN_VALUE..Int.MAX_VALUE` is a [ScenarioValidationMessage.FieldWrongType]
- *    rather than an accepted value. Truncating instead would be worse than a
- *    divergence — it would silently run a different scenario.
+ * 4. **`Int` is 32-bit here and 64-bit in Swift.** An integral scalar inside
+ *    `Long` range but outside `Int.MIN_VALUE..Int.MAX_VALUE` is a
+ *    [ScenarioValidationMessage.FieldWrongType] rather than an accepted value.
+ *    Truncating instead would be worse than a divergence — it would silently run
+ *    a different scenario. **Beyond `Long` range the failure changes shape**:
+ *    `YamlCodec`'s `yamlValueToJson` handles `Int` / `Long` / `Float` / `Double`
+ *    and nothing else, so the value raises `YamlDecodeError.UnsupportedScalar`,
+ *    which [load] folds into
+ *    [ScenarioValidationMessage.InvalidYAMLFormat] — a whole-document rejection
+ *    that names no field, where Swift reports a field-level error.
+ *    `ScenarioLoaderTests.throwsOnIntegerBeyondLongRange` pins that.
  * 5. **Whitespace trimming.** Swift trims `.whitespacesAndNewlines` (a Unicode
  *    character set), Kotlin `trim()` trims `Char.isWhitespace()`. The two
  *    disagree on a handful of exotic code points, so a persona `secret:` padded
  *    with one of them could normalize to `null` on one side only. Same family as
- *    [ScenarioValidator]'s divergence 3.
+ *    [ScenarioValidator]'s divergence 3. [stripCodeFences] is a second trim site
+ *    with a *narrower* Swift set — `.whitespaces`, no `\v` / `\f` / `` —
+ *    so a fence line indented with one of those is stripped here and kept there.
+ * 6. **Which offending key gets reported.** `collectExtraData` throws on the
+ *    first offending key in `JsonObject` insertion order; Swift iterates a
+ *    `Dictionary`, whose order is unspecified. Both reject the same scenarios;
+ *    only the key named in the message can differ.
  *
  * ## `validationError` is re-declared here on purpose
  *
@@ -158,7 +188,7 @@ public class ScenarioLoader {
         // while telling the curator nothing they can act on.
         val root: JsonElement = try {
             YamlCodec.default().decode(stripped)
-        } catch (error: YamlDecodeError) {
+        } catch (@Suppress("SwallowedException") ignored: YamlDecodeError) {
             throw validationError(ScenarioValidationMessage.InvalidYAMLFormat)
         }
         val dict = root as? JsonObject
@@ -660,6 +690,12 @@ internal fun <T : Enum<T>> serialNameLookup(
     entries: List<T>,
 ): Map<String, T> {
     val descriptor = serializer.descriptor
+    // `require` throws IllegalArgumentException, which `load`'s
+    // `@Throws(SimulationException::class)` does not cover — from Swift that
+    // terminates the process rather than raising (`kmp-interop.md` Pattern 5).
+    // Acceptable only because this is a build-time invariant of the enum and its
+    // descriptor, unreachable from any input. Do not widen this helper to a path
+    // where a caller's data can trip it without giving it a checked failure.
     require(descriptor.elementsCount == entries.size) {
         "${descriptor.serialName}: descriptor has ${descriptor.elementsCount} elements " +
             "but the enum has ${entries.size} entries"
@@ -673,14 +709,16 @@ internal fun <T : Enum<T>> serialNameLookup(
  * The **single** place a decoded YAML value becomes a type name, so the loader's
  * whole error vocabulary moves together. It targets Swift's
  * `String(describing: type(of:))` output over the Yams-bridged values, and
- * reaches it for every shape but two:
+ * reaches it for every shape but three:
  *
  * - an explicit `null` renders `Null` here and `NSNull` in Swift;
  * - an integral scalar outside 32-bit range renders `Int64` here, where Swift
- *   simply says `Int` and accepts the value.
+ *   simply says `Int` and accepts the value;
+ * - the two YAML-1.1 typed scalars of the class KDoc's divergence 1 render
+ *   `String` here, where Yams has already bridged them to `Int` / `Date`.
  *
- * Both are message text only, and message text from a *rejected* scenario, which
- * is why this is documented rather than ledgered (see the class KDoc of
+ * All three are message text only, and message text from a *rejected* scenario,
+ * which is why this is documented rather than ledgered (see the class KDoc of
  * [ScenarioLoader]).
  */
 internal fun renderActualType(element: JsonElement): String = when (element) {

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/ScenarioLoaderTestSupport.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/ScenarioLoaderTestSupport.kt
@@ -1,0 +1,97 @@
+package com.pastura.engine
+
+/**
+ * YAML fixture builders for [ScenarioLoaderTests].
+ *
+ * Kotlin counterpart of the private / file-scope helpers on Swift's
+ * `ScenarioLoaderTests.swift` (`makeMinimalYAML()` / `makeMinimalYAML(phasesBlock:)`)
+ * and `ScenarioLoaderTests+Language.swift` (`makeBaseYAML`). Collapsed into one
+ * file, mirroring `ScenarioValidatorTestSupport.kt`'s precedent for this port
+ * series — Swift's `makeYAMLWithAssignTarget` has no port here because none of
+ * the 44 transcribed tests use it (the assign-target suite is deferred).
+ */
+
+/**
+ * A two-persona (Alice / Bob), one-phase (`speak_all`) minimal scenario — the
+ * "happy path" fixture reused across the top-level suite. Self-contained, so
+ * `trimIndent()` is safe here (contrast [makeMinimalYAML] below, which builds
+ * around a caller-supplied block instead).
+ */
+internal fun makeMinimalYAML(): String = """
+    id: test_scenario
+    language: ja
+    name: Test
+    description: A test scenario
+    agents: 2
+    rounds: 3
+    context: You are in a game.
+    personas:
+      - name: Alice
+        description: A strategist
+      - name: Bob
+        description: An optimist
+    phases:
+      - type: speak_all
+        prompt: "Speak your mind."
+        output:
+          statement: string
+          inner_thought: string
+""".trimIndent()
+
+/**
+ * A two-persona (A / B) minimal scenario with [phasesBlock] — a caller-supplied
+ * `phases:` block (optionally followed by top-level extra-data keys it
+ * references) — substituted in place of a fixed phase list, for tests
+ * exercising phase-field parsing.
+ *
+ * Built with [buildString] rather than a single `trimIndent()`'d template:
+ * [phasesBlock] arrives already dedented to column 0 (each call site's own
+ * `trimIndent()`'d literal), and re-running `trimIndent()` over the
+ * concatenation would compute a common margin across both halves — which
+ * silently mis-indents whichever side has the smaller natural margin.
+ */
+internal fun makeMinimalYAML(phasesBlock: String): String = buildString {
+    appendLine("id: t")
+    appendLine("language: ja")
+    appendLine("name: T")
+    appendLine("description: T")
+    appendLine("agents: 2")
+    appendLine("rounds: 1")
+    appendLine("context: C")
+    appendLine("personas:")
+    appendLine("  - name: A")
+    appendLine("    description: D")
+    appendLine("  - name: B")
+    appendLine("    description: D")
+    append(phasesBlock)
+}
+
+/**
+ * A minimal scenario whose `language:` / `simulation_language:` lines are
+ * present only when [language] / [simulationLanguage] are non-null — mirrors
+ * Swift's `makeBaseYAML`, which omits the `language:` line entirely so
+ * `rejectsLanguageAbsent` can exercise the missing-field path.
+ */
+internal fun makeBaseYAML(language: String? = null, simulationLanguage: String? = null): String {
+    val lines = mutableListOf("id: t")
+    if (language != null) lines += "language: $language"
+    if (simulationLanguage != null) lines += "simulation_language: $simulationLanguage"
+    lines += listOf(
+        "name: T",
+        "description: T",
+        "agents: 2",
+        "rounds: 1",
+        "context: C",
+        "personas:",
+        "  - name: A",
+        "    description: D",
+        "  - name: B",
+        "    description: D",
+        "phases:",
+        "  - type: speak_all",
+        "    prompt: x",
+        "    output:",
+        "      statement: string",
+    )
+    return lines.joinToString("\n")
+}

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/ScenarioLoaderTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/ScenarioLoaderTests.kt
@@ -11,8 +11,10 @@ import kotlin.test.assertTrue
 /**
  * commonTest sibling of Swift's `ScenarioLoaderTests.swift`,
  * `ScenarioLoaderTests+Language.swift`, and `ScenarioLoaderTests+StrictTypes.swift`
- * (`Pastura/PasturaTests/Engine/`) — 43 of the port's 44 planned 1:1 transcriptions
- * landed; see the note below on the one that did not.
+ * (`Pastura/PasturaTests/Engine/`) — all 44 of the port's planned 1:1
+ * transcriptions are present, though [parsesPhaseSpeakAll] is a *partial* one
+ * (see below). The suite also carries tests beyond those 44: the
+ * "condition-4 sweep additions" region and the C2b gap pin.
  *
  * **Scope.** Only [ScenarioLoader.load]'s YAML-ingest and top-level-mapping
  * behaviour is covered here, matching [ScenarioLoader]'s own class KDoc: the
@@ -25,23 +27,23 @@ import kotlin.test.assertTrue
  * as unmapped "C2b" fields, so a test asserting on any of them cannot pass
  * against today's loader.
  *
- * **`parsesPhaseSpeakAll` is the one planned transcription NOT landed here.**
- * Swift's version asserts `phase.outputSchema?["statement"] == "string"`, and
- * `outputSchema` is exactly the C2b gap above — [ScenarioLoader.mapPhase]
- * passes it through as a hardcoded `null`. Fixing that would mean widening
- * `mapPhase` (adding `parseOutputSchema`), which is out of bounds for a
- * mechanical transcription task; the test belongs with the rest of C2b's
- * `outputSchema` coverage. `loadsMinimalValidScenario` already exercises the
- * same YAML shape (a `speak_all` phase carrying an `output:` block) without
- * asserting on the unmapped field, so the "does an `output:` block break
- * parsing" question stays covered.
+ * **[parsesPhaseSpeakAll] is a *partial* transcription, and the only one.**
+ * Swift's version makes three assertions; its third reads
+ * `phase.outputSchema?["statement"]`, which is exactly the C2b gap above —
+ * [ScenarioLoader.mapPhase] passes `outputSchema` through as a hardcoded
+ * `null`. The two `speak_all` fields this port *does* map are asserted here so
+ * the case is not silently missing from the suite, and the dropped third
+ * assertion is not simply lost: [phaseSpecialisationIsStillUnmapped] asserts
+ * `outputSchema` is `null` for a phase that declares an `output:` block, so C2b
+ * cannot restore Swift's assertion without first reddening that pin. Read the
+ * two together — neither alone is the full Swift case.
  *
  * ## ADR-023 §12 condition-4 perturbation record
  *
  * Each mechanism of
  * `shared/engine/src/commonMain/kotlin/com/pastura/engine/ScenarioLoader.kt` was
  * broken in isolation and the named **dedicated claimant** — a test that detects the
- * break through **its own** assertion — confirmed to redden. **43 mutations**, each
+ * break through **its own** assertion — confirmed to redden. **42 mutations**, each
  * asserted to match its anchor **exactly once** before applying, with the mutated
  * text re-read to confirm it landed (a `replace` that silently no-ops leaves the
  * original behaviour and reads as verified) and the executed-test count asserted
@@ -57,22 +59,26 @@ import kotlin.test.assertTrue
  * is deliberately not wired into the engine (see its class KDoc), so no other
  * suite could redden.
  *
- * **40 of the 43 reddened.** The three that did not are accounted for below the
- * table; one of them is a deliberate negative control.
+ * **42 mutations executed, 39 reddened, 3 green** (one of them the negative
+ * control). The three that stayed green are accounted for below the table. A
+ * 43rd *attempt* — `if (false)` on the `simulation_language` arm — did not
+ * compile (note 3) and was replaced by the polarity flip already in the
+ * table; a non-executing attempt is not evidence and is not counted among the
+ * 42.
  *
  * | Mechanism broken | Mutation | Dedicated claimant | Incidental |
  * |---|---|---|---|
  * | Code-fence strip | `filterNot { … startsWith("```") }` → `filterNot { false }` | [stripsCodeFencesBeforeParsing] | none |
- * | Decode failure → `InvalidYAMLFormat` | the `throw` → `JsonObject(emptyMap())` | [throwsOnInvalidYAML] — assertion **strengthened**, note 1 | none |
- * | Non-mapping root → `InvalidYAMLFormat` | the `?: throw` → `?: JsonObject(emptyMap())` | [throwsOnNonMappingRoot], [throwsOnEmptyDocument] — both **added**, note 1 | none |
+ * | Decode failure → `InvalidYAMLFormat` | the `throw` → `JsonObject(emptyMap())` | [throwsOnInvalidYAML] — assertion **strengthened**, note 1; also [throwsOnIntegerBeyondLongRange] (added post-sweep, C2b/divergence-4 region — same fold, not itself sweep-mutated) | none |
+ * | Non-mapping root → `InvalidYAMLFormat` | the `?: throw` → `?: JsonObject(emptyMap())` | [throwsOnNonMappingRoot], [throwsOnEmptyDocument] — both **added**, note 2 | none |
  * | `parseRequired` missing-key arm | `?: throw …MissingRequiredField` → `?: JsonNull` | [throwsOnMissingRequiredField] — assertion **strengthened**, note 1 | none |
  * | `parseRequired` wrong-type arm | early-return the cast, no throw | [throwsOnWrongTypeForRequiredString], [throwsOnWrongTypeForRequiredInt], [throwsOnWrongTypeForPersonasList], [throwsOnWrongTypeForPersonaName] | none |
  * | `parseOptional` absent-key arm | `?: return null` → `?: JsonNull` | [absentLogWindowIsNil] and 32 others | 32 — every fixture that omits an optional key then throws |
  * | `parseOptional` wrong-type arm | the `throw` dropped | [throwsOnQuotedSubRounds], [throwsOnQuotedExcludeSelf], [throwsOnIntExcludeSelf], [throwsOnMixedTypeOptions], [throwsOnWrongTypeForPersonaSecret], [bareSecretKeyWithNoValueIsATypeError] | 1 |
  * | `probability` quoted/bool guard | `!it.isString && !it.isYamlBooleanLiteral()` dropped | [throwsOnQuotedProbability] — **added**, note 2 | none |
- * | `language` membership | `!in` → `in` | [rejectsLanguageInvalid] | none |
+ * | `language` membership | `if (…) {` → `if (false) {` | [rejectsLanguageInvalid] | none |
  * | `simulation_language` membership | `!in` → `in` (not `if (false)`; see note 3) | [rejectsSimulationLanguageInvalid] | 1 — [parsesSimulationLanguageEn] |
- * | persona count matches `agents` | `!=` → `==` | [throwsOnAgentCountMismatch] | none |
+ * | persona count matches `agents` | `if (…) {` → `if (false) {` | [throwsOnAgentCountMismatch] | none |
  * | `STANDARD_KEYS` extra-data filter | `filterNot { it.key in STANDARD_KEYS }` → `filterNot { false }` | [parsesExtraDataStringArray] and 24 others | 24 — every fixture then routes `id` etc. through `convertToAnyCodableValue` |
  * | persona `secret` trim | `?.trim()` dropped | [trimsSurroundingWhitespaceFromPersonaSecret], [normalizesEmptyPersonaSecretToNil] | none |
  * | persona `secret` empty→null | `if (secret.isNullOrEmpty()) null else secret` → `secret` | [normalizesEmptyPersonaSecretToNil] | none |
@@ -103,19 +109,25 @@ import kotlin.test.assertTrue
  * | Phase wiring: `source` | read → `null` | [parsesEventInjectFullSpec], [parsesEventInjectMinimalSpec], [phaseSpecialisationIsStillUnmapped] | none |
  * | Phase wiring: `if` → `condition` | read → `null` | [phaseSpecialisationIsStillUnmapped] | none |
  * | Scenario wiring: `log_window` | read → `null` | [parsesLogWindow], [rejectsNonIntLogWindow] | none |
+ * | `YamlType.BOOL` token lookup on a **quoted** token (divergence 2) | *(not sweep-mutated; added post-sweep as a divergence pin)* | [throwsOnQuotedExcludeSelf] pins the rejecting case; [divergesOnQuotedYesExcludeSelf] pins the accepting (divergent) one | none
  * | **NEGATIVE CONTROL** — `acceptedLanguagesList` ordering | `.sorted()` → `.sortedDescending()` | *(none — expected green)* | none |
  *
- * 1. **Three mechanisms were claimed only by a bare "it throws" assertion**, so
+ * 1. **Two mechanisms were claimed only by a bare "it throws" assertion**, so
  *    the mutation moved the failure to a *different* message and the test stayed
- *    green. Common cause: the loader has one exception type, so a type-only
- *    assertion cannot tell its layers apart — the same shape B1's sweep found in
- *    `ScenarioValidator`. Fixed by asserting the rendered message.
- * 2. **Six mechanisms had no claimant at all**, and five of them have none on the
- *    **Swift** side either — nothing in `ScenarioLoaderTests*.swift` drives a
- *    quoted `probability`, a dictionary-valued extra-data key, an extra-data
- *    array mixing mappings and scalars, a `personas:` list holding a scalar, an
- *    absent `type:`, or `no_repeat`. Each gained a test in the
- *    "condition-4 sweep additions" region.
+ *    green: the decode-failure fold ([throwsOnInvalidYAML]) and `parseRequired`'s
+ *    missing-key arm ([throwsOnMissingRequiredField]). Common cause: the loader
+ *    has one exception type, so a type-only assertion cannot tell its layers
+ *    apart — the same shape B1's sweep found in `ScenarioValidator`. Fixed by
+ *    asserting the rendered message.
+ * 2. **Seven mechanisms had no claimant at all** — nothing in
+ *    `ScenarioLoaderTests*.swift` drives a quoted `probability`, a
+ *    dictionary-valued extra-data key, an extra-data array mixing mappings and
+ *    scalars, a `personas:` list holding a scalar, an absent `type:`, `no_repeat`,
+ *    or a non-mapping YAML root (a sequence, or an empty document) either — see
+ *    each addition's own KDoc for the specific gap. Each gained a test in the
+ *    "condition-4 sweep additions" region, except the non-mapping-root pair
+ *    ([throwsOnNonMappingRoot], [throwsOnEmptyDocument]), which sit in the
+ *    "Validation Errors" region next to the mechanism they share a fold with.
  * 3. `if (false)` does **not** compile on the `simulation_language` arm: the
  *    smart cast from the `!= null` half is lost and the later `!!`-free use
  *    fails. The polarity flip is the compiling substitute, and it reddens the
@@ -248,7 +260,11 @@ class ScenarioLoaderTests {
                   statement: string
         """.trimIndent()
         val caught = assertFailsWith<SimulationException> { loader.load(yaml) }
-        assertTrue(caught.error is SimulationError.ScenarioValidationFailed)
+        val error = caught.error
+        assertTrue(error is SimulationError.ScenarioValidationFailed)
+        val msg = error.message
+        assertTrue(msg.contains("'log_window'"))
+        assertTrue(msg.contains("Int"))
     }
 
     @Test
@@ -258,14 +274,6 @@ class ScenarioLoaderTests {
         assertEquals("A strategist", scenario.personas[0].description)
         assertEquals("Bob", scenario.personas[1].name)
     }
-
-    // `parsesPhaseSpeakAll` is deliberately NOT transcribed here — see the
-    // class KDoc's "parsesPhaseSpeakAll is the one planned transcription NOT
-    // landed here" paragraph. Its Swift assertion on `phase.outputSchema` hits
-    // ScenarioLoader.kt's C2b gap (outputSchema is a hardcoded `null` today),
-    // and watering the assertion down to only the fields that do parse would
-    // silently narrow the test's meaning rather than flag the gap — the STOP
-    // RULE calls for removal plus a report, not a weakened stand-in.
 
     // endregion
 
@@ -401,8 +409,14 @@ class ScenarioLoaderTests {
      *
      * Added by the condition-4 sweep: [throwsOnInvalidPhaseType] covers an
      * *unknown* type, but nothing drove an *absent* one, so defaulting the
-     * missing-type throw to `speak_all` left the suite green. The two collapse
-     * to one message by design — see `parsePhaseType`'s KDoc.
+     * missing-type throw to `speak_all` left the suite green. Missing and
+     * invalid do **not** collapse to one message — `parsePhaseType` throws
+     * [com.pastura.models.ScenarioValidationMessage.PhaseMissingType] here and
+     * [com.pastura.models.ScenarioValidationMessage.PhaseInvalidType] for
+     * [throwsOnInvalidPhaseType], and this test's own assertion proves they
+     * differ. What *does* collapse is missing-vs-**wrong-type**: `type: 42`
+     * (a non-String value) also renders `PhaseMissingType`, per
+     * `parsePhaseType`'s KDoc — and no test in this suite claims that arm.
      */
     @Test
     fun throwsOnMissingPhaseType() {
@@ -438,7 +452,11 @@ class ScenarioLoaderTests {
                 prompt: "Go"
         """.trimIndent()
         val caught = assertFailsWith<SimulationException> { loader.load(yaml) }
-        assertTrue(caught.error is SimulationError.ScenarioValidationFailed)
+        val error = caught.error
+        assertTrue(error is SimulationError.ScenarioValidationFailed)
+        val msg = error.message
+        assertTrue(msg.contains("invalid type"))
+        assertTrue(msg.contains("'invalid_type'"))
     }
 
     @Test
@@ -461,7 +479,11 @@ class ScenarioLoaderTests {
                 prompt: "Go"
         """.trimIndent()
         val caught = assertFailsWith<SimulationException> { loader.load(yaml) }
-        assertTrue(caught.error is SimulationError.ScenarioValidationFailed)
+        val error = caught.error
+        assertTrue(error is SimulationError.ScenarioValidationFailed)
+        val msg = error.message
+        assertTrue(msg.contains("agents (5)"))
+        assertTrue(msg.contains("personas count (2)"))
     }
 
     @Test
@@ -617,8 +639,18 @@ class ScenarioLoaderTests {
 
     @Test
     fun throwsOnProbabilityBoolPretendingToBeInt() {
-        // Bool-as-Int laundering would let `probability: true` pass — guard
-        // against it explicitly so the Int-coercion exception stays narrow.
+        // In Swift this guard is load-bearing: `as? Int` launders a Bool, so
+        // without an explicit Bool check `probability: true` would silently
+        // pass. In Kotlin it is not — the condition-4 sweep found that
+        // deleting `!it.isYamlBooleanLiteral()` from
+        // `parseOptionalDoubleAcceptingInt` leaves `"true".toDoubleOrNull() ==
+        // null`, so this fixture still throws either way and no input here
+        // can distinguish the guard's presence from its absence. Kept for
+        // parity with the Swift transcription and because a no-op guard is
+        // still correct, not because it detects anything on this side.
+        // (`YamlType.INT`'s copy of the same `!it.isYamlBooleanLiteral()`
+        // guard is redundant for the identical reason; its `!it.isString`
+        // sibling is not — see [throwsOnQuotedSubRounds].)
         val yaml = makeMinimalYAML(
             """
                 phases:
@@ -876,7 +908,7 @@ class ScenarioLoaderTests {
                   - type: speak_all
                     prompt: "Go"
             """.trimIndent()
-            assertNull(loader.load(yaml).personas[0].secret)
+            assertNull(loader.load(yaml).personas[0].secret, "authored=$authored")
         }
     }
 
@@ -1023,7 +1055,11 @@ class ScenarioLoaderTests {
             """.trimIndent(),
         )
         val caught = assertFailsWith<SimulationException> { loader.load(yaml) }
-        assertTrue(caught.error is SimulationError.ScenarioValidationFailed)
+        val error = caught.error
+        assertTrue(error is SimulationError.ScenarioValidationFailed)
+        val msg = error.message
+        assertTrue(msg.contains("'exclude_self'"))
+        assertTrue(msg.contains("Bool"))
     }
 
     /** YAML 1.1 treats bare `yes`/`no`/`on`/`off` as booleans. This loader
@@ -1200,11 +1236,16 @@ class ScenarioLoaderTests {
     /*
      * Every test in this region was added because the ADR-023 §12 condition-4
      * sweep broke the mechanism it names and the suite stayed green — no
-     * transcribed Swift case reached it. Three of them (the `probability`
-     * quoted-scalar guard, the dictionary-valued extra-data guard, and the
-     * absent-`type:` throw, above) have no dedicated claimant on the **Swift**
-     * side either; the rest cover Kotlin-only mechanisms the port introduced.
-     * The sweep's full table is in the #501 record for #1558.
+     * transcribed Swift case reached it. Only [throwsOnIntegerBeyond32Bits]
+     * (and, added separately below in the C2b gap / divergence-4 region,
+     * `throwsOnIntegerBeyondLongRange`) cover Kotlin-only mechanisms with no
+     * Swift twin to transcribe. The rest — [throwsOnQuotedProbability],
+     * [throwsOnExtraDataArrayMixingDictAndScalar],
+     * [throwsOnPersonasListWithScalarElement], and [parsesNoRepeat] — cover
+     * mechanisms Swift shares and equally lacks a dedicated claimant for; the
+     * absent-`type:` throw ([throwsOnMissingPhaseType], in a different
+     * region above) is the same case. The sweep's full table is in the #501
+     * record for #1558.
      */
 
     /**
@@ -1256,6 +1297,7 @@ class ScenarioLoaderTests {
         val error = caught.error
         assertTrue(error is SimulationError.ScenarioValidationFailed)
         assertTrue(error.message.contains("'rules'"))
+        assertTrue(error.message.contains("mixed-type arrays are not supported"))
     }
 
     /**
@@ -1278,6 +1320,7 @@ class ScenarioLoaderTests {
         assertTrue(error is SimulationError.ScenarioValidationFailed)
         assertTrue(error.message.contains("'config'"))
         assertTrue(error.message.contains("String"))
+        assertTrue(error.message.contains("dictionary values must all be String"))
     }
 
     /**
@@ -1364,6 +1407,73 @@ class ScenarioLoaderTests {
 
     // endregion
 
+    // region Divergence pins (class KDoc divergences 2 and 4)
+
+    /**
+     * An integral scalar beyond even `Long` range.
+     *
+     * Referenced by name in [ScenarioLoader]'s class KDoc, divergence 4:
+     * `YamlCodec`'s `yamlValueToJson` handles `Int` / `Long` / `Float` / `Double`
+     * only, so a value outside all four raises `YamlDecodeError.UnsupportedScalar`,
+     * which [ScenarioLoader.load] folds into
+     * [com.pastura.models.ScenarioValidationMessage.InvalidYAMLFormat] — a
+     * whole-document rejection naming no field, unlike
+     * [throwsOnIntegerBeyond32Bits]'s field-level [FieldWrongType]-shaped message.
+     * Swift's `Int` is 64-bit and has no failure mode at this magnitude at all, so
+     * this has no Swift twin either.
+     */
+    @Test
+    fun throwsOnIntegerBeyondLongRange() {
+        val yaml = """
+            id: t
+            language: ja
+            name: T
+            description: T
+            agents: 9223372036854775808
+            rounds: 1
+            context: C
+            personas:
+              - name: A
+                description: A
+            phases:
+              - type: speak_all
+                prompt: "Speak"
+        """.trimIndent()
+        val caught = assertFailsWith<SimulationException> { loader.load(yaml) }
+        val error = caught.error
+        assertTrue(error is SimulationError.ScenarioValidationFailed)
+        assertTrue(error.message.contains("Invalid YAML format"))
+    }
+
+    /**
+     * **Divergence pin, not desirable behaviour.** Pins [ScenarioLoader]'s class
+     * KDoc divergence 2's over-acceptance: a **quoted** `exclude_self: "yes"`
+     * parses to `true` here, because [YamlType.BOOL] routes every `isString`
+     * primitive through `YAML_11_BOOLEAN_TOKENS` without checking whether the
+     * source token was quoted, and snakeyaml gives bare `yes` and quoted `"yes"`
+     * the same `isString == true`. Yams keeps a quoted `"yes"` a `String` and
+     * Swift rejects it. [throwsOnQuotedExcludeSelf] only drives `"true"`, a token
+     * outside [YamlType.BOOL]'s YAML-1.1 token map, so nothing previously pinned
+     * this input. A future fix that closes divergence 2 should make this test
+     * go red — that is the point of writing it as a pin rather than silently
+     * leaving the gap undetected.
+     */
+    @Test
+    fun divergesOnQuotedYesExcludeSelf() {
+        val yaml = makeMinimalYAML(
+            """
+                phases:
+                  - type: vote
+                    prompt: "Vote"
+                    exclude_self: "yes"
+            """.trimIndent(),
+        )
+        val scenario = loader.load(yaml)
+        assertEquals(true, scenario.phases[0].excludeSelf)
+    }
+
+    // endregion
+
     // region C2b gap pin
 
     /**
@@ -1379,9 +1489,16 @@ class ScenarioLoaderTests {
      * after the gap closed would be the coverage theater
      * `.claude/rules/kmp-interop.md` Pattern 4 warns about.
      *
-     * The `assertEquals(5, …)` guards the pin's own reachability: if a future
-     * edit made `load` reject this fixture outright, every `assertNull` below
-     * would become vacuous rather than failing.
+     * The `assertEquals(5, …)` does **not** guard against a `load` that rejects
+     * this fixture outright — a rejection throws out of `loader.load` and this
+     * test fails right there, at the `loader.load(yaml)` call, before any
+     * `assertNull` runs. What it actually guards is a `load` that *succeeds*
+     * but silently returns a shorter or empty phase list: without the size
+     * check, a five-`assertNull` pin against a zero-or-short `phases` list
+     * would go vacuous (an out-of-bounds index throws `IndexOutOfBounds`,
+     * which itself would fail the test — but only accidentally, and a
+     * `phases` list padded with unrelated phases at the checked indices would
+     * not even do that).
      *
      * **Delete this whole region in C2b**, together with the KDoc section it
      * names.
@@ -1433,6 +1550,8 @@ class ScenarioLoaderTests {
         // empty phase would fail here rather than passing the assertNulls.
         assertEquals("Choose", phases[0].prompt)
         assertEquals("words", phases[1].source)
+        assertEquals(PhaseType.SCORE_CALC, phases[2].type)
+        assertEquals(PhaseType.RELATIONSHIP_UPDATE, phases[3].type)
         assertEquals("round == 1", phases[4].condition)
     }
 

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/ScenarioLoaderTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/ScenarioLoaderTests.kt
@@ -75,6 +75,23 @@ class ScenarioLoaderTests {
         assertEquals(1, scenario.phases.size)
     }
 
+    /**
+     * Swift's `parsesPhaseSpeakAll`, minus its third assertion.
+     *
+     * Swift also reads `phase.outputSchema?["statement"]`; `output:` is one of
+     * the seven C2b fields [ScenarioLoader.mapPhase] leaves `null`, and
+     * [phaseSpecialisationIsStillUnmapped] is what pins that gap until C2b
+     * closes it. The two `speak_all` fields this port *does* map are asserted
+     * here so the case is not silently absent from the suite in the meantime.
+     */
+    @Test
+    fun parsesPhaseSpeakAll() {
+        val scenario = loader.load(makeMinimalYAML())
+        val phase = scenario.phases[0]
+        assertEquals(PhaseType.SPEAK_ALL, phase.type)
+        assertEquals("Speak your mind.", phase.prompt)
+    }
+
     // endregion
 
     // region log_window (#907)
@@ -1015,6 +1032,80 @@ class ScenarioLoaderTests {
         val error = caught.error
         assertTrue(error is SimulationError.ScenarioValidationFailed)
         assertTrue(error.message.contains("'options'"))
+    }
+
+    // endregion
+
+    // region C2b gap pin
+
+    /**
+     * Pins the seven phase fields this port deliberately leaves unmapped.
+     *
+     * The YAML below populates every one of them, and every assertion says
+     * `null`. That inverts the usual polarity on purpose: the test is **not**
+     * asserting correct behaviour — it is asserting a known-incomplete state,
+     * so that the moment C2b teaches [ScenarioLoader.mapPhase] to read any of
+     * these keys, this test goes red and forces both itself and the
+     * `PORT IN PROGRESS` section of [ScenarioLoader]'s class KDoc to be
+     * deleted. A pin that self-destructs is the point; one that stayed green
+     * after the gap closed would be the coverage theater
+     * `.claude/rules/kmp-interop.md` Pattern 4 warns about.
+     *
+     * The `assertEquals(5, …)` guards the pin's own reachability: if a future
+     * edit made `load` reject this fixture outright, every `assertNull` below
+     * would become vacuous rather than failing.
+     *
+     * **Delete this whole region in C2b**, together with the KDoc section it
+     * names.
+     */
+    @Test
+    fun phaseSpecialisationIsStillUnmapped() {
+        val yaml = makeMinimalYAML(
+            """
+                phases:
+                  - type: choose
+                    prompt: "Choose"
+                    output:
+                      action: string
+                    pairing: round_robin
+                  - type: assign
+                    source: words
+                    target: random_one
+                  - type: score_calc
+                    logic: pairwise_payoff
+                    payoff:
+                      - when: [cooperate, cooperate]
+                        points: [3, 3]
+                  - type: relationship_update
+                    action_deltas:
+                      betray: -2
+                  - type: conditional
+                    if: "round == 1"
+                    then:
+                      - type: speak_all
+                        prompt: "Hi"
+                    else:
+                      - type: eliminate
+            """.trimIndent(),
+        )
+        val phases = loader.load(yaml).phases
+        assertEquals(5, phases.size)
+
+        assertNull(phases[0].outputSchema, "output: is C2b")
+        assertNull(phases[0].pairing, "pairing: is C2b")
+        assertNull(phases[1].target, "target: is C2b")
+        assertNull(phases[2].logic, "logic: is C2b")
+        assertNull(phases[2].payoff, "payoff: is C2b")
+        assertNull(phases[3].actionDeltas, "action_deltas: is C2b")
+        assertNull(phases[4].thenPhases, "then: is C2b")
+        assertNull(phases[4].elsePhases, "else: is C2b")
+
+        // The C2a-mapped fields on the same phases DO land — this half of the
+        // pin is a positive control, so a `load` that silently returned an
+        // empty phase would fail here rather than passing the assertNulls.
+        assertEquals("Choose", phases[0].prompt)
+        assertEquals("words", phases[1].source)
+        assertEquals("round == 1", phases[4].condition)
     }
 
     // endregion

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/ScenarioLoaderTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/ScenarioLoaderTests.kt
@@ -1,0 +1,1021 @@
+package com.pastura.engine
+
+import com.pastura.models.PhaseType
+import com.pastura.models.SimulationError
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * commonTest sibling of Swift's `ScenarioLoaderTests.swift`,
+ * `ScenarioLoaderTests+Language.swift`, and `ScenarioLoaderTests+StrictTypes.swift`
+ * (`Pastura/PasturaTests/Engine/`) — 43 of the port's 44 planned 1:1 transcriptions
+ * landed; see the note below on the one that did not.
+ *
+ * **Scope.** Only [ScenarioLoader.load]'s YAML-ingest and top-level-mapping
+ * behaviour is covered here, matching [ScenarioLoader]'s own class KDoc: the
+ * six `estimateInferenceCount` tests (that estimator landed separately, in
+ * [InferenceEstimator]), `parsesPhaseWithAllFields`, the three
+ * `relationship_update` tests, and the eleven enum / `outputSchema` /
+ * `payoff` arms of `ScenarioLoaderTests+StrictTypes.swift` are deferred to a
+ * follow-up PR — [ScenarioLoader.mapPhase]'s KDoc documents `output`,
+ * `target`, `pairing`, `logic`, `then` / `else`, `action_deltas`, and `payoff`
+ * as unmapped "C2b" fields, so a test asserting on any of them cannot pass
+ * against today's loader.
+ *
+ * **`parsesPhaseSpeakAll` is the one planned transcription NOT landed here.**
+ * Swift's version asserts `phase.outputSchema?["statement"] == "string"`, and
+ * `outputSchema` is exactly the C2b gap above — [ScenarioLoader.mapPhase]
+ * passes it through as a hardcoded `null`. Fixing that would mean widening
+ * `mapPhase` (adding `parseOutputSchema`), which is out of bounds for a
+ * mechanical transcription task; the test belongs with the rest of C2b's
+ * `outputSchema` coverage. `loadsMinimalValidScenario` already exercises the
+ * same YAML shape (a `speak_all` phase carrying an `output:` block) without
+ * asserting on the unmapped field, so the "does an `output:` block break
+ * parsing" question stays covered.
+ */
+class ScenarioLoaderTests {
+
+    private val loader = ScenarioLoader()
+
+    // region Valid Scenario Loading
+
+    @Test
+    fun loadsMinimalValidScenario() {
+        val yaml = """
+            id: test_scenario
+            language: ja
+            name: Test
+            description: A test scenario
+            agents: 2
+            rounds: 3
+            context: You are in a game.
+            personas:
+              - name: Alice
+                description: A strategist
+              - name: Bob
+                description: An optimist
+            phases:
+              - type: speak_all
+                prompt: "Speak your mind."
+                output:
+                  statement: string
+                  inner_thought: string
+        """.trimIndent()
+        val scenario = loader.load(yaml)
+        assertEquals("test_scenario", scenario.id)
+        assertEquals("Test", scenario.name)
+        assertEquals("A test scenario", scenario.description)
+        assertEquals(2, scenario.agentCount)
+        assertEquals(3, scenario.rounds)
+        assertEquals("You are in a game.", scenario.context)
+        assertEquals(2, scenario.personas.size)
+        assertEquals(1, scenario.phases.size)
+    }
+
+    // endregion
+
+    // region log_window (#907)
+
+    @Test
+    fun parsesLogWindow() {
+        val yaml = """
+            id: lw_test
+            language: ja
+            name: LW
+            description: log window test
+            agents: 2
+            rounds: 1
+            log_window: 5
+            context: Context
+            personas:
+              - name: Alice
+                description: A
+              - name: Bob
+                description: B
+            phases:
+              - type: speak_all
+                prompt: Go
+                output:
+                  statement: string
+        """.trimIndent()
+        val scenario = loader.load(yaml)
+        assertEquals(5, scenario.logWindow)
+    }
+
+    @Test
+    fun absentLogWindowIsNil() {
+        val scenario = loader.load(makeMinimalYAML())
+        assertNull(scenario.logWindow)
+    }
+
+    @Test
+    fun rejectsNonIntLogWindow() {
+        val yaml = """
+            id: lw_bad
+            language: ja
+            name: LW
+            description: log window test
+            agents: 2
+            rounds: 1
+            log_window: "five"
+            context: Context
+            personas:
+              - name: Alice
+                description: A
+              - name: Bob
+                description: B
+            phases:
+              - type: speak_all
+                prompt: Go
+                output:
+                  statement: string
+        """.trimIndent()
+        val caught = assertFailsWith<SimulationException> { loader.load(yaml) }
+        assertTrue(caught.error is SimulationError.ScenarioValidationFailed)
+    }
+
+    @Test
+    fun parsesPersonasCorrectly() {
+        val scenario = loader.load(makeMinimalYAML())
+        assertEquals("Alice", scenario.personas[0].name)
+        assertEquals("A strategist", scenario.personas[0].description)
+        assertEquals("Bob", scenario.personas[1].name)
+    }
+
+    // `parsesPhaseSpeakAll` is deliberately NOT transcribed here — see the
+    // class KDoc's "parsesPhaseSpeakAll is the one planned transcription NOT
+    // landed here" paragraph. Its Swift assertion on `phase.outputSchema` hits
+    // ScenarioLoader.kt's C2b gap (outputSchema is a hardcoded `null` today),
+    // and watering the assertion down to only the fields that do parse would
+    // silently narrow the test's meaning rather than flag the gap — the STOP
+    // RULE calls for removal plus a report, not a weakened stand-in.
+
+    // endregion
+
+    // region Extra Data
+
+    @Test
+    fun parsesExtraDataStringArray() {
+        val yaml = """
+            id: test
+            language: ja
+            name: Test
+            description: Test
+            agents: 2
+            rounds: 1
+            context: Context
+            personas:
+              - name: A
+                description: A
+              - name: B
+                description: B
+            phases:
+              - type: speak_all
+                prompt: "Go"
+                output:
+                  statement: string
+            topics:
+              - "A cat in a suit"
+              - "A dog driving"
+        """.trimIndent()
+        val scenario = loader.load(yaml)
+        val topics = scenario.extraData["topics"]
+        assertTrue(topics is com.pastura.models.AnyCodableValue.ArrayValue)
+        assertEquals(2, topics.value.size)
+        assertEquals("A cat in a suit", topics.value[0])
+    }
+
+    @Test
+    fun parsesExtraDataArrayOfDictionaries() {
+        val yaml = """
+            id: test
+            language: ja
+            name: Test
+            description: Test
+            agents: 2
+            rounds: 1
+            context: Context
+            personas:
+              - name: A
+                description: A
+              - name: B
+                description: B
+            phases:
+              - type: assign
+                source: words
+                target: random_one
+            words:
+              - majority: りんご
+                minority: みかん
+              - majority: 温泉
+                minority: プール
+        """.trimIndent()
+        val scenario = loader.load(yaml)
+        val words = scenario.extraData["words"]
+        assertTrue(words is com.pastura.models.AnyCodableValue.ArrayOfDictionariesValue)
+        assertEquals(2, words.value.size)
+        assertEquals("りんご", words.value[0]["majority"])
+        assertEquals("みかん", words.value[0]["minority"])
+    }
+
+    // endregion
+
+    // region Code Fence Stripping
+
+    @Test
+    fun stripsCodeFencesBeforeParsing() {
+        val yaml = """
+            ```yaml
+            id: test
+            language: ja
+            name: Test
+            description: Test
+            agents: 2
+            rounds: 1
+            context: Context
+            personas:
+              - name: A
+                description: A
+              - name: B
+                description: B
+            phases:
+              - type: speak_all
+                prompt: "Go"
+                output:
+                  statement: string
+            ```
+        """.trimIndent()
+        val scenario = loader.load(yaml)
+        assertEquals("test", scenario.id)
+    }
+
+    // endregion
+
+    // region Validation Errors
+
+    @Test
+    fun throwsOnMissingRequiredField() {
+        val yaml = """
+            name: Test
+            description: Test
+            agents: 2
+            rounds: 1
+            context: Context
+            personas:
+              - name: A
+                description: A
+              - name: B
+                description: B
+            phases:
+              - type: speak_all
+        """.trimIndent()
+        val caught = assertFailsWith<SimulationException> { loader.load(yaml) }
+        assertTrue(caught.error is SimulationError.ScenarioValidationFailed)
+    }
+
+    @Test
+    fun throwsOnInvalidPhaseType() {
+        val yaml = """
+            id: test
+            language: ja
+            name: Test
+            description: Test
+            agents: 2
+            rounds: 1
+            context: Context
+            personas:
+              - name: A
+                description: A
+              - name: B
+                description: B
+            phases:
+              - type: invalid_type
+                prompt: "Go"
+        """.trimIndent()
+        val caught = assertFailsWith<SimulationException> { loader.load(yaml) }
+        assertTrue(caught.error is SimulationError.ScenarioValidationFailed)
+    }
+
+    @Test
+    fun throwsOnAgentCountMismatch() {
+        val yaml = """
+            id: test
+            language: ja
+            name: Test
+            description: Test
+            agents: 5
+            rounds: 1
+            context: Context
+            personas:
+              - name: A
+                description: A
+              - name: B
+                description: B
+            phases:
+              - type: speak_all
+                prompt: "Go"
+        """.trimIndent()
+        val caught = assertFailsWith<SimulationException> { loader.load(yaml) }
+        assertTrue(caught.error is SimulationError.ScenarioValidationFailed)
+    }
+
+    @Test
+    fun throwsOnInvalidYAML() {
+        val yaml = "{{invalid yaml: [["
+        val caught = assertFailsWith<SimulationException> { loader.load(yaml) }
+        assertTrue(caught.error is SimulationError.ScenarioValidationFailed)
+    }
+
+    // endregion
+
+    // region event_inject phase parsing
+
+    @Test
+    fun parsesEventInjectFullSpec() {
+        val yaml = makeMinimalYAML(
+            """
+                phases:
+                  - type: event_inject
+                    source: random_events
+                    probability: 0.3
+                    as: my_event
+                random_events:
+                  - "停電が起きた"
+                  - "謎の電話"
+            """.trimIndent(),
+        )
+        val scenario = loader.load(yaml)
+        val phase = scenario.phases[0]
+        assertEquals(PhaseType.EVENT_INJECT, phase.type)
+        assertEquals("random_events", phase.source)
+        assertEquals(0.3, phase.probability)
+        assertEquals("my_event", phase.eventVariable)
+    }
+
+    @Test
+    fun parsesEventInjectMinimalSpec() {
+        // Only `source:` is required — probability/as default at the handler.
+        val yaml = makeMinimalYAML(
+            """
+                phases:
+                  - type: event_inject
+                    source: events
+                events:
+                  - "x"
+            """.trimIndent(),
+        )
+        val scenario = loader.load(yaml)
+        val phase = scenario.phases[0]
+        assertEquals(PhaseType.EVENT_INJECT, phase.type)
+        assertEquals("events", phase.source)
+        assertNull(phase.probability)
+        assertNull(phase.eventVariable)
+    }
+
+    @Test
+    fun parsesProbabilityAsIntCoercesToDouble() {
+        // Boundary values `0` and `1` are the most ergonomic in YAML; the
+        // intentional Int -> Double coercion (parseOptionalDoubleAcceptingInt)
+        // accepts both shapes.
+        val yamlOne = makeMinimalYAML(
+            """
+                phases:
+                  - type: event_inject
+                    source: events
+                    probability: 1
+                events:
+                  - "x"
+            """.trimIndent(),
+        )
+        val scenarioOne = loader.load(yamlOne)
+        assertEquals(1.0, scenarioOne.phases[0].probability)
+
+        val yamlZero = makeMinimalYAML(
+            """
+                phases:
+                  - type: event_inject
+                    source: events
+                    probability: 0
+                events:
+                  - "x"
+            """.trimIndent(),
+        )
+        val scenarioZero = loader.load(yamlZero)
+        assertEquals(0.0, scenarioZero.phases[0].probability)
+    }
+
+    @Test
+    fun parsesProbabilityAsDouble() {
+        val yaml = makeMinimalYAML(
+            """
+                phases:
+                  - type: event_inject
+                    source: events
+                    probability: 0.5
+                events:
+                  - "x"
+            """.trimIndent(),
+        )
+        val scenario = loader.load(yaml)
+        assertEquals(0.5, scenario.phases[0].probability)
+    }
+
+    @Test
+    fun throwsOnProbabilityWrongType() {
+        val yaml = makeMinimalYAML(
+            """
+                phases:
+                  - type: event_inject
+                    source: events
+                    probability: "half"
+                events:
+                  - "x"
+            """.trimIndent(),
+        )
+        val caught = assertFailsWith<SimulationException> { loader.load(yaml) }
+        assertTrue(caught.error is SimulationError.ScenarioValidationFailed)
+    }
+
+    @Test
+    fun throwsOnProbabilityBoolPretendingToBeInt() {
+        // Bool-as-Int laundering would let `probability: true` pass — guard
+        // against it explicitly so the Int-coercion exception stays narrow.
+        val yaml = makeMinimalYAML(
+            """
+                phases:
+                  - type: event_inject
+                    source: events
+                    probability: true
+                events:
+                  - "x"
+            """.trimIndent(),
+        )
+        val caught = assertFailsWith<SimulationException> { loader.load(yaml) }
+        assertTrue(caught.error is SimulationError.ScenarioValidationFailed)
+    }
+
+    // endregion
+
+    // region language field (DoD #2, #5, #6)
+
+    @Test
+    fun rejectsLanguageAbsent() {
+        val yaml = makeBaseYAML() // no language: line
+        val caught = assertFailsWith<SimulationException> { loader.load(yaml) }
+        val error = caught.error
+        assertTrue(error is SimulationError.ScenarioValidationFailed)
+        assertTrue(error.message.contains("language"))
+    }
+
+    @Test
+    fun parsesLanguageJa() {
+        val yaml = makeBaseYAML(language = "ja")
+        val scenario = loader.load(yaml)
+        assertEquals("ja", scenario.language)
+    }
+
+    @Test
+    fun parsesLanguageEn() {
+        val yaml = makeBaseYAML(language = "en")
+        val scenario = loader.load(yaml)
+        assertEquals("en", scenario.language)
+    }
+
+    @Test
+    fun rejectsLanguageInvalid() {
+        val yaml = makeBaseYAML(language = "fr")
+        val caught = assertFailsWith<SimulationException> { loader.load(yaml) }
+        val error = caught.error
+        assertTrue(error is SimulationError.ScenarioValidationFailed)
+        assertTrue(error.message.contains("language"))
+        assertTrue(error.message.contains("fr"))
+    }
+
+    @Test
+    fun parsesSimulationLanguageEn() {
+        val yaml = makeBaseYAML(language = "ja", simulationLanguage = "en")
+        val scenario = loader.load(yaml)
+        assertEquals("en", scenario.simulationLanguage)
+    }
+
+    @Test
+    fun simulationLanguageAbsent() {
+        val yaml = makeBaseYAML(language = "ja")
+        val scenario = loader.load(yaml)
+        assertNull(scenario.simulationLanguage)
+    }
+
+    @Test
+    fun rejectsSimulationLanguageInvalid() {
+        val yaml = makeBaseYAML(language = "ja", simulationLanguage = "fr")
+        val caught = assertFailsWith<SimulationException> { loader.load(yaml) }
+        val error = caught.error
+        assertTrue(error is SimulationError.ScenarioValidationFailed)
+        assertTrue(error.message.contains("simulation_language"))
+        assertTrue(error.message.contains("fr"))
+    }
+
+    // endregion
+
+    // region Scenario top-level wrong-type errors
+
+    /** Numeric id (YAML auto-type) previously coerced silently to "42". Strict
+     * loader throws with a wrong-type message distinguishing it from "missing
+     * field" — the prior stringify fallback would have hidden typos like
+     * `id: 001` (YAML 1.1 auto-types to Int 1). */
+    @Test
+    fun throwsOnWrongTypeForRequiredString() {
+        val yaml = """
+            id: 42
+            language: ja
+            name: Test
+            description: Test
+            agents: 2
+            rounds: 1
+            context: Context
+            personas:
+              - name: A
+                description: A
+              - name: B
+                description: B
+            phases:
+              - type: speak_all
+                prompt: "Go"
+        """.trimIndent()
+        val caught = assertFailsWith<SimulationException> { loader.load(yaml) }
+        val error = caught.error
+        assertTrue(error is SimulationError.ScenarioValidationFailed)
+        val msg = error.message
+        assertTrue(msg.contains("'id'"))
+        assertTrue(msg.contains("String"))
+        assertTrue(!msg.lowercase().contains("missing"))
+    }
+
+    /** Quoted integer (`agents: "2"`) previously threw a misleading "Missing
+     * required field" error. Strict loader surfaces the real cause. */
+    @Test
+    fun throwsOnWrongTypeForRequiredInt() {
+        val yaml = """
+            id: test
+            language: ja
+            name: Test
+            description: Test
+            agents: "2"
+            rounds: 1
+            context: Context
+            personas:
+              - name: A
+                description: A
+              - name: B
+                description: B
+            phases:
+              - type: speak_all
+                prompt: "Go"
+        """.trimIndent()
+        val caught = assertFailsWith<SimulationException> { loader.load(yaml) }
+        val error = caught.error
+        assertTrue(error is SimulationError.ScenarioValidationFailed)
+        val msg = error.message
+        assertTrue(msg.contains("'agents'"))
+        assertTrue(msg.contains("Int"))
+        assertTrue(!msg.lowercase().contains("missing"))
+    }
+
+    // endregion
+
+    // region Personas / phases strict (#130 item 1 follow-up)
+
+    /** `personas: "alice"` (scalar instead of list-of-dict) previously threw
+     * with "Missing or invalid field: personas" — strict loader uses the new
+     * helper so missing vs wrong-type produce distinct messages. */
+    @Test
+    fun throwsOnWrongTypeForPersonasList() {
+        val yaml = """
+            id: t
+            language: ja
+            name: T
+            description: T
+            agents: 2
+            rounds: 1
+            context: C
+            personas: "alice"
+            phases:
+              - type: speak_all
+                prompt: "Go"
+        """.trimIndent()
+        val caught = assertFailsWith<SimulationException> { loader.load(yaml) }
+        val error = caught.error
+        assertTrue(error is SimulationError.ScenarioValidationFailed)
+        val msg = error.message
+        assertTrue(msg.contains("'personas'"))
+        assertTrue(!msg.lowercase().contains("missing"))
+    }
+
+    /** Persona with a numeric name (`- name: 42`) previously became a Scenario
+     * whose persona name wasn't the Int the author typed — `as? String` failed
+     * silently at the `mapPersona` boundary. Strict loader throws. */
+    @Test
+    fun throwsOnWrongTypeForPersonaName() {
+        val yaml = """
+            id: t
+            language: ja
+            name: T
+            description: T
+            agents: 2
+            rounds: 1
+            context: C
+            personas:
+              - name: 42
+                description: D
+              - name: B
+                description: D
+            phases:
+              - type: speak_all
+                prompt: "Go"
+        """.trimIndent()
+        val caught = assertFailsWith<SimulationException> { loader.load(yaml) }
+        val error = caught.error
+        assertTrue(error is SimulationError.ScenarioValidationFailed)
+        val msg = error.message
+        assertTrue(msg.contains("'name'"))
+        assertTrue(msg.contains("String"))
+    }
+
+    // endregion
+
+    // region Persona secret (#914)
+
+    @Test
+    fun parsesPersonaSecret() {
+        val yaml = """
+            id: t
+            language: ja
+            name: T
+            description: T
+            agents: 2
+            rounds: 1
+            context: C
+            personas:
+              - name: A
+                description: D
+                secret: You already sold the house.
+              - name: B
+                description: D
+            phases:
+              - type: speak_all
+                prompt: "Go"
+        """.trimIndent()
+        val scenario = loader.load(yaml)
+        assertEquals("You already sold the house.", scenario.personas[0].secret)
+        // Absent key -> nil (backward compatible: existing scenarios are unchanged).
+        assertNull(scenario.personas[1].secret)
+    }
+
+    /** Empty ≡ absent (#914): the loader normalizes an empty — or
+     * whitespace-only — `secret` to nil so a header-only prompt section can
+     * never render, and the patcher's `reparsed == visual` safety-net can't be
+     * pinned to a permanent fallback. Whitespace-only is included so this
+     * matches the editor boundary's trim-then-check rule exactly. */
+    @Test
+    fun normalizesEmptyPersonaSecretToNil() {
+        for (authored in listOf("\"\"", "\"   \"")) {
+            val yaml = """
+                id: t
+                language: ja
+                name: T
+                description: T
+                agents: 2
+                rounds: 1
+                context: C
+                personas:
+                  - name: A
+                    description: D
+                    secret: $authored
+                  - name: B
+                    description: D
+                phases:
+                  - type: speak_all
+                    prompt: "Go"
+            """.trimIndent()
+            assertNull(loader.load(yaml).personas[0].secret)
+        }
+    }
+
+    /** Trimming is normalization, not mutation: a secret with incidental
+     * surrounding whitespace keeps its content. */
+    @Test
+    fun trimsSurroundingWhitespaceFromPersonaSecret() {
+        val yaml = """
+            id: t
+            language: ja
+            name: T
+            description: T
+            agents: 2
+            rounds: 1
+            context: C
+            personas:
+              - name: A
+                description: D
+                secret: "  She sold the house  "
+              - name: B
+                description: D
+            phases:
+              - type: speak_all
+                prompt: "Go"
+        """.trimIndent()
+        assertEquals("She sold the house", loader.load(yaml).personas[0].secret)
+    }
+
+    /** A bare `secret:` with no value is a plausible hand-authoring shape.
+     * The YAML decodes it to an explicit null, which fails `parseOptional`'s
+     * String cast — so it is a type error, not a silent nil. Pinned so the
+     * behavior is a decision rather than an accident. */
+    @Test
+    fun bareSecretKeyWithNoValueIsATypeError() {
+        val yaml = """
+            id: t
+            language: ja
+            name: T
+            description: T
+            agents: 2
+            rounds: 1
+            context: C
+            personas:
+              - name: A
+                description: D
+                secret:
+              - name: B
+                description: D
+            phases:
+              - type: speak_all
+                prompt: "Go"
+        """.trimIndent()
+        val caught = assertFailsWith<SimulationException> { loader.load(yaml) }
+        val error = caught.error
+        assertTrue(error is SimulationError.ScenarioValidationFailed)
+        assertTrue(error.message.contains("'secret'"))
+    }
+
+    @Test
+    fun throwsOnWrongTypeForPersonaSecret() {
+        val yaml = """
+            id: t
+            language: ja
+            name: T
+            description: T
+            agents: 2
+            rounds: 1
+            context: C
+            personas:
+              - name: A
+                description: D
+                secret: 42
+              - name: B
+                description: D
+            phases:
+              - type: speak_all
+                prompt: "Go"
+        """.trimIndent()
+        val caught = assertFailsWith<SimulationException> { loader.load(yaml) }
+        val error = caught.error
+        assertTrue(error is SimulationError.ScenarioValidationFailed)
+        val msg = error.message
+        assertTrue(msg.contains("'secret'"))
+        assertTrue(msg.contains("String"))
+    }
+
+    // endregion
+
+    // region Phase-optional field wrong-type errors (#130 item 2)
+
+    /** `rounds: "3"` (accidentally quoted in YAML) previously coerced silently
+     * to `nil` -> `subRounds` defaulted to 1 -> `speak_each` ran one pass
+     * instead of three. Strict loader now throws. */
+    @Test
+    fun throwsOnQuotedSubRounds() {
+        val yaml = makeMinimalYAML(
+            """
+                phases:
+                  - type: speak_each
+                    prompt: "Talk"
+                    rounds: "3"
+            """.trimIndent(),
+        )
+        val caught = assertFailsWith<SimulationException> { loader.load(yaml) }
+        val error = caught.error
+        assertTrue(error is SimulationError.ScenarioValidationFailed)
+        val msg = error.message
+        assertTrue(msg.contains("'rounds'"))
+        assertTrue(msg.contains("Int"))
+    }
+
+    /** `exclude_self: "true"` (quoted string) previously became `nil`
+     * silently; strict loader throws. Contrast with `exclude_self: yes`
+     * (bare) which is a valid YAML 1.1 boolean — see
+     * [acceptsYAML11BooleanExcludeSelf]. */
+    @Test
+    fun throwsOnQuotedExcludeSelf() {
+        val yaml = makeMinimalYAML(
+            """
+                phases:
+                  - type: vote
+                    prompt: "Vote"
+                    exclude_self: "true"
+            """.trimIndent(),
+        )
+        val caught = assertFailsWith<SimulationException> { loader.load(yaml) }
+        val error = caught.error
+        assertTrue(error is SimulationError.ScenarioValidationFailed)
+        val msg = error.message
+        assertTrue(msg.contains("'exclude_self'"))
+        assertTrue(msg.contains("Bool"))
+    }
+
+    /** `exclude_self: 1` (integer) also fails strictly — no 0/1 -> bool
+     * coercion. */
+    @Test
+    fun throwsOnIntExcludeSelf() {
+        val yaml = makeMinimalYAML(
+            """
+                phases:
+                  - type: vote
+                    prompt: "Vote"
+                    exclude_self: 1
+            """.trimIndent(),
+        )
+        val caught = assertFailsWith<SimulationException> { loader.load(yaml) }
+        assertTrue(caught.error is SimulationError.ScenarioValidationFailed)
+    }
+
+    /** YAML 1.1 treats bare `yes`/`no`/`on`/`off` as booleans. This loader
+     * re-accepts that token set locally (see [ScenarioLoader]'s class KDoc,
+     * divergence 2) so `exclude_self: yes` parses to `true` — this is *not* a
+     * silent-coerce bug, it's the canonical spelling. Pinned as a positive
+     * test so a future "fix" doesn't break it. */
+    @Test
+    fun acceptsYAML11BooleanExcludeSelf() {
+        val yaml = makeMinimalYAML(
+            """
+                phases:
+                  - type: vote
+                    prompt: "Vote"
+                    exclude_self: yes
+            """.trimIndent(),
+        )
+        val scenario = loader.load(yaml)
+        assertEquals(true, scenario.phases[0].excludeSelf)
+    }
+
+    // endregion
+
+    // region convertToAnyCodableValue strict (#130 item 4)
+
+    /** Top-level scalar extraData (`count: 42`) previously silently
+     * disappeared — `convertToAnyCodableValue` returned nil and
+     * `collectExtraData` dropped it. Strict loader throws naming the
+     * offending field and listing supported shapes. */
+    @Test
+    fun throwsOnScalarTopLevelExtraData() {
+        val yaml = """
+            id: t
+            language: ja
+            name: T
+            description: T
+            agents: 2
+            rounds: 1
+            context: C
+            personas:
+              - name: A
+                description: D
+              - name: B
+                description: D
+            phases:
+              - type: speak_all
+                prompt: "Go"
+            count: 42
+        """.trimIndent()
+        val caught = assertFailsWith<SimulationException> { loader.load(yaml) }
+        val error = caught.error
+        assertTrue(error is SimulationError.ScenarioValidationFailed)
+        val msg = error.message
+        assertTrue(msg.contains("'count'"))
+        // Error message should hint at the supported shapes so users know how to fix.
+        assertTrue(msg.contains("String") || msg.contains("string"))
+    }
+
+    /** Quoting the scalar works — `count: "42"` parses as `.string("42")`. */
+    @Test
+    fun acceptsQuotedScalarTopLevelExtraData() {
+        val yaml = """
+            id: t
+            language: ja
+            name: T
+            description: T
+            agents: 2
+            rounds: 1
+            context: C
+            personas:
+              - name: A
+                description: D
+              - name: B
+                description: D
+            phases:
+              - type: speak_all
+                prompt: "Go"
+            count: "42"
+        """.trimIndent()
+        val scenario = loader.load(yaml)
+        val value = scenario.extraData["count"]
+        assertTrue(value is com.pastura.models.AnyCodableValue.StringValue)
+        assertEquals("42", value.value)
+    }
+
+    /** Mixed-type top-level array previously silently dropped the whole field
+     * (string-array conversion failed, array-of-dict conversion also failed,
+     * so the function returned nil). */
+    @Test
+    fun throwsOnMixedTypeExtraDataArray() {
+        val yaml = """
+            id: t
+            language: ja
+            name: T
+            description: T
+            agents: 2
+            rounds: 1
+            context: C
+            personas:
+              - name: A
+                description: D
+              - name: B
+                description: D
+            phases:
+              - type: speak_all
+                prompt: "Go"
+            topics:
+              - a
+              - 42
+        """.trimIndent()
+        val caught = assertFailsWith<SimulationException> { loader.load(yaml) }
+        val error = caught.error
+        assertTrue(error is SimulationError.ScenarioValidationFailed)
+        assertTrue(error.message.contains("'topics'"))
+    }
+
+    /** `words: [{ majority: 1, minority: 2 }]` previously stringified the Int
+     * values silently (`"1"`, `"2"`). Strict loader throws — word-wolf preset
+     * authors intending a numeric tag would fail to notice the coercion. */
+    @Test
+    fun throwsOnNonStringValueInArrayOfDicts() {
+        val yaml = """
+            id: t
+            language: ja
+            name: T
+            description: T
+            agents: 2
+            rounds: 1
+            context: C
+            personas:
+              - name: A
+                description: D
+              - name: B
+                description: D
+            phases:
+              - type: assign
+                source: words
+                target: random_one
+            words:
+              - majority: 1
+                minority: 2
+        """.trimIndent()
+        val caught = assertFailsWith<SimulationException> { loader.load(yaml) }
+        val error = caught.error
+        assertTrue(error is SimulationError.ScenarioValidationFailed)
+        assertTrue(error.message.contains("'words'"))
+    }
+
+    /** `options` containing a non-String element previously silently dropped
+     * the whole array. Strict loader throws so the typo surfaces to the
+     * user. */
+    @Test
+    fun throwsOnMixedTypeOptions() {
+        val yaml = makeMinimalYAML(
+            """
+                phases:
+                  - type: choose
+                    prompt: "Choose"
+                    options:
+                      - cooperate
+                      - 42
+            """.trimIndent(),
+        )
+        val caught = assertFailsWith<SimulationException> { loader.load(yaml) }
+        val error = caught.error
+        assertTrue(error is SimulationError.ScenarioValidationFailed)
+        assertTrue(error.message.contains("'options'"))
+    }
+
+    // endregion
+}

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/ScenarioLoaderTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/ScenarioLoaderTests.kt
@@ -35,6 +35,103 @@ import kotlin.test.assertTrue
  * same YAML shape (a `speak_all` phase carrying an `output:` block) without
  * asserting on the unmapped field, so the "does an `output:` block break
  * parsing" question stays covered.
+ *
+ * ## ADR-023 §12 condition-4 perturbation record
+ *
+ * Each mechanism of
+ * `shared/engine/src/commonMain/kotlin/com/pastura/engine/ScenarioLoader.kt` was
+ * broken in isolation and the named **dedicated claimant** — a test that detects the
+ * break through **its own** assertion — confirmed to redden. **43 mutations**, each
+ * asserted to match its anchor **exactly once** before applying, with the mutated
+ * text re-read to confirm it landed (a `replace` that silently no-ops leaves the
+ * original behaviour and reads as verified) and the executed-test count asserted
+ * non-zero and unchanged (a mutation that stops the suite compiling otherwise
+ * reads as green — B2 recorded two that did). The file was restored
+ * byte-identically after each run (`git diff --exit-code`), and the unmutated
+ * baseline measured green immediately before the first mutation and again after
+ * the last revert, so every reddening below is signal rather than pre-existing
+ * noise. Measured 2026-08-26, #1558 (PR C2a).
+ *
+ * The sweep ran **only** this suite. That is sufficient rather than a shortcut:
+ * `grep` confirms no other `shared/engine` code constructs [ScenarioLoader] — it
+ * is deliberately not wired into the engine (see its class KDoc), so no other
+ * suite could redden.
+ *
+ * **40 of the 43 reddened.** The three that did not are accounted for below the
+ * table; one of them is a deliberate negative control.
+ *
+ * | Mechanism broken | Mutation | Dedicated claimant | Incidental |
+ * |---|---|---|---|
+ * | Code-fence strip | `filterNot { … startsWith("```") }` → `filterNot { false }` | [stripsCodeFencesBeforeParsing] | none |
+ * | Decode failure → `InvalidYAMLFormat` | the `throw` → `JsonObject(emptyMap())` | [throwsOnInvalidYAML] — assertion **strengthened**, note 1 | none |
+ * | Non-mapping root → `InvalidYAMLFormat` | the `?: throw` → `?: JsonObject(emptyMap())` | [throwsOnNonMappingRoot], [throwsOnEmptyDocument] — both **added**, note 1 | none |
+ * | `parseRequired` missing-key arm | `?: throw …MissingRequiredField` → `?: JsonNull` | [throwsOnMissingRequiredField] — assertion **strengthened**, note 1 | none |
+ * | `parseRequired` wrong-type arm | early-return the cast, no throw | [throwsOnWrongTypeForRequiredString], [throwsOnWrongTypeForRequiredInt], [throwsOnWrongTypeForPersonasList], [throwsOnWrongTypeForPersonaName] | none |
+ * | `parseOptional` absent-key arm | `?: return null` → `?: JsonNull` | [absentLogWindowIsNil] and 32 others | 32 — every fixture that omits an optional key then throws |
+ * | `parseOptional` wrong-type arm | the `throw` dropped | [throwsOnQuotedSubRounds], [throwsOnQuotedExcludeSelf], [throwsOnIntExcludeSelf], [throwsOnMixedTypeOptions], [throwsOnWrongTypeForPersonaSecret], [bareSecretKeyWithNoValueIsATypeError] | 1 |
+ * | `probability` quoted/bool guard | `!it.isString && !it.isYamlBooleanLiteral()` dropped | [throwsOnQuotedProbability] — **added**, note 2 | none |
+ * | `language` membership | `!in` → `in` | [rejectsLanguageInvalid] | none |
+ * | `simulation_language` membership | `!in` → `in` (not `if (false)`; see note 3) | [rejectsSimulationLanguageInvalid] | 1 — [parsesSimulationLanguageEn] |
+ * | persona count matches `agents` | `!=` → `==` | [throwsOnAgentCountMismatch] | none |
+ * | `STANDARD_KEYS` extra-data filter | `filterNot { it.key in STANDARD_KEYS }` → `filterNot { false }` | [parsesExtraDataStringArray] and 24 others | 24 — every fixture then routes `id` etc. through `convertToAnyCodableValue` |
+ * | persona `secret` trim | `?.trim()` dropped | [trimsSurroundingWhitespaceFromPersonaSecret], [normalizesEmptyPersonaSecretToNil] | none |
+ * | persona `secret` empty→null | `if (secret.isNullOrEmpty()) null else secret` → `secret` | [normalizesEmptyPersonaSecretToNil] | none |
+ * | Nested-`conditional` depth guard | `if (… && depth > 0)` → `if (false)` | *(none — expected green, note 4)* | none |
+ * | extra-data scalar `isString` guard | `&& value.isString` dropped | [throwsOnScalarTopLevelExtraData] | none |
+ * | extra-data array-of-dicts whole-collection cast | `all { it is JsonObject }` → `any` | [throwsOnExtraDataArrayMixingDictAndScalar] — **added**, note 2 | none |
+ * | …its non-String value throw | the `throw` → `?: ""` | [throwsOnNonStringValueInArrayOfDicts] | none |
+ * | extra-data mixed-array throw | the `throw` → an empty `ArrayValue` | [throwsOnMixedTypeExtraDataArray] | none |
+ * | extra-data dictionary non-String throw | the `throw` → `?: ""` | [throwsOnExtraDataDictWithNonStringValue] — **added**, note 2 | none |
+ * | `YamlType.INT` quoted/bool guard | `!it.isString && !it.isYamlBooleanLiteral()` dropped | [throwsOnWrongTypeForRequiredInt], [throwsOnQuotedSubRounds] | none |
+ * | `YamlType.INT` 32-bit range check | the range `takeIf` dropped | [throwsOnIntegerBeyond32Bits] — **added**, note 5 | none |
+ * | `YamlType.BOOL` YAML-1.1 token set | the token lookup → `null` | [acceptsYAML11BooleanExcludeSelf] | none |
+ * | `YamlType.BOOL` `isString`-aware literal check | the quoted arm tried as a literal first | [throwsOnQuotedExcludeSelf] | none |
+ * | `STRING_LIST` whole-collection cast | `values.all { it != null }` → `any` | [throwsOnMixedTypeOptions] | none |
+ * | `OBJECT_LIST` whole-collection cast | `list.all { it is JsonObject }` → `any` | [throwsOnPersonasListWithScalarElement] — **added**, note 2 | none |
+ * | `stringContentOrNull` `isString` guard | `&& it.isString` dropped | [throwsOnWrongTypeForRequiredString], [throwsOnWrongTypeForPersonaName], [throwsOnWrongTypeForPersonaSecret], [throwsOnMixedTypeOptions], [throwsOnMixedTypeExtraDataArray], [throwsOnNonStringValueInArrayOfDicts] | none |
+ * | `isYamlBooleanLiteral` `!isString` guard | the guard dropped | *(none — expected green, note 6)* | none |
+ * | `renderActualType` `Int64` arm | `"Int64"` → `"Int"` | [throwsOnIntegerBeyond32Bits] — **added**, note 5 | none |
+ * | `PhaseType` serial-name lookup | unknown type → `PhaseType.SPEAK_ALL` | [throwsOnInvalidPhaseType] | none |
+ * | Missing-`type:` throw | `?: throw …PhaseMissingType` → `?: "speak_all"` | [throwsOnMissingPhaseType] — **added**, note 2 | none |
+ * | Phase wiring: `prompt` | read → hardcoded `null` | [parsesPhaseSpeakAll], [phaseSpecialisationIsStillUnmapped] | none |
+ * | Phase wiring: `exclude_self` | read → `null` | [acceptsYAML11BooleanExcludeSelf], [throwsOnQuotedExcludeSelf], [throwsOnIntExcludeSelf] | none |
+ * | Phase wiring: `options` | read → `null` | [throwsOnMixedTypeOptions] | none |
+ * | Phase wiring: `rounds` → `subRounds` | read → `null` | [throwsOnQuotedSubRounds] | none |
+ * | Phase wiring: `probability` | read → `null` | [parsesProbabilityAsDouble], [parsesProbabilityAsIntCoercesToDouble], [throwsOnProbabilityWrongType], [throwsOnProbabilityBoolPretendingToBeInt], [parsesEventInjectFullSpec] | none |
+ * | Phase wiring: `as` → `eventVariable` | read → `null` | [parsesEventInjectFullSpec] | none |
+ * | Phase wiring: `no_repeat` | read → `null` | [parsesNoRepeat] — **added**, note 2 | none |
+ * | Phase wiring: `source` | read → `null` | [parsesEventInjectFullSpec], [parsesEventInjectMinimalSpec], [phaseSpecialisationIsStillUnmapped] | none |
+ * | Phase wiring: `if` → `condition` | read → `null` | [phaseSpecialisationIsStillUnmapped] | none |
+ * | Scenario wiring: `log_window` | read → `null` | [parsesLogWindow], [rejectsNonIntLogWindow] | none |
+ * | **NEGATIVE CONTROL** — `acceptedLanguagesList` ordering | `.sorted()` → `.sortedDescending()` | *(none — expected green)* | none |
+ *
+ * 1. **Three mechanisms were claimed only by a bare "it throws" assertion**, so
+ *    the mutation moved the failure to a *different* message and the test stayed
+ *    green. Common cause: the loader has one exception type, so a type-only
+ *    assertion cannot tell its layers apart — the same shape B1's sweep found in
+ *    `ScenarioValidator`. Fixed by asserting the rendered message.
+ * 2. **Six mechanisms had no claimant at all**, and five of them have none on the
+ *    **Swift** side either — nothing in `ScenarioLoaderTests*.swift` drives a
+ *    quoted `probability`, a dictionary-valued extra-data key, an extra-data
+ *    array mixing mappings and scalars, a `personas:` list holding a scalar, an
+ *    absent `type:`, or `no_repeat`. Each gained a test in the
+ *    "condition-4 sweep additions" region.
+ * 3. `if (false)` does **not** compile on the `simulation_language` arm: the
+ *    smart cast from the `!= null` half is lost and the later `!!`-free use
+ *    fails. The polarity flip is the compiling substitute, and it reddens the
+ *    accepting fixture as well as the rejecting one.
+ * 4. The nested-`conditional` depth guard is **structurally unreachable in this
+ *    port**: `depth` has no non-zero caller until C2b's `mapBranch` descends
+ *    into `then:` / `else:`. Expected green; C2b must claim it.
+ * 5. `Int` is 32-bit in Kotlin and 64-bit in Swift, so this mechanism and its
+ *    `Int64` rendering exist only on this side and have no Swift twin to
+ *    transcribe. [throwsOnIntegerBeyond32Bits] is the detector for what was
+ *    otherwise a KDoc claim with nothing behind it.
+ * 6. `isYamlBooleanLiteral`'s `!isString` guard is **defence in depth**: every
+ *    caller that could be fooled by a quoted `"true"` is already `isString`-
+ *    guarded on its own. Expected green — kept because a future caller without
+ *    that guard would need it, and removing it would make this file's one
+ *    boolean-literal predicate quietly wrong.
  */
 class ScenarioLoaderTests {
 
@@ -290,7 +387,35 @@ class ScenarioLoaderTests {
               - type: speak_all
         """.trimIndent()
         val caught = assertFailsWith<SimulationException> { loader.load(yaml) }
-        assertTrue(caught.error is SimulationError.ScenarioValidationFailed)
+        val error = caught.error
+        assertTrue(error is SimulationError.ScenarioValidationFailed)
+        // Missing-vs-wrong-type is the whole point of parseRequired's two
+        // branches, and the condition-4 sweep found that collapsing the missing
+        // branch into the wrong-type one left this test green — both still
+        // throw. Assert which one fired.
+        assertTrue(error.message.contains("missing required field 'id'"))
+    }
+
+    /**
+     * A phase with no `type:` at all.
+     *
+     * Added by the condition-4 sweep: [throwsOnInvalidPhaseType] covers an
+     * *unknown* type, but nothing drove an *absent* one, so defaulting the
+     * missing-type throw to `speak_all` left the suite green. The two collapse
+     * to one message by design — see `parsePhaseType`'s KDoc.
+     */
+    @Test
+    fun throwsOnMissingPhaseType() {
+        val yaml = makeMinimalYAML(
+            """
+                phases:
+                  - prompt: "No type here"
+            """.trimIndent(),
+        )
+        val caught = assertFailsWith<SimulationException> { loader.load(yaml) }
+        val error = caught.error
+        assertTrue(error is SimulationError.ScenarioValidationFailed)
+        assertTrue(error.message.contains("missing 'type'"))
     }
 
     @Test
@@ -343,7 +468,41 @@ class ScenarioLoaderTests {
     fun throwsOnInvalidYAML() {
         val yaml = "{{invalid yaml: [["
         val caught = assertFailsWith<SimulationException> { loader.load(yaml) }
-        assertTrue(caught.error is SimulationError.ScenarioValidationFailed)
+        val error = caught.error
+        assertTrue(error is SimulationError.ScenarioValidationFailed)
+        // The message, not just the throw: the condition-4 sweep found that
+        // replacing the decode-failure fold with an empty mapping keeps this
+        // test green, because the empty mapping then fails on `id` instead.
+        assertTrue(error.message.contains("Invalid YAML format"))
+    }
+
+    /**
+     * A sequence root — the second half of Swift's
+     * `guard let raw = try? Yams.load(...), let dict = raw as? [String: Any]`.
+     *
+     * Added by the condition-4 sweep: no transcribed test drove a well-formed
+     * document whose root is not a mapping, so replacing that fold with an
+     * empty mapping left the suite green.
+     */
+    @Test
+    fun throwsOnNonMappingRoot() {
+        val caught = assertFailsWith<SimulationException> { loader.load("- 1\n- 2") }
+        val error = caught.error
+        assertTrue(error is SimulationError.ScenarioValidationFailed)
+        assertTrue(error.message.contains("Invalid YAML format"))
+    }
+
+    /**
+     * An empty document, which `YamlCodec` decodes to `JsonNull` rather than
+     * failing — so it reaches the same non-mapping fold as
+     * [throwsOnNonMappingRoot] by a different route.
+     */
+    @Test
+    fun throwsOnEmptyDocument() {
+        val caught = assertFailsWith<SimulationException> { loader.load("   \n") }
+        val error = caught.error
+        assertTrue(error is SimulationError.ScenarioValidationFailed)
+        assertTrue(error.message.contains("Invalid YAML format"))
     }
 
     // endregion
@@ -1032,6 +1191,175 @@ class ScenarioLoaderTests {
         val error = caught.error
         assertTrue(error is SimulationError.ScenarioValidationFailed)
         assertTrue(error.message.contains("'options'"))
+    }
+
+    // endregion
+
+    // region condition-4 sweep additions
+
+    /*
+     * Every test in this region was added because the ADR-023 §12 condition-4
+     * sweep broke the mechanism it names and the suite stayed green — no
+     * transcribed Swift case reached it. Three of them (the `probability`
+     * quoted-scalar guard, the dictionary-valued extra-data guard, and the
+     * absent-`type:` throw, above) have no dedicated claimant on the **Swift**
+     * side either; the rest cover Kotlin-only mechanisms the port introduced.
+     * The sweep's full table is in the #501 record for #1558.
+     */
+
+    /**
+     * `probability: "0.5"` — a quoted scalar that would parse as a number.
+     *
+     * `throwsOnProbabilityWrongType` and `throwsOnProbabilityBoolPretendingToBeInt`
+     * both survive dropping `parseOptionalDoubleAcceptingInt`'s `isString`
+     * guard, because their fixtures fail the `toDoubleOrNull` step anyway. This
+     * is the one input the guard alone rejects.
+     */
+    @Test
+    fun throwsOnQuotedProbability() {
+        val yaml = makeMinimalYAML(
+            """
+                phases:
+                  - type: event_inject
+                    source: events
+                    probability: "0.5"
+                events:
+                  - storm
+            """.trimIndent(),
+        )
+        val caught = assertFailsWith<SimulationException> { loader.load(yaml) }
+        val error = caught.error
+        assertTrue(error is SimulationError.ScenarioValidationFailed)
+        assertTrue(error.message.contains("'probability'"))
+    }
+
+    /**
+     * A top-level extra-data array mixing a mapping and a scalar.
+     *
+     * `throwsOnMixedTypeExtraDataArray` mixes only scalars, so it never
+     * exercises the whole-collection `all { it is JsonObject }` that decides
+     * whether the array-of-dictionaries branch is taken at all.
+     */
+    @Test
+    fun throwsOnExtraDataArrayMixingDictAndScalar() {
+        val yaml = makeMinimalYAML(
+            """
+                phases:
+                  - type: speak_all
+                    prompt: "Speak"
+                rules:
+                  - name: first
+                  - plain_string
+            """.trimIndent(),
+        )
+        val caught = assertFailsWith<SimulationException> { loader.load(yaml) }
+        val error = caught.error
+        assertTrue(error is SimulationError.ScenarioValidationFailed)
+        assertTrue(error.message.contains("'rules'"))
+    }
+
+    /**
+     * A top-level extra-data mapping whose value is not a String — the
+     * `ExtraDataDictNotString` arm, which no transcribed case reached.
+     */
+    @Test
+    fun throwsOnExtraDataDictWithNonStringValue() {
+        val yaml = makeMinimalYAML(
+            """
+                phases:
+                  - type: speak_all
+                    prompt: "Speak"
+                config:
+                  majority: 1
+            """.trimIndent(),
+        )
+        val caught = assertFailsWith<SimulationException> { loader.load(yaml) }
+        val error = caught.error
+        assertTrue(error is SimulationError.ScenarioValidationFailed)
+        assertTrue(error.message.contains("'config'"))
+        assertTrue(error.message.contains("String"))
+    }
+
+    /**
+     * An integral scalar beyond 32-bit `Int`.
+     *
+     * Kotlin-only: Swift's `Int` is 64-bit and accepts this, so there is no
+     * Swift twin to transcribe. This is the detector for divergence 4 in
+     * [ScenarioLoader]'s class KDoc — a claim that had none until the sweep —
+     * and it pins the `Int64` fragment [renderActualType] emits so the message
+     * is not the bewildering "must be Int, got Int".
+     */
+    @Test
+    fun throwsOnIntegerBeyond32Bits() {
+        val yaml = """
+            id: t
+            language: ja
+            name: T
+            description: T
+            agents: 2147483648
+            rounds: 1
+            context: C
+            personas:
+              - name: A
+                description: A
+            phases:
+              - type: speak_all
+                prompt: "Speak"
+        """.trimIndent()
+        val caught = assertFailsWith<SimulationException> { loader.load(yaml) }
+        val error = caught.error
+        assertTrue(error is SimulationError.ScenarioValidationFailed)
+        assertTrue(error.message.contains("'agents'"))
+        assertTrue(error.message.contains("must be Int, got Int64"))
+    }
+
+    /**
+     * A `personas:` list holding a scalar element.
+     *
+     * `throwsOnWrongTypeForPersonasList` supplies a non-list, which fails the
+     * `as? JsonArray` step first — so it never reaches the whole-collection
+     * `all { it is JsonObject }`. Swift's `as? [[String: Any]]` fails for the
+     * WHOLE list here, which is why the error names `personas` rather than the
+     * offending element.
+     */
+    @Test
+    fun throwsOnPersonasListWithScalarElement() {
+        val yaml = """
+            id: t
+            language: ja
+            name: T
+            description: T
+            agents: 2
+            rounds: 1
+            context: C
+            personas:
+              - name: A
+                description: A
+              - just_a_string
+            phases:
+              - type: speak_all
+                prompt: "Speak"
+        """.trimIndent()
+        val caught = assertFailsWith<SimulationException> { loader.load(yaml) }
+        val error = caught.error
+        assertTrue(error is SimulationError.ScenarioValidationFailed)
+        assertTrue(error.message.contains("'personas'"))
+    }
+
+    /** `no_repeat:` (#1006) — mapped, but claimed by nothing until the sweep. */
+    @Test
+    fun parsesNoRepeat() {
+        val yaml = makeMinimalYAML(
+            """
+                phases:
+                  - type: assign
+                    source: words
+                    no_repeat: true
+                words:
+                  - alpha
+            """.trimIndent(),
+        )
+        assertEquals(true, loader.load(yaml).phases[0].noRepeat)
     }
 
     // endregion

--- a/shared/models/src/commonMain/kotlin/com/pastura/models/ScenarioCodec.kt
+++ b/shared/models/src/commonMain/kotlin/com/pastura/models/ScenarioCodec.kt
@@ -20,10 +20,13 @@ import kotlinx.serialization.json.JsonElement
  *
  * **encode-only by design** (W4 PR-A scope decision per W3 PR-C plan v4
  * Option γ-prime): the W4 H4 measurement only exercises the encode path;
- * Swift→K/N decode is NOT on the production iOS graph (YAML → `Scenario`
- * decoding stays Swift-side via `ScenarioLoader`). Adding a decode surface
- * here would be premature — W4 PR-C snakeyaml validation work may need it,
- * in which case it lands then.
+ * Swift→K/N decode is NOT on the production iOS graph — YAML → `Scenario`
+ * decoding runs Swift-side via `Pastura/Pastura/Engine/ScenarioLoader.swift`
+ * in production. A Kotlin `ScenarioLoader` (`shared/engine`) exists as of
+ * ADR-023 Stage 3 Wave C PR C2a, but it is not wired into anything yet, so
+ * the production graph is unchanged. Adding a decode surface here would be
+ * premature — W4 PR-C snakeyaml validation work may need it, in which case
+ * it lands then.
  *
  * **Json instance choice:** `Json` (companion object — kotlinx-serialization
  * default settings) matches existing `commonTest/` usage. No custom


### PR DESCRIPTION
## Summary

ADR-023 Stage 3 Wave C, **PR C2a** — ports the YAML-ingest and top-level-mapping half of `Pastura/Pastura/Engine/ScenarioLoader.swift` to `shared/engine/src/commonMain/kotlin/com/pastura/engine/ScenarioLoader.kt`, on top of ADR-012's `YamlCodec`. The estimator half landed earlier as `InferenceEstimator.kt`, so the ledger row was already `SPLIT`; it now names both Kotlin landings.

The mapping is a hand-written walk over the `JsonElement` tree, **not** `Json.decodeFromJsonElement`: a serializer-driven decode would fork parity twice over — its wire keys are camelCase where preset YAML is snake_case, and its errors are kotlinx's rather than the `ScenarioValidationMessage` vocabulary the iOS UI renders today.

### The C2a / C2b cut, stated mechanically

**C2a maps every phase field reachable through the three generic parse helpers; C2b adds every field needing a dedicated helper.** The seven deferred fields (`output`, `target`, `pairing`, `logic`, `then`/`else`, `action_deltas`, `payoff`) are explicit `null, // C2b` constructor arguments, so C2b's diff lands exactly on the gap rather than adding lines around it.

The split is **vertical** — implementation plus the tests that claim it, per PR — matching C1's B1/B2 (#1554/#1555). A horizontal split (implementation first, remaining tests second) was drafted and rejected at plan review: it would have merged ~500 lines whose strict-type helpers are claimed only by `+StrictTypes`, and §12 condition 2 is coverage-at-landing, not cadence.

### Both YAML engines were measured, not assumed

Yams is YAML 1.1; `YamlCodec` is snakeyaml-engine's 1.2 core schema. A throwaway probe was run on **both** sides before a line was written ([full table](https://github.com/tyabu12/pastura/issues/1558#issuecomment-5420968361)). Three results contradicted the plan review's predictions: duplicate keys throw on both sides, merge keys `<<:` and anchors resolve on both sides, and **`y`/`n` are `String` on both sides** — so admitting them to the loader's YAML-1.1 bool set would have opened a *new* divergence rather than closing one.

`yes`/`no`/`on`/`off` are re-accepted **loader-locally**. `YamlCodec`'s 1.2 contract and its `LoadSettings` are untouched, so the models roundtrip / canonicalizer surface is unaffected.

### Not wired into anything

Same posture as the validator: ADR-023 §4 gates the preflight on validator **and** linter together, and the linter is unported, so `DivergenceLedger.VALIDATOR_UNPORTED` stays. Nothing in `shared/engine` constructs this loader, and Stage-4 parity reads `ParityGolden.scenarioJson` through `ScenarioCodec` rather than through it.

That is also what contains the one thing this PR knowingly puts on `main`: **a partially-mapping loader, for one PR cycle.** Beyond having no consumers, it is fenced by a `PORT IN PROGRESS` KDoc section, a board row that says so in prose, and `phaseSpecialisationIsStillUnmapped` — a pin whose assertions are all `assertNull`, so C2b cannot map any of the seven without reddening it and being forced to delete the pin, the KDoc section, and the Swift-side note together.

### Six documented-not-ledgered divergences

In the class KDoc, on PR B1's standing reason (a rejected scenario produces no transcript to compare): the two YAML-1.1 typed scalars (`12:30:00`, `2026-08-26` — stated per scalar, because the polarity is *not* symmetric), the two opposite-direction over-acceptances the loader-local bool token set costs, `expected:`/`got:` type-name rendering, the 32-bit/64-bit `Int` split and how it degrades beyond `Long` range, the two whitespace-trim sites, and which offending extra-data key gets named.

## Test plan

- `./gradlew :shared:models:jvmTest :shared:engine:jvmTest` — the CI pair (`kmp-interop.md`: models alone is blind to engine breakage). Green. `ScenarioLoaderTests` runs **56** tests.
- `./gradlew :shared:engine:compileCommonMainKotlinMetadata` — green (every per-target compile can pass while metadata fails).
- `./gradlew :shared:engine:linkDebugFrameworkMacosArm64` — green; `verifyExportedThrowsAnnotations` reports **7** pinned selectors exporting `error:` (the new one is `load(yaml:)`), and `verifyEngineFrameworkSurface` reports the exported surface coroutine-free.
- `scripts/xcodebuild.sh test` — green, 3557 tests in 286 suites, plus the UI suite.
- `swiftlint lint --quiet --strict` — clean.

**§12 condition 2** — behavioural parity rather than golden JSON: the ported surface is a *parser*, so its observable contract is the accept/reject decision and the rendered message, both driven directly by fixtures transcribed 1:1 from the Swift suite. A golden-tree comparison would pin `Scenario`'s wire shape, which `ScenarioCodec` / `ParityScenarioDecodeTests` already own.

**§12 condition 4** — 42 mutations executed, 39 reddened, 3 green (one a negative control). Recorded in `ScenarioLoaderTests.kt`'s class KDoc and on [#501](https://github.com/tyabu12/pastura/issues/501#issuecomment-5421197803). The driver asserted each anchor matched exactly once, re-read the file to confirm the mutation landed, asserted a non-zero *and unchanged* executed-test count, and verified byte-identical restoration after every run. Nine tests exist because the sweep proved the suite could not see the mechanism at all — five of those mechanisms have no claimant on the **Swift** side either.

## Review

Reviewer: **Opus**, in five partitions (the branch exceeded the reviewer's scope budget twice, so it was split by area and then the test file by concern — the model was never downgraded to fit).

No behavioural defect was found in the port. Partition 1 walked the Kotlin mapping against the Swift original — check order in `mapToScenario`, the `convertToAnyCodableValue` cast ladder including the vacuous-`all` empty-list case, `JsonNull` as present-but-wrong-type, the `@Throws` export and its pin, and helper visibility — and passed it. The condition-4 audit could not find a single table row whose named claimant fails to detect its mutation.

Everything else was applied. The findings fell in two classes, both of which matter for a PR whose product *is* a divergence surface and an evidence record:

**Prose that claimed more than was verified.** ADR-023 §4's SPLIT bullet still said this file "gains" the ledger row when it lands, and §13 designates that bullet as the record of what is outstanding — leaving it is the exact drift §4's own staleness note was written about. The board had dropped "loader" from the left-to-do list, reading as wiring done. `engine.md`'s new clause was true but incomplete: the descriptor lookup removes the hand-maintained map and moves the trap to a missing `@SerialName`, which the count check cannot see. Divergence 1 asserted a symmetric polarity flip that only one of its two scalars has; divergence 2 recorded one over-acceptance where there are two, in opposite directions, and the undocumented one is the likelier in real curator YAML; divergence 4 stated the 32-bit rejection absolutely, where beyond `Long` range the failure degrades to a whole-document `InvalidYAMLFormat`.

**Assertions weaker than the mechanisms they named.** Both extra-data guards fell through to `ExtraDataUnsupportedType`, whose message satisfied the assertions as written; `rejectsNonIntLogWindow` and three others asserted only that *something* threw. The perturbation record misdescribed two mutations (both were `if (false)`, not a polarity flip) and its totals did not reconcile with its own table — a non-compiling attempt was being counted as evidence.

Two tests were added for claims that had none: the beyond-`Long` fold, and the quoted-`"yes"` over-acceptance.

**One finding rejected**: a second `///` pointer at `mapToScenario` alongside the one on `load(yaml:)`. The existing note follows the convention `estimateInferenceCount` established, and a second copy is one more stale-able artefact for a marginal gain in grep proximity.

## Device QA

実機QA不要 — Kotlin `commonMain` / `commonTest` とドキュメントのみ。Swift 側の変更は `ScenarioLoader.swift` のドキュメンテーションコメント 1 箇所だけで、実行コードに触れていない。`#if !targetEnvironment(simulator)` ブロック、Metal / llama.cpp 推論経路、Pattern-6 の executor 凍結のいずれにも掛からない。K/N フレームワークは iOS アプリにまだリンクされていない（Stage 5）ので、`@Throws` エクスポートの実機影響もない。

Part of #1558 — C2b（フェーズ特化 + 残りのテスト兄弟）が続く。
