### PR TITLE
✨ feat: ADR-023 Stage 3 — ScenarioLoader phase specialisation port (PR C2b)

### DIFF
--- a/.claude/rules/engine.md
+++ b/.claude/rules/engine.md
@@ -23,7 +23,11 @@ omission. Four do not.
   than vanishing: the descriptor falls back to the **declaration** name when
   `@SerialName` is absent, so a Kotlin case added without its annotation resolves
   as `SPEAK_ALL` rather than `speak_all`, and `serialNameLookup`'s count check
-  cannot see it. (Phase-field mapping is a separate, still-unported concern, C2b.)
+  cannot see it. The same helper resolves `target:` / `pairing:` / `logic:` against
+  `AssignTarget` / `PairingStrategy` / `ScoreCalcLogic`, so all four enum mirrors in
+  the loader are derived, not written — and `InvalidLogic`'s `allowed:` message text
+  is joined from that same map's key order, which is why it lists the cases in
+  declaration order rather than sorted.
 - **Conditional-branch policy.** `ScenarioValidator.validateBranch` and
   `ConditionalHandler.subHandlers` are not `PhaseType`-exhaustive, so decide
   explicitly: *allow* (register in `subHandlers`) or *reject* (a

--- a/Pastura/Pastura/Engine/ScenarioLoader.swift
+++ b/Pastura/Pastura/Engine/ScenarioLoader.swift
@@ -56,18 +56,14 @@ nonisolated public struct ScenarioLoader: Sendable {  // swiftlint:disable:this 
   /// **Partially dual-landed with
   /// `shared/engine/src/commonMain/kotlin/com/pastura/engine/ScenarioLoader.kt`**
   /// (spelled out so a move leaves a greppable string behind) — change both
-  /// (ADR-023 §4, PR C2a). This file's row in `shared/adr-023-port-ledger.tsv`
+  /// (ADR-023 §4, PRs C2a + C2b). This file's row in `shared/adr-023-port-ledger.tsv`
   /// is `SPLIT` naming that path alongside `InferenceEstimator.kt`, and the
   /// coverage gate verifies both paths are tracked — it cannot verify that an
   /// edit here was mirrored, so the pairing is yours to honour.
   ///
-  /// **Delete the next sentence when C2b lands**, together with the Kotlin
-  /// file's `PORT IN PROGRESS` KDoc section; both are pinned by
-  /// `ScenarioLoaderTests.phaseSpecialisationIsStillUnmapped`, which reddens the
-  /// moment those fields start being mapped. Phase specialisation (`output`,
-  /// `target`, `pairing`, `logic`, `then`/`else`, `action_deltas`, `payoff`) is
-  /// not yet ported, so a change confined to one of those fields has no Kotlin
-  /// side to mirror yet.
+  /// The pairing is now **whole-file**: PR C2b closed the phase-specialisation
+  /// gap C2a left, so every helper below has a Kotlin counterpart and no field
+  /// is exempt from the mirror.
   public func load(yaml: String) throws -> Scenario {
     let stripped = stripCodeFences(yaml)
 

--- a/docs/decisions/ADR-023.md
+++ b/docs/decisions/ADR-023.md
@@ -259,11 +259,13 @@ precisely how §4 went stale in the first place.)
   `InferenceEstimator.kt` (#1464, `6341951a`, 2026-08-14); YAML ingest and top-level structural
   mapping (`load(yaml:)`, `mapToScenario`, `mapPersona`, `collectExtraData`, and the three generic
   parse helpers) landed as `ScenarioLoader.kt` (#1558, PR C2a, 2026-08-26), and the ledger row now
-  names both. **Still outstanding: phase specialisation** — every `mapPhase` field needing a
-  dedicated helper (`output`, `target`, `pairing`, `logic`, `then` / `else`, `action_deltas`,
-  `payoff`), deferred to PR C2b. `docs/kmp-migration-status.md`'s hand-maintained row carries that
-  split in prose, but its machine-checked section is handler-only, so this bullet remains the
-  record that the remainder is outstanding.
+  names both. Phase specialisation — every `mapPhase` field needing a dedicated helper (`output`,
+  `target`, `pairing`, `logic`, `then` / `else`, `action_deltas`, `payoff`) plus the depth-1
+  conditional recursion — followed in #1560, PR C2b, 2026-08-26. The port is **complete**; like
+  `ScenarioValidator` it is deliberately **not wired** into `SimulationEngine`, because §4 puts the
+  preflight gate on the validator and the ADR-024 linter together and the linter is unported.
+  `docs/kmp-migration-status.md`'s hand-maintained row carries the same state in prose, but its
+  machine-checked section is handler-only, so this bullet remains the record.
 
 ### How this section went stale, and what changed
 

--- a/docs/kmp-migration-status.md
+++ b/docs/kmp-migration-status.md
@@ -45,7 +45,7 @@ Legend: ✅ done · 🔄 in progress · 🟡 partial · ⬜ not started.
 | Wave A — non-handler run-path (scoring, mechanisms, prompt/LLM glue) | ✅ done | #1207 #1212 #1217 |
 | Wave B — 14 phase handlers | ✅ 14/14 | checklist ↓ |
 | code-phase track | ✅ done | CP1 #1226 · CP2 #1230 · CP3 #1232 |
-| Loader / validator port + `detector`·`logger` wiring | 🟡 partial | validator prerequisites in ([#1464](https://github.com/tyabu12/pastura/issues/1464)); validator fully ported — run gate + commit gate ([#1552](https://github.com/tyabu12/pastura/issues/1552) B1/B2); loader half-ported — YAML ingest + top-level mapping landed ([#1558](https://github.com/tyabu12/pastura/issues/1558) C2a), phase specialisation deferred (C2b), and like the validator it is **not wired** yet; linter / preflight wiring left · [ADR-023](decisions/ADR-023.md) §4 · #501 |
+| Loader / validator port + `detector`·`logger` wiring | 🟡 partial | validator prerequisites in ([#1464](https://github.com/tyabu12/pastura/issues/1464)); validator fully ported — run gate + commit gate ([#1552](https://github.com/tyabu12/pastura/issues/1552) B1/B2); loader fully ported — YAML ingest + top-level mapping ([#1558](https://github.com/tyabu12/pastura/issues/1558) C2a) then phase specialisation ([#1560](https://github.com/tyabu12/pastura/issues/1560) C2b), and like the validator it is **not wired** yet; linter / preflight wiring left · [ADR-023](decisions/ADR-023.md) §4 · #501 |
 
 ### Wave B handler checklist
 

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/ScenarioLoader.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/ScenarioLoader.kt
@@ -121,10 +121,14 @@ import kotlinx.serialization.json.JsonPrimitive
  *    [ScenarioValidator]'s divergence 3. [stripCodeFences] is a second trim site
  *    with a *narrower* Swift set — `.whitespaces`, no `\v` / `\f` / `` —
  *    so a fence line indented with one of those is stripped here and kept there.
- * 6. **Which offending key gets reported.** `collectExtraData` throws on the
- *    first offending key in `JsonObject` insertion order; Swift iterates a
- *    `Dictionary`, whose order is unspecified. Both reject the same scenarios;
- *    only the key named in the message can differ.
+ * 6. **Which offending key gets reported.** `collectExtraData`,
+ *    [parseOutputSchema] and [parseActionDeltas] each throw on the first
+ *    offending key in `JsonObject` insertion order; Swift iterates a
+ *    `Dictionary`, whose order is unspecified. Both engines reject the same
+ *    scenarios; only the key named in the message can differ, and only when a
+ *    mapping holds more than one bad value. The two phase-level sites arrived
+ *    with C2b — this entry covers all three, so the next per-key helper joins
+ *    it rather than opening a fourth.
  *
  * ## `validationError` is re-declared here on purpose
  *
@@ -400,7 +404,13 @@ public class ScenarioLoader {
             )
     }
 
-    /** Same shape as [parseAssignTarget], for a `choose` phase's `pairing:`. */
+    /**
+     * Same shape as [parseAssignTarget], **including the [parseOptional]-first
+     * order** — resolving the lookup against the raw element instead would turn
+     * a wrong-typed `pairing:` from a
+     * [ScenarioValidationMessage.FieldWrongType] into an
+     * [ScenarioValidationMessage.InvalidPairing].
+     */
     private fun parsePairing(dict: JsonObject, label: String): PairingStrategy? {
         val str = parseOptional(dict, "pairing", label, YamlType.STRING) ?: return null
         return PAIRING_STRATEGIES_BY_YAML_NAME[str]
@@ -533,8 +543,9 @@ public class ScenarioLoader {
      * row throws rather than silently scoring a wrong verdict at runtime.
      *
      * Mixed semantics, matching Swift's cast ladder: `payoff:` itself is
-     * whole-collection ([YamlType.OBJECT_LIST], so a non-list names the key),
-     * while each row is checked individually and reports its own index. The
+     * whole-collection ([YamlType.OBJECT_LIST]), so a non-list is rejected as a
+     * whole rather than row by row, while each row is checked individually and
+     * reports its own index. The
      * `points` elements go through [YamlType.INT], which supplies the
      * boolean and quoted-scalar exclusions Swift's `as? Int` guards spell out
      * by hand (`!(value is Bool)`), plus the 32-bit range check of the class

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/ScenarioLoader.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/ScenarioLoader.kt
@@ -1,11 +1,15 @@
 package com.pastura.engine
 
 import com.pastura.models.AnyCodableValue
+import com.pastura.models.AssignTarget
+import com.pastura.models.PairingStrategy
+import com.pastura.models.PayoffRule
 import com.pastura.models.Persona
 import com.pastura.models.Phase
 import com.pastura.models.PhaseType
 import com.pastura.models.Scenario
 import com.pastura.models.ScenarioValidationMessage
+import com.pastura.models.ScoreCalcLogic
 import com.pastura.models.SimulationError
 import com.pastura.models.YamlCodec
 import com.pastura.models.YamlDecodeError
@@ -117,7 +121,14 @@ import kotlinx.serialization.json.JsonPrimitive
  *    `Long` range but outside `Int.MIN_VALUE..Int.MAX_VALUE` is a
  *    [ScenarioValidationMessage.FieldWrongType] rather than an accepted value.
  *    Truncating instead would be worse than a divergence — it would silently run
- *    a different scenario. **Beyond `Long` range the failure changes shape**:
+ *    a different scenario. Every field reusing [YamlType.INT]'s cast inherits
+ *    this, so it reaches the phase-level integral fields too, only under a
+ *    different message: an out-of-range `payoff:` row `points` element reports
+ *    [ScenarioValidationMessage.PayoffRowInvalid] and an out-of-range
+ *    `action_deltas` value reports
+ *    [ScenarioValidationMessage.ActionDeltasValueNotInt], because those two
+ *    helpers own their own vocabulary rather than routing through
+ *    [parseOptional]. **Beyond `Long` range the failure changes shape**:
  *    `YamlCodec`'s `yamlValueToJson` handles `Int` / `Long` / `Float` / `Double`
  *    and nothing else, so the value raises `YamlDecodeError.UnsupportedScalar`,
  *    which [load] folds into
@@ -390,6 +401,58 @@ public class ScenarioLoader {
         )
     }
 
+    /**
+     * Resolves the `assign` phase's `target:` against [AssignTarget]'s
+     * `@SerialName` values. Strict-throw on an unknown value, mirroring
+     * [parsePhaseType] (issue #108 / #211).
+     *
+     * A **wrong-typed** value routes through [parseOptional] first, exactly as
+     * Swift's `parseOptional<String>` does, so `target: 3` reports the unified
+     * [ScenarioValidationMessage.FieldWrongType] message and only a well-typed
+     * but unrecognised string reaches
+     * [ScenarioValidationMessage.InvalidTarget]. The order is the message the
+     * curator sees; do not fold the two steps together.
+     */
+    private fun parseAssignTarget(dict: JsonObject, label: String): AssignTarget? {
+        val str = parseOptional(dict, "target", label, YamlType.STRING) ?: return null
+        return ASSIGN_TARGETS_BY_YAML_NAME[str]
+            ?: throw validationError(
+                ScenarioValidationMessage.InvalidTarget(label = label, value = str),
+            )
+    }
+
+    /** Same shape as [parseAssignTarget], for a `choose` phase's `pairing:`. */
+    private fun parsePairing(dict: JsonObject, label: String): PairingStrategy? {
+        val str = parseOptional(dict, "pairing", label, YamlType.STRING) ?: return null
+        return PAIRING_STRATEGIES_BY_YAML_NAME[str]
+            ?: throw validationError(
+                ScenarioValidationMessage.InvalidPairing(label = label, value = str),
+            )
+    }
+
+    /**
+     * Same shape as [parseAssignTarget], for a `score_calc` phase's `logic:`,
+     * plus the `allowed:` fragment listing every accepted value.
+     *
+     * That fragment is **derived from the lookup map, never hand-written**:
+     * [serialNameLookup]'s `associate` yields a `LinkedHashMap` in enum
+     * declaration order, so this reaches the same string as Swift's
+     * `ScoreCalcLogic.allCases.map(\.rawValue).joined(separator: ", ")`. A
+     * hand-written list would be a second mirror no compiler checks; derived,
+     * a sixth case joins the lookup and this message in one edit.
+     */
+    private fun parseLogic(dict: JsonObject, label: String): ScoreCalcLogic? {
+        val str = parseOptional(dict, "logic", label, YamlType.STRING) ?: return null
+        return SCORE_CALC_LOGICS_BY_YAML_NAME[str]
+            ?: throw validationError(
+                ScenarioValidationMessage.InvalidLogic(
+                    label = label,
+                    value = str,
+                    allowed = SCORE_CALC_LOGICS_BY_YAML_NAME.keys.joinToString(", "),
+                ),
+            )
+    }
+
     private fun mapPhase(dict: JsonObject, index: Int): Phase =
         mapPhase(dict, label = "Phase $index", depth = 0)
 
@@ -397,14 +460,11 @@ public class ScenarioLoader {
      * Maps one phase mapping.
      *
      * [label] is used in error messages: top-level calls pass `"Phase K"`, and
-     * C2b's nested calls will pass `"Phase K.then[N]"` / `"Phase K.else[N]"` so
-     * the user can locate the offending sub-phase in their YAML. [depth] is `0`
-     * at top level; `>= 1` rejects a nested `conditional` at parse time, which
-     * defends the depth-1 rule before [ScenarioValidator] sees the scenario.
-     *
-     * **[depth] has no non-zero caller yet** — `then:` / `else:` descent is
-     * C2b's `mapBranch`. The parameter and its check are ported now so that
-     * diff adds only the recursion.
+     * the nested calls from [mapBranch] pass `"Phase K.then[N]"` /
+     * `"Phase K.else[N]"` so the user can locate the offending sub-phase in
+     * their YAML. [depth] is `0` at top level; `>= 1` rejects a nested
+     * `conditional` at parse time, which defends the depth-1 rule before
+     * [ScenarioValidator] sees the scenario.
      */
     private fun mapPhase(dict: JsonObject, label: String, depth: Int): Phase {
         val phaseType = parsePhaseType(dict, label, depth)
@@ -415,12 +475,21 @@ public class ScenarioLoader {
         val excludeSelf = parseOptional(dict, "exclude_self", label, YamlType.BOOL)
         val options = parseOptional(dict, "options", label, YamlType.STRING_LIST)
 
+        val target = parseAssignTarget(dict, label)
+        val outputSchema = parseOutputSchema(dict, label)
+        val pairing = parsePairing(dict, label)
+        val logic = parseLogic(dict, label)
+
         // speak_each `rounds:` → subRounds (the scenario-level `rounds` is a
         // different key on a different mapping).
         val subRounds = parseOptional(dict, "rounds", label, YamlType.INT)
 
-        // Conditional-specific `if:` expression. `then:` / `else:` are C2b.
+        // Conditional-specific fields (`if:` expression + `then:` / `else:`
+        // sub-phase arrays). The branches descend with depth+1, so a nested
+        // `conditional` is rejected by `parsePhaseType`.
         val condition = parseOptional(dict, "if", label, YamlType.STRING)
+        val thenPhases = mapBranch(dict["then"], "then", label, depth)
+        val elsePhases = mapBranch(dict["else"], "else", label, depth)
 
         // event_inject-specific fields. `probability` accepts an integral scalar
         // so the boundary literals `0` / `1` round-trip naturally; `as:` names
@@ -431,9 +500,11 @@ public class ScenarioLoader {
         // `exclude_self`; no validation needed — a bool is always well-formed.
         val noRepeat = parseOptional(dict, "no_repeat", label, YamlType.BOOL)
 
-        // relationship_update-specific (#910). YAML-only — no visual editing UI
-        // in v1 — but it round-trips through the editor's dual buffer.
+        // relationship_update-specific (#910). Both YAML-only — no visual
+        // editing UI in v1 — but they round-trip through the editor's dual
+        // buffer.
         val voteAgainst = parseOptional(dict, "vote_against", label, YamlType.INT)
+        val actionDeltas = parseActionDeltas(dict, label)
 
         // Per-phase statement brevity override (#881). The 1..6 range is
         // ScenarioValidator's, not the loader's — `load` stays non-validating.
@@ -443,33 +514,126 @@ public class ScenarioLoader {
         // commentator. Absent falls back to the Engine-owned default template.
         val narrator = parseOptional(dict, "narrator", label, YamlType.STRING)
 
-        // Every argument is named and present, including the seven this port
-        // does not map yet, so C2b's diff lands exactly on the gap rather than
-        // adding lines around it.
+        // pairwise_payoff table (ADR-027). YAML-only, round-tripping through
+        // the editor's dual buffer like `narrator` / `action_deltas`. An absent
+        // `payoff:` stays null — a guaranteed-no-op phase is the linter's to
+        // flag, not a load throw; only a malformed *present* table throws.
+        val payoff = parsePayoff(dict, label)
+
+        // Every argument is named, mirroring the Swift original's call.
         return Phase(
             type = phaseType,
             prompt = prompt,
-            outputSchema = null, // C2b
+            outputSchema = outputSchema,
             options = options,
-            pairing = null, // C2b
-            logic = null, // C2b
+            pairing = pairing,
+            logic = logic,
             template = template,
             source = source,
-            target = null, // C2b
+            target = target,
             excludeSelf = excludeSelf,
             subRounds = subRounds,
             maxSentences = maxSentences,
             condition = condition,
-            thenPhases = null, // C2b
-            elsePhases = null, // C2b
+            thenPhases = thenPhases,
+            elsePhases = elsePhases,
             probability = probability,
             eventVariable = eventVariable,
             voteAgainst = voteAgainst,
-            actionDeltas = null, // C2b
+            actionDeltas = actionDeltas,
             noRepeat = noRepeat,
             narrator = narrator,
-            payoff = null, // C2b
+            payoff = payoff,
         )
+    }
+
+    /**
+     * Parses the `payoff:` table for a `pairwise_payoff` `score_calc` phase — a
+     * list of `{when: [String], points: [Int]}` rows (ADR-027). Strict on
+     * arity: each `when` / `points` must hold exactly two elements. A malformed
+     * row throws rather than silently scoring a wrong verdict at runtime.
+     *
+     * Mixed semantics, matching Swift's cast ladder: `payoff:` itself is
+     * whole-collection ([YamlType.OBJECT_LIST], so a non-list names the key),
+     * while each row is checked individually and reports its own index. The
+     * `points` elements go through [YamlType.INT], which supplies the
+     * boolean and quoted-scalar exclusions Swift's `as? Int` guards spell out
+     * by hand (`!(value is Bool)`), plus the 32-bit range check of the class
+     * KDoc's divergence 4.
+     */
+    private fun parsePayoff(dict: JsonObject, label: String): List<PayoffRule>? {
+        val raw = dict["payoff"] ?: return null
+        val list = YamlType.OBJECT_LIST.cast(raw)
+            ?: throw validationError(
+                ScenarioValidationMessage.PayoffNotList(
+                    label = label,
+                    got = renderActualType(raw),
+                ),
+            )
+        return list.mapIndexed { index, row ->
+            val actions = row["when"]
+                ?.let { YamlType.STRING_LIST.cast(it) }
+                ?.takeIf { it.size == 2 }
+                ?: throw validationError(
+                    ScenarioValidationMessage.PayoffRowInvalid(
+                        label = label,
+                        detail = "row $index 'when' must be 2 strings",
+                    ),
+                )
+            val pointsRaw = (row["points"] as? JsonArray)?.takeIf { it.size == 2 }
+                ?: throw validationError(
+                    ScenarioValidationMessage.PayoffRowInvalid(
+                        label = label,
+                        detail = "row $index 'points' must be 2 ints",
+                    ),
+                )
+            val points = pointsRaw.map { element ->
+                YamlType.INT.cast(element)
+                    ?: throw validationError(
+                        ScenarioValidationMessage.PayoffRowInvalid(
+                            label = label,
+                            detail = "row $index 'points' has a non-Int value",
+                        ),
+                    )
+            }
+            PayoffRule(`when` = actions, points = points)
+        }
+    }
+
+    /**
+     * Parses the `action_deltas:` map for `relationship_update` phases — a
+     * mapping of choose-action value → affinity delta. Strict per #130: a
+     * non-Int value (`cooperate: "one"`) throws rather than silently coercing,
+     * and [YamlType.INT] excludes booleans and quoted scalars for the same
+     * reason Swift writes `!(value is Bool)` — `as? Int` launders one.
+     *
+     * **Deliberately not a [YamlType] whole-collection cast**, unlike the
+     * `STRING_LIST` / `OBJECT_LIST` sites a few lines up: Swift's
+     * `raw as? [String: Any]` succeeds on any mapping and then throws *per
+     * offending key*, so the message names the key the curator must fix. Only a
+     * non-mapping `raw` is whole-collection here.
+     */
+    private fun parseActionDeltas(dict: JsonObject, label: String): Map<String, Int>? {
+        val raw = dict["action_deltas"] ?: return null
+        val map = raw as? JsonObject
+            ?: throw validationError(
+                ScenarioValidationMessage.ActionDeltasNotDict(
+                    label = label,
+                    got = renderActualType(raw),
+                ),
+            )
+        return map.entries.associate { (key, value) ->
+            key to (
+                YamlType.INT.cast(value)
+                    ?: throw validationError(
+                        ScenarioValidationMessage.ActionDeltasValueNotInt(
+                            label = label,
+                            key = key,
+                            got = renderActualType(value),
+                        ),
+                    )
+                )
+        }
     }
 
     /**
@@ -491,6 +655,67 @@ public class ScenarioLoader {
             throw validationError(ScenarioValidationMessage.NestedConditionalNotAllowed(label))
         }
         return phaseType
+    }
+
+    /**
+     * Parses the `output:` schema mapping. Values must be strings — the schema
+     * is an LLM prompt hint, and a non-string value (e.g. `count: 1`) is a typo
+     * rather than a type shorthand worth preserving. It used to be stringified
+     * silently.
+     *
+     * **Deliberately not a [YamlType] whole-collection cast**, for the same
+     * reason as [parseActionDeltas]: Swift's `raw as? [String: Any]` succeeds on
+     * any mapping and then throws *per offending key*, so the message names the
+     * key. Only a non-mapping `raw` is whole-collection here.
+     */
+    private fun parseOutputSchema(dict: JsonObject, label: String): Map<String, String>? {
+        val raw = dict["output"] ?: return null
+        val output = raw as? JsonObject
+            ?: throw validationError(
+                ScenarioValidationMessage.OutputNotDict(
+                    label = label,
+                    got = renderActualType(raw),
+                ),
+            )
+        return output.entries.associate { (key, value) ->
+            key to (
+                value.stringContentOrNull()
+                    ?: throw validationError(
+                        ScenarioValidationMessage.OutputValueNotString(
+                            label = label,
+                            key = key,
+                            got = renderActualType(value),
+                        ),
+                    )
+                )
+        }
+    }
+
+    /**
+     * Maps a conditional's `then:` / `else:` sub-phase array, recursing into
+     * [mapPhase] at `depth + 1` so a nested `conditional` is rejected there.
+     *
+     * Whole-collection ([YamlType.OBJECT_LIST]), matching Swift's
+     * `as? [[String: Any]]`: one non-mapping element makes the branch
+     * wrong-shaped as a whole.
+     */
+    private fun mapBranch(
+        raw: JsonElement?,
+        branchLabel: String,
+        parentLabel: String,
+        depth: Int,
+    ): List<Phase>? {
+        val phasesRaw = raw ?: return null
+        val list = YamlType.OBJECT_LIST.cast(phasesRaw)
+            ?: throw validationError(
+                ScenarioValidationMessage.BranchNotArray(
+                    label = parentLabel,
+                    branch = branchLabel,
+                ),
+            )
+        return list.mapIndexed { subIndex, subRaw ->
+            mapPhase(subRaw, label = "$parentLabel.$branchLabel[$subIndex]", depth = depth + 1)
+        }
     }
 
     /**
@@ -574,6 +799,20 @@ public class ScenarioLoader {
 
         private val PHASE_TYPES_BY_YAML_NAME: Map<String, PhaseType> =
             serialNameLookup(PhaseType.serializer(), PhaseType.entries)
+
+        private val ASSIGN_TARGETS_BY_YAML_NAME: Map<String, AssignTarget> =
+            serialNameLookup(AssignTarget.serializer(), AssignTarget.entries)
+
+        private val PAIRING_STRATEGIES_BY_YAML_NAME: Map<String, PairingStrategy> =
+            serialNameLookup(PairingStrategy.serializer(), PairingStrategy.entries)
+
+        /**
+         * Also the source of [ScenarioValidationMessage.InvalidLogic]'s
+         * `allowed:` fragment — see [parseLogic] for why it is derived from the
+         * key order rather than written out.
+         */
+        private val SCORE_CALC_LOGICS_BY_YAML_NAME: Map<String, ScoreCalcLogic> =
+            serialNameLookup(ScoreCalcLogic.serializer(), ScoreCalcLogic.entries)
     }
 }
 
@@ -676,14 +915,17 @@ internal class YamlType<T> private constructor(
  * drift out of the loader (`.claude/rules/engine.md` § "Kotlin enum mirror" — the
  * mirrors that no compiler catches). Same source and same reasoning as the
  * forward direction, `PhaseType.serialName()` in `PhaseDispatcher.kt`; this is
- * generic because C2b needs it for three more enums, none of which has a
- * `serialName()` extension.
+ * generic because the loader needs it for four enums — [PhaseType],
+ * `AssignTarget`, `PairingStrategy` and `ScoreCalcLogic` — only the first of
+ * which has a `serialName()` extension.
  *
  * [entries] must be the enum's `entries` list: an enum serial descriptor names
  * its elements in declaration order, so index *i* is `entries[i]`. The
  * [require] guards the one way that could stop being true.
  *
- * Reused by C2b for `target:` / `pairing:` / `logic:`.
+ * Declaration order is load-bearing for one caller beyond lookup: the returned
+ * `LinkedHashMap`'s key order is what `ScenarioLoader.parseLogic` joins into
+ * [ScenarioValidationMessage.InvalidLogic]'s `allowed:` fragment.
  */
 internal fun <T : Enum<T>> serialNameLookup(
     serializer: KSerializer<T>,

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/ScenarioLoader.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/ScenarioLoader.kt
@@ -37,27 +37,6 @@ import kotlinx.serialization.json.JsonPrimitive
  * [ScenarioValidator]'s execution-limit / inference-cap / phase-semantic gate —
  * the returned scenario is well-formed but not yet known to be runnable.
  *
- * ## PORT IN PROGRESS — phase specialisation is not here yet (C2b)
- *
- * [mapPhase] maps exactly the phase fields reachable through the three generic
- * parse helpers. Every field needing a dedicated helper is still unmapped and is
- * passed to the [Phase] constructor as an explicit `null, // C2b`:
- * `output` (`parseOutputSchema`), `target` (`parseAssignTarget`),
- * `pairing` (`parsePairing`), `logic` (`parseLogic`), `then` / `else`
- * (`mapBranch`, the depth-1 conditional), `action_deltas`
- * (`parseActionDeltas`) and `payoff` (`parsePayoff`). A scenario using any of
- * them therefore loads with that field silently `null` here while Swift maps it
- * — which is why nothing calls this loader yet (see below).
- *
- * `ScenarioLoaderTests.phaseSpecialisationIsStillUnmapped` pins that list from
- * the test side and is written to go **red** the moment any of the seven starts
- * being mapped, so this section cannot outlive the gap it describes. **Three
- * artefacts describe this gap and must be deleted together**: that pin, this
- * section, and the "delete the next sentence when C2b lands" paragraph on
- * `ScenarioLoader.swift`'s `load(yaml:)` — the Swift one is the dangerous
- * straggler, because a stale "no Kotlin side to mirror yet" tells the next
- * editor to skip a mirror that by then exists.
- *
  * ## Not wired into the engine
  *
  * Nothing in `shared/engine` calls this, deliberately — the same posture as

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/ScenarioLoaderTestSupport.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/ScenarioLoaderTestSupport.kt
@@ -69,6 +69,11 @@ internal fun makeMinimalYAML(phasesBlock: String): String = buildString {
  * A two-persona (A / B) minimal `assign` scenario whose `target:` value is
  * [target] — for the strict `AssignTarget` parsing tests, which need an
  * otherwise-fixed fixture varying only that one token.
+ *
+ * Interpolated into a `trimIndent()`'d literal, unlike
+ * [makeMinimalYAML]'s `phasesBlock`, and safe only because [target] is a bare
+ * scalar token: a multi-line value would contribute lines to `trimIndent()`'s
+ * common-margin computation and mis-dedent the whole fixture.
  */
 internal fun makeYAMLWithAssignTarget(target: String): String = """
     id: t

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/ScenarioLoaderTestSupport.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/ScenarioLoaderTestSupport.kt
@@ -4,11 +4,10 @@ package com.pastura.engine
  * YAML fixture builders for [ScenarioLoaderTests].
  *
  * Kotlin counterpart of the private / file-scope helpers on Swift's
- * `ScenarioLoaderTests.swift` (`makeMinimalYAML()` / `makeMinimalYAML(phasesBlock:)`)
- * and `ScenarioLoaderTests+Language.swift` (`makeBaseYAML`). Collapsed into one
- * file, mirroring `ScenarioValidatorTestSupport.kt`'s precedent for this port
- * series — Swift's `makeYAMLWithAssignTarget` has no port here because none of
- * the 44 transcribed tests use it (the assign-target suite is deferred).
+ * `ScenarioLoaderTests.swift` (`makeMinimalYAML()` / `makeMinimalYAML(phasesBlock:)`
+ * / `makeYAMLWithAssignTarget`) and `ScenarioLoaderTests+Language.swift`
+ * (`makeBaseYAML`). Collapsed into one file, mirroring
+ * `ScenarioValidatorTestSupport.kt`'s precedent for this port series.
  */
 
 /**
@@ -65,6 +64,32 @@ internal fun makeMinimalYAML(phasesBlock: String): String = buildString {
     appendLine("    description: D")
     append(phasesBlock)
 }
+
+/**
+ * A two-persona (A / B) minimal `assign` scenario whose `target:` value is
+ * [target] — for the strict `AssignTarget` parsing tests, which need an
+ * otherwise-fixed fixture varying only that one token.
+ */
+internal fun makeYAMLWithAssignTarget(target: String): String = """
+    id: t
+    language: ja
+    name: T
+    description: T
+    agents: 2
+    rounds: 1
+    context: C
+    personas:
+      - name: A
+        description: D
+      - name: B
+        description: D
+    phases:
+      - type: assign
+        source: topics
+        target: $target
+    topics:
+      - x
+""".trimIndent()
 
 /**
  * A minimal scenario whose `language:` / `simulation_language:` lines are

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/ScenarioLoaderTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/ScenarioLoaderTests.kt
@@ -19,8 +19,13 @@ import kotlin.test.assertTrue
  * `ScenarioLoaderTests+Payoff.swift`, `ScenarioLoaderTests+MaxSentences.swift`
  * and the loader-facing arms of `ConditionalScenarioIOTests.swift`
  * (`Pastura/PasturaTests/Engine/`) — **69 1:1 transcriptions**, 44 from PR C2a
- * and 25 from C2b, each complete. The suite also carries tests beyond those 69:
- * the two "condition-4 sweep additions" regions.
+ * and 25 from C2b, each complete. The suite carries **88** tests in all —
+ * `88 = 69 transcriptions + 14 in the two "condition-4 sweep additions"
+ * regions + 3 sweep additions filed under "Validation Errors" instead, next to
+ * the mechanism they share a fold with (note 2) + 2 divergence pins`. Every non-transcription is a claimant some sweep
+ * asked for and says so in its own KDoc; the arithmetic is spelled out so a
+ * reader auditing the count can tell a bookkeeping slip from a missing
+ * transcription.
  *
  * **Scope.** Only [ScenarioLoader.load]'s behaviour is covered here, matching
  * [ScenarioLoader]'s own class KDoc. Two groups of Swift cases are therefore
@@ -74,7 +79,7 @@ import kotlin.test.assertTrue
  * | `STANDARD_KEYS` extra-data filter | `filterNot { it.key in STANDARD_KEYS }` → `filterNot { false }` | [parsesExtraDataStringArray] and 24 others | 24 — every fixture then routes `id` etc. through `convertToAnyCodableValue` |
  * | persona `secret` trim | `?.trim()` dropped | [trimsSurroundingWhitespaceFromPersonaSecret], [normalizesEmptyPersonaSecretToNil] | none |
  * | persona `secret` empty→null | `if (secret.isNullOrEmpty()) null else secret` → `secret` | [normalizesEmptyPersonaSecretToNil] | none |
- * | Nested-`conditional` depth guard | `if (… && depth > 0)` → `if (false)` | *(none — expected green, note 4)* | none |
+ * | Nested-`conditional` depth guard | `if (… && depth > 0)` → `if (false)` | [rejectsNestedConditionalInThenBranch], [rejectsNestedConditionalInElseBranch] — **re-measured in C2b**, note 4 | none |
  * | extra-data scalar `isString` guard | `&& value.isString` dropped | [throwsOnScalarTopLevelExtraData] | none |
  * | extra-data array-of-dicts whole-collection cast | `all { it is JsonObject }` → `any` | [throwsOnExtraDataArrayMixingDictAndScalar] — **added**, note 2 | none |
  * | …its non-String value throw | the `throw` → `?: ""` | [throwsOnNonStringValueInArrayOfDicts] | none |
@@ -125,9 +130,12 @@ import kotlin.test.assertTrue
  *    fails. The polarity flip is the compiling substitute, and it reddens the
  *    accepting fixture as well as the rejecting one.
  * 4. The nested-`conditional` depth guard was **structurally unreachable when
- *    this row was measured**: `depth` had no non-zero caller until `mapBranch`
- *    landed. Green then, and claimed now — see the C2b table's
- *    `mapBranch: depth + 1 recursion` row.
+ *    this row was first measured**: `depth` had no non-zero caller until
+ *    `mapBranch` landed. Green then. C2b re-ran this exact mutation once
+ *    `mapBranch` existed, and it reddens; the cell above now names its
+ *    claimants. The guard (in `parsePhaseType`) and the recursion (in
+ *    `mapBranch`) are two different mutations that happen to share detectors —
+ *    the C2b table carries the recursion as its own row.
  * 5. `Int` is 32-bit in Kotlin and 64-bit in Swift, so this mechanism and its
  *    `Int64` rendering exist only on this side and have no Swift twin to
  *    transcribe. [throwsOnIntegerBeyond32Bits] is the detector for what was
@@ -148,14 +156,24 @@ import kotlin.test.assertTrue
  *
  * ## ADR-023 §12 condition-4 perturbation record — C2b surface
  *
- * Same procedure, same guarantees, scoped to what PR C2b added: the seven
- * phase-specialisation helpers, `mapBranch`'s recursion, and the seven
- * `mapPhase` arguments that stopped being `null`. C2a's ingest and
- * generic-helper surface is **not** re-swept — it was swept whole above, and
- * the table's three reassigned cells were re-measured rather than assumed.
- * **34 mutations executed, 33 reddened, 1 green** (the negative control).
- * Baseline: 85 tests green immediately before the first mutation and again
- * after the last revert. Measured 2026-08-26, #1560 (PR C2b).
+ * Same procedure, same guarantees, scoped to what PR C2b added: six
+ * phase-specialisation helpers plus `mapBranch` and its recursion, and the
+ * seven `mapPhase` arguments that stopped being `null`. (Six helpers, seven
+ * arguments — `then` / `else` is one helper feeding two fields.) C2a's ingest
+ * and generic-helper surface is **not** re-swept: it was swept whole above.
+ *
+ * Four C2a-surface mutations *are* re-run here, and appear as rows in this
+ * table rather than as a claim in prose — the three cells whose claimant this
+ * PR deleted (`Phase wiring: prompt` / `source` / `if → condition`) and note
+ * 4's depth guard, which only became reachable once `mapBranch` landed. An
+ * unrecorded re-measurement is indistinguishable from an inference, which is
+ * the standard this record already holds its non-executing attempts to.
+ *
+ * **41 mutations executed, 40 reddened, 1 green** (the negative control):
+ * 34 on C2b's own surface, 4 re-measured from C2a's table, and 3 added in a
+ * second pass to claim mechanisms the first pass exposed. Baseline: 88 tests
+ * green immediately before the first mutation and again after the last revert.
+ * Measured 2026-08-26, #1560 (PR C2b).
  *
  * | Mechanism broken | Mutation | Dedicated claimant | Incidental |
  * |---|---|---|---|
@@ -172,7 +190,14 @@ import kotlin.test.assertTrue
  * | `payoff:` row `when` arity 2 | `takeIf { it.size == 2 }` → `takeIf { true }` | [throwsOnWhenArityNotTwo] | none |
  * | `payoff:` row `points` array cast + arity | same `takeIf` flip | [throwsOnPointsArityNotTwo] | none |
  * | `payoff:` row `points` element throw | the `?: throw …PayoffRowInvalid` made unreachable | [throwsOnNonIntPayoffPointsValue] — **added**, note 9 | 1 |
- * | `payoff:` row `points` bool / quoted exclusion | `YamlType.INT.cast` → a lenient `content.toIntOrNull()` | [throwsOnQuotedPayoffPointsValue] — **added**, note 9 | none |
+ * | `payoff:` row `points` quoted-scalar exclusion | `YamlType.INT.cast` → a lenient `content.toIntOrNull()` | [throwsOnQuotedPayoffPointsValue] — **added**, note 9 | none |
+ * | `payoff:` row `points` boolean exclusion | `true` special-cased to `1` ahead of the cast | [throwsOnBoolPayoffPointsValue] — **added**, note 9 | none |
+ * | `payoff:` row `points` 32-bit range (divergence 4) | the range check dropped from the cast | [throwsOnPayoffPointsBeyond32Bits] — **added**, note 10 | none |
+ * | `action_deltas` value 32-bit range + `Int64` rendering (divergence 4) | same | [throwsOnActionDeltaBeyond32Bits] — **added**, note 10 | none |
+ * | *(C2a surface, re-measured)* Phase wiring: `prompt` | read → `null` | [parsesPhaseSpeakAll] | 1 |
+ * | *(C2a surface, re-measured)* Phase wiring: `source` | read → `null` | [parsesEventInjectFullSpec], [parsesEventInjectMinimalSpec] | 1 |
+ * | *(C2a surface, re-measured)* Phase wiring: `if` → `condition` | read → `null` | [loadsConditionalWithBothBranches] | none |
+ * | *(C2a surface, re-measured)* Nested-`conditional` depth guard | `if (… && depth > 0)` → `if (false)` | [rejectsNestedConditionalInThenBranch], [rejectsNestedConditionalInElseBranch] | none |
  * | `action_deltas:` absent → `null` | `?: return null` → `?: JsonNull` | [parsesRelationshipUpdateMinimalSpec] and 39 others | 39 |
  * | `action_deltas:` non-mapping throw | the `?: throw …ActionDeltasNotDict` → an empty mapping | [throwsOnNonDictActionDeltas] — **added**, note 9 | none |
  * | `action_deltas:` per-value `Int` throw | the `?: throw …ActionDeltasValueNotInt` → `?: 0` | [throwsOnNonIntActionDeltaValue] | none |
@@ -200,13 +225,23 @@ import kotlin.test.assertTrue
  *    transcribed case only asserted that loading throws. Re-ordering the
  *    fragment left the suite green. The assertion now spells the whole string
  *    out in declaration order.
- * 9. **Four mechanisms had no claimant on either side.** Swift's `+Payoff`
+ * 9. **Six mechanisms had no claimant on either side.** Swift's `+Payoff`
  *    suite covers both arity failures but never a well-sized row holding a bad
  *    value; no Swift test feeds a non-mapping `action_deltas:`; and every
  *    conditional test asserts on a *well-formed* branch, so nothing read the
  *    sub-phase label that is a curator's only way to locate the offending
  *    phase. Each gained a test in the "condition-4 sweep additions (C2b
- *    surface)" region.
+ *    surface)" region, joined by the boolean-exclusion fixture the first pass
+ *    itself missed: nothing fed `points: [3, true]`, and Swift needs its
+ *    explicit `!(value is Bool)` at that spot precisely because `as? Int`
+ *    launders one into `1`.
+ * 10. **Divergence 4 gained two specific, testable claims in this PR** — an
+ *    out-of-32-bit-range `payoff:` `points` element reports
+ *    `PayoffRowInvalid`, an `action_deltas` value reports
+ *    `ActionDeltasValueNotInt` — and neither had a detector. Same shape as
+ *    note 5: a KDoc claim with nothing behind it is not a claim. Both have one
+ *    now, and the `action_deltas` case also pins the `Int64` `got:` rendering
+ *    that keeps the message from reading "must be Int, got Int".
  *
  *    Six mutations in an earlier pass — the `?: throw` arms — were first
  *    attempted as `if (false) { throw … }` and did **not** compile, the same
@@ -1205,7 +1240,12 @@ class ScenarioLoaderTests {
     fun rejectsAssignWithUnknownTarget() {
         val yaml = makeYAMLWithAssignTarget("randomOne") // typo of random_one
         val caught = assertFailsWith<SimulationException> { loader.load(yaml) }
-        assertTrue(caught.error is SimulationError.ScenarioValidationFailed)
+        val error = caught.error
+        assertTrue(error is SimulationError.ScenarioValidationFailed)
+        // Strengthened beyond the Swift original, which only checks that
+        // loading throws: a `label` / `value` argument swap in the throw would
+        // otherwise stay green. Same reason as [rejectsScoreCalcWithUnknownLogic].
+        assertTrue(error.message.contains("'randomOne'"), error.message)
     }
 
     /**
@@ -1216,12 +1256,21 @@ class ScenarioLoaderTests {
     fun rejectsAssignWithCapitalizedTarget() {
         val yaml = makeYAMLWithAssignTarget("All")
         val caught = assertFailsWith<SimulationException> { loader.load(yaml) }
-        assertTrue(caught.error is SimulationError.ScenarioValidationFailed)
+        val error = caught.error
+        assertTrue(error is SimulationError.ScenarioValidationFailed)
+        // Strengthened beyond the Swift original, which only checks that
+        // loading throws: a `label` / `value` argument swap in the throw would
+        // otherwise stay green. Same reason as [rejectsScoreCalcWithUnknownLogic].
+        assertTrue(error.message.contains("'All'"), error.message)
     }
 
     @Test
     fun acceptsAssignWithCanonicalTargetAll() {
-        loader.load(makeYAMLWithAssignTarget("all"))
+        val scenario = loader.load(makeYAMLWithAssignTarget("all"))
+        // Swift asserts only that loading succeeds, but nothing else in the
+        // suite reads `AssignTarget.ALL` — [parsesPhaseWithAllFields] covers
+        // only `RANDOM_ONE` — so a mis-mapped `all` key would be invisible.
+        assertEquals(AssignTarget.ALL, scenario.phases[0].target)
     }
 
     @Test
@@ -1244,7 +1293,12 @@ class ScenarioLoaderTests {
             """.trimIndent(),
         )
         val caught = assertFailsWith<SimulationException> { loader.load(yaml) }
-        assertTrue(caught.error is SimulationError.ScenarioValidationFailed)
+        val error = caught.error
+        assertTrue(error is SimulationError.ScenarioValidationFailed)
+        // Strengthened beyond the Swift original, which only checks that
+        // loading throws: a `label` / `value` argument swap in the throw would
+        // otherwise stay green. Same reason as [rejectsScoreCalcWithUnknownLogic].
+        assertTrue(error.message.contains("'roundRobin'"), error.message)
     }
 
     /**
@@ -1689,8 +1743,11 @@ class ScenarioLoaderTests {
      * arity, which a serializer<->loader round-trip alone cannot (a symmetric
      * mis-key round-trips). Kotlin counterpart of Swift's `payoffHeader`
      * private computed property (`ScenarioLoaderTests+Payoff.swift`); local to
-     * this region rather than [makeMinimalYAML] since only these five tests
-     * use its Alice/Bob-named personas.
+     * this region rather than [makeMinimalYAML] since only the payoff cases
+     * need its Alice/Bob-named personas. Like [makeMinimalYAML], it builds with
+     * [buildString] because [phasesBlock] arrives dedented to column 0 —
+     * `trimIndent()` over the concatenation would compute one margin across
+     * both halves and mis-indent the shorter one.
      */
     private fun makePayoffYAML(phasesBlock: String): String = buildString {
         appendLine("id: t")
@@ -1937,36 +1994,6 @@ class ScenarioLoaderTests {
 
         val caught = assertFailsWith<SimulationException> { loader.load(yaml) }
         assertTrue(caught.error is SimulationError.ScenarioValidationFailed)
-    }
-
-    /**
-     * A `then:` / `else:` that is not a list of mappings is rejected, naming
-     * the branch.
-     *
-     * **No Swift twin to transcribe.** `ScenarioValidationMessage.branchNotArray`
-     * is rendered by `ScenarioValidationMessageTests.swift` but no Swift loader
-     * test reaches `mapBranch`'s cast, so the mechanism ships unclaimed on both
-     * sides; this is the Kotlin-side claimant, in the same category as the
-     * "condition-4 sweep additions" region below.
-     *
-     * Asserts the rendered branch name rather than the exception type alone:
-     * `then:` and `else:` share the mechanism, and a `label`/`branch` argument
-     * swap is exactly the kind of break a type-only assertion sleeps through.
-     */
-    @Test
-    fun throwsOnScalarThenBranch() {
-        val yaml = makeMinimalYAML(
-            """
-                phases:
-                  - type: conditional
-                    if: "current_round == 1"
-                    then: not_a_list
-            """.trimIndent(),
-        )
-        val caught = assertFailsWith<SimulationException> { loader.load(yaml) }
-        val error = caught.error
-        assertTrue(error is SimulationError.ScenarioValidationFailed)
-        assertTrue(error.message.contains("'then'"), error.message)
     }
 
     // endregion
@@ -2273,6 +2300,111 @@ class ScenarioLoaderTests {
         val error = caught.error
         assertTrue(error is SimulationError.ScenarioValidationFailed)
         assertTrue(error.message.contains("'points' has a non-Int value"), error.message)
+    }
+
+    /**
+     * A `then:` / `else:` that is not a list of mappings is rejected, naming
+     * the branch.
+     *
+     * **No Swift twin to transcribe.** `ScenarioValidationMessage.branchNotArray`
+     * is rendered by `ScenarioValidationMessageTests.swift` but no Swift loader
+     * test reaches `mapBranch`'s cast, so the mechanism ships unclaimed on both
+     * sides; this is the Kotlin-side claimant, in the same category as the
+     * "condition-4 sweep additions" region below.
+     *
+     * Asserts the rendered branch name rather than the exception type alone:
+     * `then:` and `else:` share the mechanism, and a `label`/`branch` argument
+     * swap is exactly the kind of break a type-only assertion sleeps through.
+     */
+    @Test
+    fun throwsOnScalarThenBranch() {
+        val yaml = makeMinimalYAML(
+            """
+                phases:
+                  - type: conditional
+                    if: "current_round == 1"
+                    then: not_a_list
+            """.trimIndent(),
+        )
+        val caught = assertFailsWith<SimulationException> { loader.load(yaml) }
+        val error = caught.error
+        assertTrue(error is SimulationError.ScenarioValidationFailed)
+        assertTrue(error.message.contains("'then'"), error.message)
+    }
+
+    /**
+     * A **boolean** `points:` element is rejected.
+     *
+     * The third of the guard's three halves. Swift needs an explicit
+     * `!(value is Bool)` here because `as? Int` launders a boolean into `1` /
+     * `0` — the #130 type-laundering class the whole helper family exists to
+     * prevent — and a `payoff:` row silently scoring `1` for `true` is a wrong
+     * verdict, not a parse warning. Kotlin gets the exclusion from
+     * [YamlType.INT]; without a fixture, a caller that special-cased `true`
+     * would stay green.
+     */
+    @Test
+    fun throwsOnBoolPayoffPointsValue() {
+        val yaml = makePayoffYAML(
+            """
+                - type: score_calc
+                  logic: pairwise_payoff
+                  payoff:
+                    - when: [a, b]
+                      points: [3, true]
+            """.trimIndent(),
+        )
+        val caught = assertFailsWith<SimulationException> { loader.load(yaml) }
+        val error = caught.error
+        assertTrue(error is SimulationError.ScenarioValidationFailed)
+        assertTrue(error.message.contains("'points' has a non-Int value"), error.message)
+    }
+
+    /**
+     * An out-of-32-bit-range `points:` element is rejected — the phase-level
+     * half of the class KDoc's **divergence 4**.
+     *
+     * `PayoffRule.points` is `List<Int>`, so a value Swift accepts (its `Int` is
+     * 64-bit) is a `PayoffRowInvalid` here. Truncating would be worse than the
+     * divergence: it would score a different table than the author wrote. The
+     * KDoc names this exact message, and note 5's lesson is that a KDoc claim
+     * with no detector behind it is not a claim.
+     */
+    @Test
+    fun throwsOnPayoffPointsBeyond32Bits() {
+        val yaml = makePayoffYAML(
+            """
+                - type: score_calc
+                  logic: pairwise_payoff
+                  payoff:
+                    - when: [a, b]
+                      points: [2147483648, 0]
+            """.trimIndent(),
+        )
+        val caught = assertFailsWith<SimulationException> { loader.load(yaml) }
+        val error = caught.error
+        assertTrue(error is SimulationError.ScenarioValidationFailed)
+        assertTrue(error.message.contains("'points' has a non-Int value"), error.message)
+    }
+
+    /** The `action_deltas` half of the same divergence-4 claim. */
+    @Test
+    fun throwsOnActionDeltaBeyond32Bits() {
+        val yaml = makeMinimalYAML(
+            """
+                phases:
+                  - type: relationship_update
+                    action_deltas:
+                      cooperate: 2147483648
+            """.trimIndent(),
+        )
+        val caught = assertFailsWith<SimulationException> { loader.load(yaml) }
+        val error = caught.error
+        assertTrue(error is SimulationError.ScenarioValidationFailed)
+        assertTrue(error.message.contains("action_deltas value for 'cooperate'"), error.message)
+        // The `got:` fragment is Int64, not Int — see divergence 4. A bare
+        // "must be Int, got Int" would be the bewildering message it avoids.
+        assertTrue(error.message.contains("Int64"), error.message)
     }
 
     /** A scalar `action_deltas:` is rejected, naming the field. */

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/ScenarioLoaderTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/ScenarioLoaderTests.kt
@@ -15,33 +15,20 @@ import kotlin.test.assertTrue
 
 /**
  * commonTest sibling of Swift's `ScenarioLoaderTests.swift`,
- * `ScenarioLoaderTests+Language.swift`, and `ScenarioLoaderTests+StrictTypes.swift`
- * (`Pastura/PasturaTests/Engine/`) — all 44 of the port's planned 1:1
- * transcriptions are present, though [parsesPhaseSpeakAll] is a *partial* one
- * (see below). The suite also carries tests beyond those 44: the
- * "condition-4 sweep additions" region and the C2b gap pin.
+ * `ScenarioLoaderTests+Language.swift`, `ScenarioLoaderTests+StrictTypes.swift`,
+ * `ScenarioLoaderTests+Payoff.swift`, `ScenarioLoaderTests+MaxSentences.swift`
+ * and the loader-facing arms of `ConditionalScenarioIOTests.swift`
+ * (`Pastura/PasturaTests/Engine/`) — **69 1:1 transcriptions**, 44 from PR C2a
+ * and 25 from C2b, each complete. The suite also carries tests beyond those 69:
+ * the two "condition-4 sweep additions" regions.
  *
- * **Scope.** Only [ScenarioLoader.load]'s YAML-ingest and top-level-mapping
- * behaviour is covered here, matching [ScenarioLoader]'s own class KDoc: the
- * six `estimateInferenceCount` tests (that estimator landed separately, in
- * [InferenceEstimator]), `parsesPhaseWithAllFields`, the three
- * `relationship_update` tests, and the eleven enum / `outputSchema` /
- * `payoff` arms of `ScenarioLoaderTests+StrictTypes.swift` are deferred to a
- * follow-up PR — [ScenarioLoader.mapPhase]'s KDoc documents `output`,
- * `target`, `pairing`, `logic`, `then` / `else`, `action_deltas`, and `payoff`
- * as unmapped "C2b" fields, so a test asserting on any of them cannot pass
- * against today's loader.
- *
- * **[parsesPhaseSpeakAll] is a *partial* transcription, and the only one.**
- * Swift's version makes three assertions; its third reads
- * `phase.outputSchema?["statement"]`, which is exactly the C2b gap above —
- * [ScenarioLoader.mapPhase] passes `outputSchema` through as a hardcoded
- * `null`. The two `speak_all` fields this port *does* map are asserted here so
- * the case is not silently missing from the suite, and the dropped third
- * assertion is not simply lost: [phaseSpecialisationIsStillUnmapped] asserts
- * `outputSchema` is `null` for a phase that declares an `output:` block, so C2b
- * cannot restore Swift's assertion without first reddening that pin. Read the
- * two together — neither alone is the full Swift case.
+ * **Scope.** Only [ScenarioLoader.load]'s behaviour is covered here, matching
+ * [ScenarioLoader]'s own class KDoc. Two groups of Swift cases are therefore
+ * deliberately absent rather than pending: the six `estimateInferenceCount`
+ * tests, which belong to [InferenceEstimator] and live in
+ * `InferenceEstimatorTests.kt` (`ScenarioLoader.swift` is a `SPLIT` ledger
+ * row), and `ConditionalScenarioIOTests`' `roundTrip*` arms, which exercise
+ * the Swift-only `ScenarioSerializer` (`STAY` per ADR-023 §4).
  *
  * ## ADR-023 §12 condition-4 perturbation record
  *
@@ -1855,6 +1842,36 @@ class ScenarioLoaderTests {
         assertTrue(caught.error is SimulationError.ScenarioValidationFailed)
     }
 
+    /**
+     * A `then:` / `else:` that is not a list of mappings is rejected, naming
+     * the branch.
+     *
+     * **No Swift twin to transcribe.** `ScenarioValidationMessage.branchNotArray`
+     * is rendered by `ScenarioValidationMessageTests.swift` but no Swift loader
+     * test reaches `mapBranch`'s cast, so the mechanism ships unclaimed on both
+     * sides; this is the Kotlin-side claimant, in the same category as the
+     * "condition-4 sweep additions" region below.
+     *
+     * Asserts the rendered branch name rather than the exception type alone:
+     * `then:` and `else:` share the mechanism, and a `label`/`branch` argument
+     * swap is exactly the kind of break a type-only assertion sleeps through.
+     */
+    @Test
+    fun throwsOnScalarThenBranch() {
+        val yaml = makeMinimalYAML(
+            """
+                phases:
+                  - type: conditional
+                    if: "current_round == 1"
+                    then: not_a_list
+            """.trimIndent(),
+        )
+        val caught = assertFailsWith<SimulationException> { loader.load(yaml) }
+        val error = caught.error
+        assertTrue(error is SimulationError.ScenarioValidationFailed)
+        assertTrue(error.message.contains("'then'"), error.message)
+    }
+
     // endregion
 
     // region condition-4 sweep additions
@@ -1863,8 +1880,7 @@ class ScenarioLoaderTests {
      * Every test in this region was added because the ADR-023 §12 condition-4
      * sweep broke the mechanism it names and the suite stayed green — no
      * transcribed Swift case reached it. Only [throwsOnIntegerBeyond32Bits]
-     * (and, added separately below in the C2b gap / divergence-4 region,
-     * `throwsOnIntegerBeyondLongRange`) cover Kotlin-only mechanisms with no
+     * and [throwsOnIntegerBeyondLongRange] cover Kotlin-only mechanisms with no
      * Swift twin to transcribe. The rest — [throwsOnQuotedProbability],
      * [throwsOnExtraDataArrayMixingDictAndScalar],
      * [throwsOnPersonasListWithScalarElement], and [parsesNoRepeat] — cover
@@ -2096,89 +2112,6 @@ class ScenarioLoaderTests {
         )
         val scenario = loader.load(yaml)
         assertEquals(true, scenario.phases[0].excludeSelf)
-    }
-
-    // endregion
-
-    // region C2b gap pin
-
-    /**
-     * Pins the seven phase fields this port deliberately leaves unmapped.
-     *
-     * The YAML below populates every one of them, and every assertion says
-     * `null`. That inverts the usual polarity on purpose: the test is **not**
-     * asserting correct behaviour — it is asserting a known-incomplete state,
-     * so that the moment C2b teaches [ScenarioLoader.mapPhase] to read any of
-     * these keys, this test goes red and forces both itself and the
-     * `PORT IN PROGRESS` section of [ScenarioLoader]'s class KDoc to be
-     * deleted. A pin that self-destructs is the point; one that stayed green
-     * after the gap closed would be the coverage theater
-     * `.claude/rules/kmp-interop.md` Pattern 4 warns about.
-     *
-     * The `assertEquals(5, …)` does **not** guard against a `load` that rejects
-     * this fixture outright — a rejection throws out of `loader.load` and this
-     * test fails right there, at the `loader.load(yaml)` call, before any
-     * `assertNull` runs. What it actually guards is a `load` that *succeeds*
-     * but silently returns a shorter or empty phase list: without the size
-     * check, a five-`assertNull` pin against a zero-or-short `phases` list
-     * would go vacuous (an out-of-bounds index throws `IndexOutOfBounds`,
-     * which itself would fail the test — but only accidentally, and a
-     * `phases` list padded with unrelated phases at the checked indices would
-     * not even do that).
-     *
-     * **Delete this whole region in C2b**, together with the KDoc section it
-     * names.
-     */
-    @Test
-    fun phaseSpecialisationIsStillUnmapped() {
-        val yaml = makeMinimalYAML(
-            """
-                phases:
-                  - type: choose
-                    prompt: "Choose"
-                    output:
-                      action: string
-                    pairing: round_robin
-                  - type: assign
-                    source: words
-                    target: random_one
-                  - type: score_calc
-                    logic: pairwise_payoff
-                    payoff:
-                      - when: [cooperate, cooperate]
-                        points: [3, 3]
-                  - type: relationship_update
-                    action_deltas:
-                      betray: -2
-                  - type: conditional
-                    if: "round == 1"
-                    then:
-                      - type: speak_all
-                        prompt: "Hi"
-                    else:
-                      - type: eliminate
-            """.trimIndent(),
-        )
-        val phases = loader.load(yaml).phases
-        assertEquals(5, phases.size)
-
-        assertNull(phases[0].outputSchema, "output: is C2b")
-        assertNull(phases[0].pairing, "pairing: is C2b")
-        assertNull(phases[1].target, "target: is C2b")
-        assertNull(phases[2].logic, "logic: is C2b")
-        assertNull(phases[2].payoff, "payoff: is C2b")
-        assertNull(phases[3].actionDeltas, "action_deltas: is C2b")
-        assertNull(phases[4].thenPhases, "then: is C2b")
-        assertNull(phases[4].elsePhases, "else: is C2b")
-
-        // The C2a-mapped fields on the same phases DO land — this half of the
-        // pin is a positive control, so a `load` that silently returned an
-        // empty phase would fail here rather than passing the assertNulls.
-        assertEquals("Choose", phases[0].prompt)
-        assertEquals("words", phases[1].source)
-        assertEquals(PhaseType.SCORE_CALC, phases[2].type)
-        assertEquals(PhaseType.RELATIONSHIP_UPDATE, phases[3].type)
-        assertEquals("round == 1", phases[4].condition)
     }
 
     // endregion

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/ScenarioLoaderTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/ScenarioLoaderTests.kt
@@ -22,10 +22,10 @@ import kotlin.test.assertTrue
  * and 25 from C2b, each complete. The suite carries **88** tests in all —
  * `88 = 69 transcriptions + 14 in the two "condition-4 sweep additions"
  * regions + 3 sweep additions filed under "Validation Errors" instead, next to
- * the mechanism they share a fold with (note 2) + 2 divergence pins`. Every non-transcription is a claimant some sweep
- * asked for and says so in its own KDoc; the arithmetic is spelled out so a
- * reader auditing the count can tell a bookkeeping slip from a missing
- * transcription.
+ * the mechanisms they share a fold with (note 2) + 2 divergence pins`. Every
+ * non-transcription is either a sweep claimant or a divergence pin, and says
+ * which in its own KDoc; the arithmetic is spelled out so a reader auditing the
+ * count can tell a bookkeeping slip from a missing transcription.
  *
  * **Scope.** Only [ScenarioLoader.load]'s behaviour is covered here, matching
  * [ScenarioLoader]'s own class KDoc. Two groups of Swift cases are therefore
@@ -79,7 +79,7 @@ import kotlin.test.assertTrue
  * | `STANDARD_KEYS` extra-data filter | `filterNot { it.key in STANDARD_KEYS }` → `filterNot { false }` | [parsesExtraDataStringArray] and 24 others | 24 — every fixture then routes `id` etc. through `convertToAnyCodableValue` |
  * | persona `secret` trim | `?.trim()` dropped | [trimsSurroundingWhitespaceFromPersonaSecret], [normalizesEmptyPersonaSecretToNil] | none |
  * | persona `secret` empty→null | `if (secret.isNullOrEmpty()) null else secret` → `secret` | [normalizesEmptyPersonaSecretToNil] | none |
- * | Nested-`conditional` depth guard | `if (… && depth > 0)` → `if (false)` | [rejectsNestedConditionalInThenBranch], [rejectsNestedConditionalInElseBranch] — **re-measured in C2b**, note 4 | none |
+ * | Nested-`conditional` depth guard | `if (… && depth > 0)` → `if (false)` | *(none — green in C2a, note 4)*; red under C2b: [rejectsNestedConditionalInThenBranch], [rejectsNestedConditionalInElseBranch] | none |
  * | extra-data scalar `isString` guard | `&& value.isString` dropped | [throwsOnScalarTopLevelExtraData] | none |
  * | extra-data array-of-dicts whole-collection cast | `all { it is JsonObject }` → `any` | [throwsOnExtraDataArrayMixingDictAndScalar] — **added**, note 2 | none |
  * | …its non-String value throw | the `throw` → `?: ""` | [throwsOnNonStringValueInArrayOfDicts] | none |
@@ -122,9 +122,10 @@ import kotlin.test.assertTrue
  *    scalars, a `personas:` list holding a scalar, an absent `type:`, `no_repeat`,
  *    or a non-mapping YAML root (a sequence, or an empty document) either — see
  *    each addition's own KDoc for the specific gap. Each gained a test in the
- *    "condition-4 sweep additions" region, except the non-mapping-root pair
- *    ([throwsOnNonMappingRoot], [throwsOnEmptyDocument]), which sit in the
- *    "Validation Errors" region next to the mechanism they share a fold with.
+ *    "condition-4 sweep additions" region, except three —
+ *    [throwsOnMissingPhaseType], [throwsOnNonMappingRoot] and
+ *    [throwsOnEmptyDocument] — which sit in the "Validation Errors" region next
+ *    to the mechanisms they share a fold with.
  * 3. `if (false)` does **not** compile on the `simulation_language` arm: the
  *    smart cast from the `!= null` half is lost and the later `!!`-free use
  *    fails. The polarity flip is the compiling substitute, and it reddens the
@@ -192,8 +193,8 @@ import kotlin.test.assertTrue
  * | `payoff:` row `points` element throw | the `?: throw …PayoffRowInvalid` made unreachable | [throwsOnNonIntPayoffPointsValue] — **added**, note 9 | 1 |
  * | `payoff:` row `points` quoted-scalar exclusion | `YamlType.INT.cast` → a lenient `content.toIntOrNull()` | [throwsOnQuotedPayoffPointsValue] — **added**, note 9 | none |
  * | `payoff:` row `points` boolean exclusion | `true` special-cased to `1` ahead of the cast | [throwsOnBoolPayoffPointsValue] — **added**, note 9 | none |
- * | `payoff:` row `points` 32-bit range (divergence 4) | the range check dropped from the cast | [throwsOnPayoffPointsBeyond32Bits] — **added**, note 10 | none |
- * | `action_deltas` value 32-bit range + `Int64` rendering (divergence 4) | same | [throwsOnActionDeltaBeyond32Bits] — **added**, note 10 | none |
+ * | `payoff:` row `points` 32-bit range (divergence 4) | the `YamlType.INT.cast` call replaced **site-locally** by a lenient `toLongOrNull()?.toInt()`, note 11 | [throwsOnPayoffPointsBeyond32Bits] — **added**, note 10 | none |
+ * | `action_deltas` value 32-bit range (divergence 4) | same, site-local, note 11 | [throwsOnActionDeltaBeyond32Bits] — **added**, note 10 | none |
  * | *(C2a surface, re-measured)* Phase wiring: `prompt` | read → `null` | [parsesPhaseSpeakAll] | 1 |
  * | *(C2a surface, re-measured)* Phase wiring: `source` | read → `null` | [parsesEventInjectFullSpec], [parsesEventInjectMinimalSpec] | 1 |
  * | *(C2a surface, re-measured)* Phase wiring: `if` → `condition` | read → `null` | [loadsConditionalWithBothBranches] | none |
@@ -243,11 +244,20 @@ import kotlin.test.assertTrue
  *    now, and the `action_deltas` case also pins the `Int64` `got:` rendering
  *    that keeps the message from reading "must be Int, got Int".
  *
- *    Six mutations in an earlier pass — the `?: throw` arms — were first
- *    attempted as `if (false) { throw … }` and did **not** compile, the same
- *    shape as note 3. They were re-run as elvis-substitutions and are counted
- *    once, in the form that executed; the non-compiling attempts are not
- *    evidence and are not among the 34.
+ *     Six mutations in an earlier pass — the `?: throw` arms — were first
+ *     attempted as `if (false) { throw … }` and did **not** compile, the same
+ *     shape as note 3. They were re-run as elvis-substitutions and are counted
+ *     once, in the form that executed; the non-compiling attempts are not
+ *     evidence and are not among the 41.
+ * 11. **Both divergence-4 mutations are site-local on purpose.** Editing the
+ *     shared `YamlType.INT` range check instead — C2a's own
+ *     `YamlType.INT 32-bit range check` row — would have reddened
+ *     [throwsOnIntegerBeyond32Bits] as well, and the two new tests each other,
+ *     so the row would have measured C2a's mechanism rather than the
+ *     phase-level claim it exists to defend. `Incidental | none` on both rows
+ *     is the measured result of the site-local form. The `Int64` `got:`
+ *     rendering [throwsOnActionDeltaBeyond32Bits] also asserts is **not**
+ *     mutated here — that is C2a's `renderActualType Int64 arm` row.
  */
 class ScenarioLoaderTests {
 
@@ -2243,11 +2253,13 @@ class ScenarioLoaderTests {
     // region condition-4 sweep additions (C2b surface)
 
     /*
-     * Every test in this region was added because the ADR-023 §12 condition-4
-     * sweep over C2b's surface broke the mechanism it names and the suite
-     * stayed green — no transcribed Swift case reached it, and Swift has no
-     * dedicated claimant for it either. They are Kotlin-side claimants for
-     * mechanisms both ports share, the same category as the region above.
+     * Every test in this region claims a mechanism that had no dedicated
+     * claimant on **either** side: no transcribed Swift case reaches it, and
+     * Swift has none of its own. All but one were found by the ADR-023 §12
+     * condition-4 sweep over C2b's surface — the mutation landed and the suite
+     * stayed green. The exception is [throwsOnScalarThenBranch], written ahead
+     * of the sweep from reading the Swift suite; its own KDoc says so. Same
+     * category as the region above.
      */
 
     /**
@@ -2309,8 +2321,11 @@ class ScenarioLoaderTests {
      * **No Swift twin to transcribe.** `ScenarioValidationMessage.branchNotArray`
      * is rendered by `ScenarioValidationMessageTests.swift` but no Swift loader
      * test reaches `mapBranch`'s cast, so the mechanism ships unclaimed on both
-     * sides; this is the Kotlin-side claimant, in the same category as the
-     * "condition-4 sweep additions" region below.
+     * sides; this is the Kotlin-side claimant. Written **before** the sweep
+     * rather than because of it — the gap was visible from the Swift suite — so
+     * it is the one test in this region the preamble's "the sweep found it"
+     * does not describe. The sweep then confirmed it also catches a
+     * `label` / `branch` argument swap.
      *
      * Asserts the rendered branch name rather than the exception type alone:
      * `then:` and `else:` share the mechanism, and a `label`/`branch` argument
@@ -2335,7 +2350,7 @@ class ScenarioLoaderTests {
     /**
      * A **boolean** `points:` element is rejected.
      *
-     * The third of the guard's three halves. Swift needs an explicit
+     * The third of the guard's three exclusions. Swift needs an explicit
      * `!(value is Bool)` here because `as? Int` launders a boolean into `1` /
      * `0` — the #130 type-laundering class the whole helper family exists to
      * prevent — and a `payoff:` row silently scoring `1` for `true` is a wrong

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/ScenarioLoaderTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/ScenarioLoaderTests.kt
@@ -61,7 +61,7 @@ import kotlin.test.assertTrue
  * | Mechanism broken | Mutation | Dedicated claimant | Incidental |
  * |---|---|---|---|
  * | Code-fence strip | `filterNot { … startsWith("```") }` → `filterNot { false }` | [stripsCodeFencesBeforeParsing] | none |
- * | Decode failure → `InvalidYAMLFormat` | the `throw` → `JsonObject(emptyMap())` | [throwsOnInvalidYAML] — assertion **strengthened**, note 1; also [throwsOnIntegerBeyondLongRange] (added post-sweep, C2b/divergence-4 region — same fold, not itself sweep-mutated) | none |
+ * | Decode failure → `InvalidYAMLFormat` | the `throw` → `JsonObject(emptyMap())` | [throwsOnInvalidYAML] — assertion **strengthened**, note 1; also [throwsOnIntegerBeyondLongRange] (added post-sweep — same fold, not itself sweep-mutated) | none |
  * | Non-mapping root → `InvalidYAMLFormat` | the `?: throw` → `?: JsonObject(emptyMap())` | [throwsOnNonMappingRoot], [throwsOnEmptyDocument] — both **added**, note 2 | none |
  * | `parseRequired` missing-key arm | `?: throw …MissingRequiredField` → `?: JsonNull` | [throwsOnMissingRequiredField] — assertion **strengthened**, note 1 | none |
  * | `parseRequired` wrong-type arm | early-return the cast, no throw | [throwsOnWrongTypeForRequiredString], [throwsOnWrongTypeForRequiredInt], [throwsOnWrongTypeForPersonasList], [throwsOnWrongTypeForPersonaName] | none |
@@ -91,15 +91,15 @@ import kotlin.test.assertTrue
  * | `renderActualType` `Int64` arm | `"Int64"` → `"Int"` | [throwsOnIntegerBeyond32Bits] — **added**, note 5 | none |
  * | `PhaseType` serial-name lookup | unknown type → `PhaseType.SPEAK_ALL` | [throwsOnInvalidPhaseType] | none |
  * | Missing-`type:` throw | `?: throw …PhaseMissingType` → `?: "speak_all"` | [throwsOnMissingPhaseType] — **added**, note 2 | none |
- * | Phase wiring: `prompt` | read → hardcoded `null` | [parsesPhaseSpeakAll], [phaseSpecialisationIsStillUnmapped] | none |
+ * | Phase wiring: `prompt` | read → hardcoded `null` | [parsesPhaseSpeakAll] | none |
  * | Phase wiring: `exclude_self` | read → `null` | [acceptsYAML11BooleanExcludeSelf], [throwsOnQuotedExcludeSelf], [throwsOnIntExcludeSelf] | none |
  * | Phase wiring: `options` | read → `null` | [throwsOnMixedTypeOptions] | none |
  * | Phase wiring: `rounds` → `subRounds` | read → `null` | [throwsOnQuotedSubRounds] | none |
  * | Phase wiring: `probability` | read → `null` | [parsesProbabilityAsDouble], [parsesProbabilityAsIntCoercesToDouble], [throwsOnProbabilityWrongType], [throwsOnProbabilityBoolPretendingToBeInt], [parsesEventInjectFullSpec] | none |
  * | Phase wiring: `as` → `eventVariable` | read → `null` | [parsesEventInjectFullSpec] | none |
  * | Phase wiring: `no_repeat` | read → `null` | [parsesNoRepeat] — **added**, note 2 | none |
- * | Phase wiring: `source` | read → `null` | [parsesEventInjectFullSpec], [parsesEventInjectMinimalSpec], [phaseSpecialisationIsStillUnmapped] | none |
- * | Phase wiring: `if` → `condition` | read → `null` | [phaseSpecialisationIsStillUnmapped] | none |
+ * | Phase wiring: `source` | read → `null` | [parsesEventInjectFullSpec], [parsesEventInjectMinimalSpec] | none |
+ * | Phase wiring: `if` → `condition` | read → `null` | [loadsConditionalWithBothBranches] — reassigned in C2b, note 7 | none |
  * | Scenario wiring: `log_window` | read → `null` | [parsesLogWindow], [rejectsNonIntLogWindow] | none |
  * | `YamlType.BOOL` token lookup on a **quoted** token (divergence 2) | *(not sweep-mutated; added post-sweep as a divergence pin)* | [throwsOnQuotedExcludeSelf] pins the rejecting case; [divergesOnQuotedYesExcludeSelf] pins the accepting (divergent) one | none
  * | **NEGATIVE CONTROL** — `acceptedLanguagesList` ordering | `.sorted()` → `.sortedDescending()` | *(none — expected green)* | none |
@@ -124,9 +124,10 @@ import kotlin.test.assertTrue
  *    smart cast from the `!= null` half is lost and the later `!!`-free use
  *    fails. The polarity flip is the compiling substitute, and it reddens the
  *    accepting fixture as well as the rejecting one.
- * 4. The nested-`conditional` depth guard is **structurally unreachable in this
- *    port**: `depth` has no non-zero caller until C2b's `mapBranch` descends
- *    into `then:` / `else:`. Expected green; C2b must claim it.
+ * 4. The nested-`conditional` depth guard was **structurally unreachable when
+ *    this row was measured**: `depth` had no non-zero caller until `mapBranch`
+ *    landed. Green then, and claimed now — see the C2b table's
+ *    `mapBranch: depth + 1 recursion` row.
  * 5. `Int` is 32-bit in Kotlin and 64-bit in Swift, so this mechanism and its
  *    `Int64` rendering exist only on this side and have no Swift twin to
  *    transcribe. [throwsOnIntegerBeyond32Bits] is the detector for what was
@@ -136,6 +137,82 @@ import kotlin.test.assertTrue
  *    guarded on its own. Expected green — kept because a future caller without
  *    that guard would need it, and removing it would make this file's one
  *    boolean-literal predicate quietly wrong.
+ * 7. **Reassigned in C2b.** The three cells above that named
+ *    `phaseSpecialisationIsStillUnmapped` lost their claimant when C2b deleted
+ *    that pin. Two were over-claimed and simply drop it ([parsesPhaseSpeakAll]
+ *    and the two `event_inject` cases already detect those breaks on their
+ *    own); `Phase wiring: if → condition` had the pin as its **sole** claimant
+ *    and is reassigned to [loadsConditionalWithBothBranches], which asserts
+ *    `phase.condition` directly. Re-measured under the C2b sweep below, not
+ *    inferred.
+ *
+ * ## ADR-023 §12 condition-4 perturbation record — C2b surface
+ *
+ * Same procedure, same guarantees, scoped to what PR C2b added: the seven
+ * phase-specialisation helpers, `mapBranch`'s recursion, and the seven
+ * `mapPhase` arguments that stopped being `null`. C2a's ingest and
+ * generic-helper surface is **not** re-swept — it was swept whole above, and
+ * the table's three reassigned cells were re-measured rather than assumed.
+ * **34 mutations executed, 33 reddened, 1 green** (the negative control).
+ * Baseline: 85 tests green immediately before the first mutation and again
+ * after the last revert. Measured 2026-08-26, #1560 (PR C2b).
+ *
+ * | Mechanism broken | Mutation | Dedicated claimant | Incidental |
+ * |---|---|---|---|
+ * | `target:` unknown-value throw | the `?: throw …InvalidTarget` dropped | [rejectsAssignWithUnknownTarget], [rejectsAssignWithCapitalizedTarget] | none |
+ * | `target:` routes through [parseOptional] first | the `parseOptional` call → a raw type-name read | [throwsOnIntAssignTarget] | 5 |
+ * | `pairing:` unknown-value throw | the `?: throw …InvalidPairing` dropped | [rejectsChooseWithUnknownPairing] | none |
+ * | `pairing:` routes through [parseOptional] first | same shape | [throwsOnIntChoosePairing] | 2 |
+ * | `logic:` unknown-value throw | the `?: throw …InvalidLogic` → a fallback enum case | [rejectsScoreCalcWithUnknownLogic] | none |
+ * | `logic:` routes through [parseOptional] first | same shape | [throwsOnBoolScoreCalcLogic] | 5 |
+ * | `allowed:` fragment derived from the lookup's key order | `.keys.joinToString` → `.keys.sorted().joinToString` | [rejectsScoreCalcWithUnknownLogic] — assertion **strengthened**, note 8 | none |
+ * | `payoff:` absent → `null` | `?: return null` → `?: JsonNull` | [absentPayoffLeavesNilNotThrow] and 40 others | 40 |
+ * | `payoff:` whole-collection cast | the `?: throw …PayoffNotList` → `?: emptyList()` | [throwsOnPayoffNotList] | none |
+ * | `payoff:` row `when` string-list cast | `STRING_LIST.cast` → a lenient `toString()` map | [parsesPayoffTableOnScoreCalc] | none |
+ * | `payoff:` row `when` arity 2 | `takeIf { it.size == 2 }` → `takeIf { true }` | [throwsOnWhenArityNotTwo] | none |
+ * | `payoff:` row `points` array cast + arity | same `takeIf` flip | [throwsOnPointsArityNotTwo] | none |
+ * | `payoff:` row `points` element throw | the `?: throw …PayoffRowInvalid` made unreachable | [throwsOnNonIntPayoffPointsValue] — **added**, note 9 | 1 |
+ * | `payoff:` row `points` bool / quoted exclusion | `YamlType.INT.cast` → a lenient `content.toIntOrNull()` | [throwsOnQuotedPayoffPointsValue] — **added**, note 9 | none |
+ * | `action_deltas:` absent → `null` | `?: return null` → `?: JsonNull` | [parsesRelationshipUpdateMinimalSpec] and 39 others | 39 |
+ * | `action_deltas:` non-mapping throw | the `?: throw …ActionDeltasNotDict` → an empty mapping | [throwsOnNonDictActionDeltas] — **added**, note 9 | none |
+ * | `action_deltas:` per-value `Int` throw | the `?: throw …ActionDeltasValueNotInt` → `?: 0` | [throwsOnNonIntActionDeltaValue] | none |
+ * | `output:` absent → `null` | `?: return null` → `?: JsonNull` | [parsesPhaseWithAllFields] and 33 others | 33 |
+ * | `output:` non-mapping throw | the `?: throw …OutputNotDict` → an empty mapping | [throwsOnNonDictOutputSchema] | none |
+ * | `output:` per-value `String` throw | the `?: throw …OutputValueNotString` → `?: ""` | [throwsOnNonStringOutputSchemaValue] | none |
+ * | `then:` / `else:` absent → `null` | `?: return null` → `?: JsonNull` | [loadsConditionalWithOnlyThenBranch] and 41 others | 41 |
+ * | `mapBranch` whole-collection cast | the `?: throw …BranchNotArray` → `?: emptyList()` | [throwsOnScalarThenBranch] — **added** in the C2b gap-retirement commit | none |
+ * | `mapBranch` names the **branch**, not the parent | `branch = branchLabel` → `branch = parentLabel` | [throwsOnScalarThenBranch] | none |
+ * | `mapBranch` descends at `depth + 1` | `depth = depth + 1` → `depth = depth` | [rejectsNestedConditionalInThenBranch], [rejectsNestedConditionalInElseBranch] | none |
+ * | `mapBranch` sub-phase label form | `"$parent.$branch[$i]"` → `"$parent"` | [namesTheOffendingSubPhaseInsideABranch] — **added**, note 9 | none |
+ * | Phase wiring: `output` → `outputSchema` | read → `null` | [parsesPhaseSpeakAll] | none |
+ * | Phase wiring: `pairing` | read → `null` | [parsesPhaseWithAllFields] | none |
+ * | Phase wiring: `logic` | read → `null` | [parsesPhaseWithAllFields] | none |
+ * | Phase wiring: `target` | read → `null` | [parsesPhaseWithAllFields] | none |
+ * | Phase wiring: `then` → `thenPhases` | read → `null` | [loadsConditionalWithBothBranches], [loadsConditionalWithOnlyThenBranch] | none |
+ * | Phase wiring: `else` → `elsePhases` | read → `null` | [loadsConditionalWithBothBranches] | none |
+ * | Phase wiring: `action_deltas` | read → `null` | [parsesRelationshipUpdateFullSpec] | none |
+ * | Phase wiring: `payoff` | read → `null` | [parsesPayoffTableOnScoreCalc] | none |
+ * | **NEGATIVE CONTROL** — `parsePayoff` KDoc wording | "matching" → "mirroring" | *(none — expected green)* | none |
+ *
+ * 8. The `allowed:` fragment is derived from
+ *    `ScenarioLoader.SCORE_CALC_LOGICS_BY_YAML_NAME`'s key order *so that* it
+ *    cannot drift from the enum — but nothing detected a drift, because the
+ *    transcribed case only asserted that loading throws. Re-ordering the
+ *    fragment left the suite green. The assertion now spells the whole string
+ *    out in declaration order.
+ * 9. **Four mechanisms had no claimant on either side.** Swift's `+Payoff`
+ *    suite covers both arity failures but never a well-sized row holding a bad
+ *    value; no Swift test feeds a non-mapping `action_deltas:`; and every
+ *    conditional test asserts on a *well-formed* branch, so nothing read the
+ *    sub-phase label that is a curator's only way to locate the offending
+ *    phase. Each gained a test in the "condition-4 sweep additions (C2b
+ *    surface)" region.
+ *
+ *    Six mutations in an earlier pass — the `?: throw` arms — were first
+ *    attempted as `if (false) { throw … }` and did **not** compile, the same
+ *    shape as note 3. They were re-run as elvis-substitutions and are counted
+ *    once, in the form that executed; the non-compiling attempts are not
+ *    evidence and are not among the 34.
  */
 class ScenarioLoaderTests {
 
@@ -1170,6 +1247,19 @@ class ScenarioLoaderTests {
         assertTrue(caught.error is SimulationError.ScenarioValidationFailed)
     }
 
+    /**
+     * Assertion **strengthened** beyond the Swift original, which only checks
+     * that loading throws.
+     *
+     * The `allowed:` fragment is derived from
+     * `ScenarioLoader.SCORE_CALC_LOGICS_BY_YAML_NAME`'s key order rather than
+     * hand-written, precisely so it cannot drift from the enum — but the
+     * condition-4 sweep found that nothing detected a drift: re-ordering the
+     * fragment left the suite green. This spells the whole string out, in
+     * `ScoreCalcLogic` declaration order, matching what Swift's
+     * `allCases.map(\.rawValue).joined(separator: ", ")` renders. A sixth
+     * case, or a re-ordering, reddens here.
+     */
     @Test
     fun rejectsScoreCalcWithUnknownLogic() {
         val yaml = makeMinimalYAML(
@@ -1180,7 +1270,14 @@ class ScenarioLoaderTests {
             """.trimIndent(),
         )
         val caught = assertFailsWith<SimulationException> { loader.load(yaml) }
-        assertTrue(caught.error is SimulationError.ScenarioValidationFailed)
+        val error = caught.error
+        assertTrue(error is SimulationError.ScenarioValidationFailed)
+        assertTrue(
+            error.message.contains(
+                "prisoners_dilemma, vote_tally, wordwolf_judge, event_reactive, pairwise_payoff",
+            ),
+            error.message,
+        )
     }
 
     // endregion
@@ -2112,6 +2209,115 @@ class ScenarioLoaderTests {
         )
         val scenario = loader.load(yaml)
         assertEquals(true, scenario.phases[0].excludeSelf)
+    }
+
+    // endregion
+
+    // region condition-4 sweep additions (C2b surface)
+
+    /*
+     * Every test in this region was added because the ADR-023 §12 condition-4
+     * sweep over C2b's surface broke the mechanism it names and the suite
+     * stayed green — no transcribed Swift case reached it, and Swift has no
+     * dedicated claimant for it either. They are Kotlin-side claimants for
+     * mechanisms both ports share, the same category as the region above.
+     */
+
+    /**
+     * A non-Int `points:` element is rejected. Swift's `+Payoff` suite covers
+     * both arity failures but never a well-sized row holding a bad value, so
+     * the per-element guard (`YamlType.INT`, i.e. Swift's
+     * `as? Int, !(value is Bool)`) shipped unclaimed.
+     */
+    @Test
+    fun throwsOnNonIntPayoffPointsValue() {
+        val yaml = makePayoffYAML(
+            """
+                - type: score_calc
+                  logic: pairwise_payoff
+                  payoff:
+                    - when: [a, b]
+                      points: [3, "x"]
+            """.trimIndent(),
+        )
+        val caught = assertFailsWith<SimulationException> { loader.load(yaml) }
+        val error = caught.error
+        assertTrue(error is SimulationError.ScenarioValidationFailed)
+        assertTrue(error.message.contains("'points' has a non-Int value"), error.message)
+    }
+
+    /**
+     * A **quoted** `points:` element is rejected too.
+     *
+     * Separate from [throwsOnNonIntPayoffPointsValue] because it claims a
+     * different half of the guard: that one detects the throw going missing,
+     * this one detects the *cast* being loosened to a lenient
+     * `content.toIntOrNull()`, which would accept `"3"` and drop the 32-bit
+     * range check with it. Swift needs its explicit `!(value is Bool)` at the
+     * same spot for the same reason — `as? Int` launders a boolean — and
+     * rejects a quoted scalar identically, so this is parity, not a Kotlin
+     * house rule.
+     */
+    @Test
+    fun throwsOnQuotedPayoffPointsValue() {
+        val yaml = makePayoffYAML(
+            """
+                - type: score_calc
+                  logic: pairwise_payoff
+                  payoff:
+                    - when: [a, b]
+                      points: [3, "3"]
+            """.trimIndent(),
+        )
+        val caught = assertFailsWith<SimulationException> { loader.load(yaml) }
+        val error = caught.error
+        assertTrue(error is SimulationError.ScenarioValidationFailed)
+        assertTrue(error.message.contains("'points' has a non-Int value"), error.message)
+    }
+
+    /** A scalar `action_deltas:` is rejected, naming the field. */
+    @Test
+    fun throwsOnNonDictActionDeltas() {
+        val yaml = makeMinimalYAML(
+            """
+                phases:
+                  - type: relationship_update
+                    action_deltas: not_a_dict
+            """.trimIndent(),
+        )
+        val caught = assertFailsWith<SimulationException> { loader.load(yaml) }
+        val error = caught.error
+        assertTrue(error is SimulationError.ScenarioValidationFailed)
+        assertTrue(error.message.contains("'action_deltas'"), error.message)
+    }
+
+    /**
+     * An error raised **inside** a `then:` sub-phase names that sub-phase, not
+     * its parent.
+     *
+     * `mapBranch`'s `"$parentLabel.$branchLabel[$subIndex]"` label is the only
+     * thing that lets a curator find the offending phase in a conditional, and
+     * the sweep showed that collapsing it to the bare parent label left the
+     * suite green — every other conditional test asserts on a *well-formed*
+     * branch.
+     */
+    @Test
+    fun namesTheOffendingSubPhaseInsideABranch() {
+        val yaml = makeMinimalYAML(
+            """
+                phases:
+                  - type: conditional
+                    if: "current_round == 1"
+                    then:
+                      - type: speak_each
+                        prompt: "Talk"
+                        rounds: "3"
+            """.trimIndent(),
+        )
+        val caught = assertFailsWith<SimulationException> { loader.load(yaml) }
+        val error = caught.error
+        assertTrue(error is SimulationError.ScenarioValidationFailed)
+        assertTrue(error.message.contains("Phase 0.then[0]"), error.message)
     }
 
     // endregion

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/ScenarioLoaderTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/ScenarioLoaderTests.kt
@@ -1,10 +1,15 @@
 package com.pastura.engine
 
+import com.pastura.models.AssignTarget
+import com.pastura.models.PairingStrategy
+import com.pastura.models.PayoffRule
 import com.pastura.models.PhaseType
+import com.pastura.models.ScoreCalcLogic
 import com.pastura.models.SimulationError
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
@@ -184,21 +189,95 @@ class ScenarioLoaderTests {
         assertEquals(1, scenario.phases.size)
     }
 
-    /**
-     * Swift's `parsesPhaseSpeakAll`, minus its third assertion.
-     *
-     * Swift also reads `phase.outputSchema?["statement"]`; `output:` is one of
-     * the seven C2b fields [ScenarioLoader.mapPhase] leaves `null`, and
-     * [phaseSpecialisationIsStillUnmapped] is what pins that gap until C2b
-     * closes it. The two `speak_all` fields this port *does* map are asserted
-     * here so the case is not silently absent from the suite in the meantime.
-     */
     @Test
     fun parsesPhaseSpeakAll() {
         val scenario = loader.load(makeMinimalYAML())
         val phase = scenario.phases[0]
         assertEquals(PhaseType.SPEAK_ALL, phase.type)
         assertEquals("Speak your mind.", phase.prompt)
+        assertEquals("string", phase.outputSchema?.get("statement"))
+    }
+
+    @Test
+    fun parsesPhaseWithAllFields() {
+        val yaml = """
+            id: test
+            language: ja
+            name: Test
+            description: Test
+            agents: 2
+            rounds: 1
+            context: Context
+            personas:
+              - name: A
+                description: A
+              - name: B
+                description: B
+            phases:
+              - type: choose
+                prompt: "Choose!"
+                output:
+                  action: string
+                options:
+                  - cooperate
+                  - betray
+                pairing: round_robin
+              - type: score_calc
+                logic: prisoners_dilemma
+              - type: summarize
+                template: "{agent1}({action1}) vs {agent2}({action2})"
+              - type: vote
+                prompt: "Vote!"
+                output:
+                  vote: string
+                exclude_self: true
+              - type: speak_each
+                prompt: "Talk"
+                output:
+                  statement: string
+                rounds: 3
+              - type: assign
+                source: words
+                target: random_one
+              - type: eliminate
+        """.trimIndent()
+        val scenario = loader.load(yaml)
+
+        // choose phase
+        val choose = scenario.phases[0]
+        assertEquals(PhaseType.CHOOSE, choose.type)
+        assertEquals(listOf("cooperate", "betray"), choose.options)
+        assertEquals(PairingStrategy.ROUND_ROBIN, choose.pairing)
+
+        // score_calc phase
+        val scoreCalc = scenario.phases[1]
+        assertEquals(PhaseType.SCORE_CALC, scoreCalc.type)
+        assertEquals(ScoreCalcLogic.PRISONERS_DILEMMA, scoreCalc.logic)
+
+        // summarize phase
+        val summarize = scenario.phases[2]
+        assertEquals(PhaseType.SUMMARIZE, summarize.type)
+        assertEquals("{agent1}({action1}) vs {agent2}({action2})", summarize.template)
+
+        // vote phase
+        val vote = scenario.phases[3]
+        assertEquals(PhaseType.VOTE, vote.type)
+        assertEquals(true, vote.excludeSelf)
+
+        // speak_each phase
+        val speakEach = scenario.phases[4]
+        assertEquals(PhaseType.SPEAK_EACH, speakEach.type)
+        assertEquals(3, speakEach.subRounds)
+
+        // assign phase
+        val assign = scenario.phases[5]
+        assertEquals(PhaseType.ASSIGN, assign.type)
+        assertEquals("words", assign.source)
+        assertEquals(AssignTarget.RANDOM_ONE, assign.target)
+
+        // eliminate phase
+        val eliminate = scenario.phases[6]
+        assertEquals(PhaseType.ELIMINATE, eliminate.type)
     }
 
     // endregion
@@ -667,6 +746,61 @@ class ScenarioLoaderTests {
 
     // endregion
 
+    // region relationship_update phase parsing (#910)
+
+    @Test
+    fun parsesRelationshipUpdateFullSpec() {
+        val yaml = makeMinimalYAML(
+            """
+                phases:
+                  - type: relationship_update
+                    vote_against: -1
+                    action_deltas:
+                      cooperate: 1
+                      betray: -2
+            """.trimIndent(),
+        )
+        val scenario = loader.load(yaml)
+        val phase = scenario.phases[0]
+        assertEquals(PhaseType.RELATIONSHIP_UPDATE, phase.type)
+        assertEquals(-1, phase.voteAgainst)
+        assertEquals(mapOf("cooperate" to 1, "betray" to -2), phase.actionDeltas)
+    }
+
+    @Test
+    fun parsesRelationshipUpdateMinimalSpec() {
+        // Both rule fields are optional at parse time; the shape check that
+        // requires >= 1 rule lives at the validator gate (#910 later commit).
+        val yaml = makeMinimalYAML(
+            """
+                phases:
+                  - type: relationship_update
+            """.trimIndent(),
+        )
+        val scenario = loader.load(yaml)
+        val phase = scenario.phases[0]
+        assertEquals(PhaseType.RELATIONSHIP_UPDATE, phase.type)
+        assertNull(phase.voteAgainst)
+        assertNull(phase.actionDeltas)
+    }
+
+    @Test
+    fun throwsOnNonIntActionDeltaValue() {
+        // Strict per #130: a String delta value is a typo, not a coercion.
+        val yaml = makeMinimalYAML(
+            """
+                phases:
+                  - type: relationship_update
+                    action_deltas:
+                      cooperate: "one"
+            """.trimIndent(),
+        )
+        val caught = assertFailsWith<SimulationException> { loader.load(yaml) }
+        assertTrue(caught.error is SimulationError.ScenarioValidationFailed)
+    }
+
+    // endregion
+
     // region language field (DoD #2, #5, #6)
 
     @Test
@@ -997,6 +1131,73 @@ class ScenarioLoaderTests {
 
     // endregion
 
+    // region Assign target parsing (strict)
+
+    /**
+     * Typo'd target string is rejected at parse time (was a silent `.all`
+     * default before #108 / typed `AssignTarget`).
+     */
+    @Test
+    fun rejectsAssignWithUnknownTarget() {
+        val yaml = makeYAMLWithAssignTarget("randomOne") // typo of random_one
+        val caught = assertFailsWith<SimulationException> { loader.load(yaml) }
+        assertTrue(caught.error is SimulationError.ScenarioValidationFailed)
+    }
+
+    /**
+     * Case is significant — `target: All` was previously silently treated as
+     * the default; now rejected.
+     */
+    @Test
+    fun rejectsAssignWithCapitalizedTarget() {
+        val yaml = makeYAMLWithAssignTarget("All")
+        val caught = assertFailsWith<SimulationException> { loader.load(yaml) }
+        assertTrue(caught.error is SimulationError.ScenarioValidationFailed)
+    }
+
+    @Test
+    fun acceptsAssignWithCanonicalTargetAll() {
+        loader.load(makeYAMLWithAssignTarget("all"))
+    }
+
+    @Test
+    fun acceptsAssignWithCanonicalTargetRandomOne() {
+        loader.load(makeYAMLWithAssignTarget("random_one"))
+    }
+
+    // endregion
+
+    // region Pairing / logic parsing (strict)
+
+    @Test
+    fun rejectsChooseWithUnknownPairing() {
+        val yaml = makeMinimalYAML(
+            """
+                phases:
+                  - type: choose
+                    pairing: roundRobin
+                    options: [a, b]
+            """.trimIndent(),
+        )
+        val caught = assertFailsWith<SimulationException> { loader.load(yaml) }
+        assertTrue(caught.error is SimulationError.ScenarioValidationFailed)
+    }
+
+    @Test
+    fun rejectsScoreCalcWithUnknownLogic() {
+        val yaml = makeMinimalYAML(
+            """
+                phases:
+                  - type: score_calc
+                    logic: made_up_logic
+            """.trimIndent(),
+        )
+        val caught = assertFailsWith<SimulationException> { loader.load(yaml) }
+        assertTrue(caught.error is SimulationError.ScenarioValidationFailed)
+    }
+
+    // endregion
+
     // region Phase-optional field wrong-type errors (#130 item 2)
 
     /** `rounds: "3"` (accidentally quoted in YAML) previously coerced silently
@@ -1079,6 +1280,52 @@ class ScenarioLoaderTests {
         )
         val scenario = loader.load(yaml)
         assertEquals(true, scenario.phases[0].excludeSelf)
+    }
+
+    // endregion
+
+    // region parseOutputSchema strict (#130 item 3)
+
+    /**
+     * `output: { count: 1 }` previously stringified `1` to `"1"` silently. The
+     * schema is an LLM prompt hint — a non-String value is almost always a typo.
+     */
+    @Test
+    fun throwsOnNonStringOutputSchemaValue() {
+        val yaml = makeMinimalYAML(
+            """
+                phases:
+                  - type: speak_all
+                    prompt: "Go"
+                    output:
+                      statement: string
+                      count: 1
+            """.trimIndent(),
+        )
+        val caught = assertFailsWith<SimulationException> { loader.load(yaml) }
+        val error = caught.error
+        assertTrue(error is SimulationError.ScenarioValidationFailed)
+        val msg = error.message
+        assertTrue(msg.contains("output"))
+        assertTrue(msg.contains("'count'"))
+    }
+
+    /**
+     * `output: "string"` (scalar instead of dict) previously just skipped the
+     * schema (no-op). Strict loader throws so users catch the mis-shape.
+     */
+    @Test
+    fun throwsOnNonDictOutputSchema() {
+        val yaml = makeMinimalYAML(
+            """
+                phases:
+                  - type: speak_all
+                    prompt: "Go"
+                    output: "string"
+            """.trimIndent(),
+        )
+        val caught = assertFailsWith<SimulationException> { loader.load(yaml) }
+        assertTrue(caught.error is SimulationError.ScenarioValidationFailed)
     }
 
     // endregion
@@ -1227,6 +1474,385 @@ class ScenarioLoaderTests {
         val error = caught.error
         assertTrue(error is SimulationError.ScenarioValidationFailed)
         assertTrue(error.message.contains("'options'"))
+    }
+
+    // endregion
+
+    // region Enum-valued phase fields wrong-type (#211)
+
+    /**
+     * `target: 42` previously coerced silently via `as? String` -> `nil`,
+     * running the assign phase with no target. Strict loader throws with the
+     * unified wrong-type format (via `parseOptional<String>`).
+     */
+    @Test
+    fun throwsOnIntAssignTarget() {
+        val yaml = makeMinimalYAML(
+            """
+                phases:
+                  - type: assign
+                    source: words
+                    target: 42
+            """.trimIndent(),
+        )
+        val caught = assertFailsWith<SimulationException> { loader.load(yaml) }
+        val error = caught.error
+        assertTrue(error is SimulationError.ScenarioValidationFailed)
+        val msg = error.message
+        assertTrue(msg.contains("'target'"))
+        assertTrue(msg.contains("String"))
+        assertTrue(!msg.lowercase().contains("missing"))
+        // Distinguish from the invalid-enum-value branch ("has invalid target: ...").
+        assertTrue(!msg.contains("invalid target"))
+    }
+
+    /**
+     * `pairing: 42` previously coerced silently to `nil`, running `choose`
+     * with no pairing strategy. Strict loader throws.
+     */
+    @Test
+    fun throwsOnIntChoosePairing() {
+        val yaml = makeMinimalYAML(
+            """
+                phases:
+                  - type: choose
+                    pairing: 42
+                    options: [a, b]
+            """.trimIndent(),
+        )
+        val caught = assertFailsWith<SimulationException> { loader.load(yaml) }
+        val error = caught.error
+        assertTrue(error is SimulationError.ScenarioValidationFailed)
+        val msg = error.message
+        assertTrue(msg.contains("'pairing'"))
+        assertTrue(msg.contains("String"))
+        assertTrue(!msg.lowercase().contains("missing"))
+        assertTrue(!msg.contains("invalid pairing"))
+    }
+
+    /**
+     * `logic: true` (YAML 1.1 bare boolean) previously coerced silently to
+     * `nil`, producing a score_calc phase with no scoring logic. Strict
+     * loader throws.
+     */
+    @Test
+    fun throwsOnBoolScoreCalcLogic() {
+        val yaml = makeMinimalYAML(
+            """
+                phases:
+                  - type: score_calc
+                    logic: true
+            """.trimIndent(),
+        )
+        val caught = assertFailsWith<SimulationException> { loader.load(yaml) }
+        val error = caught.error
+        assertTrue(error is SimulationError.ScenarioValidationFailed)
+        val msg = error.message
+        assertTrue(msg.contains("'logic'"))
+        assertTrue(msg.contains("String"))
+        assertTrue(!msg.lowercase().contains("missing"))
+        assertTrue(!msg.contains("invalid logic"))
+    }
+
+    // endregion
+
+    // region max_sentences on phase (#881)
+
+    /**
+     * Parse coverage for the per-phase `max_sentences:` key (#881) — guards
+     * the literal YAML key name, which a serializer<->loader round-trip alone
+     * cannot (a symmetric mis-key would still round-trip).
+     */
+    @Test
+    fun parsesMaxSentencesOnPhase() {
+        val yaml = """
+            id: t
+            language: ja
+            name: T
+            description: d
+            agents: 2
+            rounds: 1
+            context: c
+            personas:
+              - name: Alice
+                description: a
+              - name: Bob
+                description: b
+            phases:
+              - type: speak_each
+                prompt: "Speak."
+                max_sentences: 5
+                output:
+                  statement: string
+              - type: speak_all
+                prompt: "Speak."
+                output:
+                  statement: string
+        """.trimIndent()
+        val scenario = loader.load(yaml)
+        assertEquals(5, scenario.phases[0].maxSentences)
+        // Absent key -> null (no backward-compat fill).
+        assertNull(scenario.phases[1].maxSentences)
+    }
+
+    // endregion
+
+    // region payoff table on score_calc phase (ADR-027)
+
+    /**
+     * Parse coverage for the `payoff:` table on a `pairwise_payoff`
+     * `score_calc` phase (ADR-027). Guards the literal YAML key names + strict
+     * arity, which a serializer<->loader round-trip alone cannot (a symmetric
+     * mis-key round-trips). Kotlin counterpart of Swift's `payoffHeader`
+     * private computed property (`ScenarioLoaderTests+Payoff.swift`); local to
+     * this region rather than [makeMinimalYAML] since only these five tests
+     * use its Alice/Bob-named personas.
+     */
+    private fun makePayoffYAML(phasesBlock: String): String = buildString {
+        appendLine("id: t")
+        appendLine("language: ja")
+        appendLine("name: T")
+        appendLine("description: d")
+        appendLine("agents: 2")
+        appendLine("rounds: 1")
+        appendLine("context: c")
+        appendLine("personas:")
+        appendLine("  - name: Alice")
+        appendLine("    description: a")
+        appendLine("  - name: Bob")
+        appendLine("    description: b")
+        appendLine("phases:")
+        append(phasesBlock)
+    }
+
+    @Test
+    fun parsesPayoffTableOnScoreCalc() {
+        val yaml = makePayoffYAML(
+            """
+                - type: choose
+                  options: [協力, 裏切り]
+                  pairing: round_robin
+                - type: score_calc
+                  logic: pairwise_payoff
+                  payoff:
+                    - when: [協力, 協力]
+                      points: [3, 3]
+                    - when: [裏切り, 裏切り]
+                      points: [1, 1]
+            """.trimIndent(),
+        )
+        val scenario = loader.load(yaml)
+        val payoff = scenario.phases[1].payoff
+        assertNotNull(payoff)
+        assertEquals(2, payoff.size)
+        assertEquals(PayoffRule(`when` = listOf("協力", "協力"), points = listOf(3, 3)), payoff[0])
+        assertEquals(PayoffRule(`when` = listOf("裏切り", "裏切り"), points = listOf(1, 1)), payoff[1])
+    }
+
+    @Test
+    fun absentPayoffLeavesNilNotThrow() {
+        // `load` stays non-validating (#665): a pairwise_payoff phase with no
+        // `payoff:` loads with `payoff == null` — the guaranteed-no-op is a
+        // linter concern (R20a), not a load throw.
+        val yaml = makePayoffYAML(
+            """
+                - type: score_calc
+                  logic: pairwise_payoff
+            """.trimIndent(),
+        )
+        val scenario = loader.load(yaml)
+        assertNull(scenario.phases[0].payoff)
+    }
+
+    @Test
+    fun throwsOnWhenArityNotTwo() {
+        val yaml = makePayoffYAML(
+            """
+                - type: score_calc
+                  logic: pairwise_payoff
+                  payoff:
+                    - when: [協力]
+                      points: [3, 3]
+            """.trimIndent(),
+        )
+        val caught = assertFailsWith<SimulationException> { loader.load(yaml) }
+        val error = caught.error
+        assertTrue(error is SimulationError.ScenarioValidationFailed)
+        // The message template names both fields, so assert the discriminating
+        // detail suffix, not a bare "when" substring.
+        assertTrue(error.message.contains("'when' must be 2 strings"))
+    }
+
+    @Test
+    fun throwsOnPointsArityNotTwo() {
+        val yaml = makePayoffYAML(
+            """
+                - type: score_calc
+                  logic: pairwise_payoff
+                  payoff:
+                    - when: [協力, 協力]
+                      points: [3]
+            """.trimIndent(),
+        )
+        val caught = assertFailsWith<SimulationException> { loader.load(yaml) }
+        val error = caught.error
+        assertTrue(error is SimulationError.ScenarioValidationFailed)
+        assertTrue(error.message.contains("'points' must be 2 ints"))
+    }
+
+    @Test
+    fun throwsOnPayoffNotList() {
+        val yaml = makePayoffYAML(
+            """
+                - type: score_calc
+                  logic: pairwise_payoff
+                  payoff: not_a_list
+            """.trimIndent(),
+        )
+        val caught = assertFailsWith<SimulationException> { loader.load(yaml) }
+        val error = caught.error
+        assertTrue(error is SimulationError.ScenarioValidationFailed)
+        assertTrue(error.message.contains("payoff"))
+    }
+
+    // endregion
+
+    // region conditional phase parsing (loader-facing arms of Swift's ConditionalScenarioIOTests)
+
+    @Test
+    fun loadsConditionalWithBothBranches() {
+        val yaml = """
+            id: test
+            language: ja
+            name: Test
+            description: test
+            agents: 2
+            rounds: 1
+            context: ctx
+            personas:
+              - name: Alice
+                description: a
+              - name: Bob
+                description: b
+            phases:
+              - type: conditional
+                if: "max_score >= 10"
+                then:
+                  - type: summarize
+                    template: won
+                else:
+                  - type: speak_all
+                    prompt: keep going
+                    output:
+                      statement: string
+        """.trimIndent()
+
+        val scenario = loader.load(yaml)
+        assertEquals(1, scenario.phases.size)
+
+        val phase = scenario.phases[0]
+        assertEquals(PhaseType.CONDITIONAL, phase.type)
+        assertEquals("max_score >= 10", phase.condition)
+        assertEquals(1, phase.thenPhases?.size)
+        assertEquals(PhaseType.SUMMARIZE, phase.thenPhases?.first()?.type)
+        assertEquals("won", phase.thenPhases?.first()?.template)
+        assertEquals(1, phase.elsePhases?.size)
+        assertEquals(PhaseType.SPEAK_ALL, phase.elsePhases?.first()?.type)
+        assertEquals("keep going", phase.elsePhases?.first()?.prompt)
+    }
+
+    @Test
+    fun loadsConditionalWithOnlyThenBranch() {
+        val yaml = """
+            id: test
+            language: ja
+            name: Test
+            description: test
+            agents: 2
+            rounds: 1
+            context: ctx
+            personas:
+              - name: Alice
+                description: a
+              - name: Bob
+                description: b
+            phases:
+              - type: conditional
+                if: "current_round == 1"
+                then:
+                  - type: summarize
+                    template: intro
+        """.trimIndent()
+
+        val scenario = loader.load(yaml)
+        val phase = scenario.phases[0]
+        assertEquals(1, phase.thenPhases?.size)
+        // Unspecified `else:` parses as null — the handler falls back to a
+        // no-op branch when the condition is false.
+        assertNull(phase.elsePhases)
+    }
+
+    @Test
+    fun rejectsNestedConditionalInThenBranch() {
+        val yaml = """
+            id: test
+            language: ja
+            name: Test
+            description: test
+            agents: 2
+            rounds: 1
+            context: ctx
+            personas:
+              - name: Alice
+                description: a
+              - name: Bob
+                description: b
+            phases:
+              - type: conditional
+                if: "current_round == 1"
+                then:
+                  - type: conditional
+                    if: "max_score > 0"
+                    then:
+                      - type: summarize
+                        template: nested
+        """.trimIndent()
+
+        val caught = assertFailsWith<SimulationException> { loader.load(yaml) }
+        assertTrue(caught.error is SimulationError.ScenarioValidationFailed)
+    }
+
+    @Test
+    fun rejectsNestedConditionalInElseBranch() {
+        val yaml = """
+            id: test
+            language: ja
+            name: Test
+            description: test
+            agents: 2
+            rounds: 1
+            context: ctx
+            personas:
+              - name: Alice
+                description: a
+              - name: Bob
+                description: b
+            phases:
+              - type: conditional
+                if: "current_round == 1"
+                then:
+                  - type: summarize
+                    template: fine
+                else:
+                  - type: conditional
+                    if: "current_round == 2"
+                    then:
+                      - type: summarize
+                        template: bad
+        """.trimIndent()
+
+        val caught = assertFailsWith<SimulationException> { loader.load(yaml) }
+        assertTrue(caught.error is SimulationError.ScenarioValidationFailed)
     }
 
     // endregion

--- a/shared/models/src/commonMain/kotlin/com/pastura/models/ScenarioCodec.kt
+++ b/shared/models/src/commonMain/kotlin/com/pastura/models/ScenarioCodec.kt
@@ -22,8 +22,9 @@ import kotlinx.serialization.json.JsonElement
  * Option γ-prime): the W4 H4 measurement only exercises the encode path;
  * Swift→K/N decode is NOT on the production iOS graph — YAML → `Scenario`
  * decoding runs Swift-side via `Pastura/Pastura/Engine/ScenarioLoader.swift`
- * in production. A Kotlin `ScenarioLoader` (`shared/engine`) exists as of
- * ADR-023 Stage 3 Wave C PR C2a, but it is not wired into anything yet, so
+ * in production. A Kotlin `ScenarioLoader` (`shared/engine`) is **fully
+ * ported** as of ADR-023 Stage 3 Wave C (PRs C2a + C2b), but it is not wired
+ * into anything yet — the §4 preflight gate waits on the ADR-024 linter — so
  * the production graph is unchanged. Adding a decode surface here would be
  * premature — W4 PR-C snakeyaml validation work may need it, in which case
  * it lands then.


### PR DESCRIPTION
## Summary

ADR-023 Stage 3 Wave C, PR **C2b** — the phase-specialisation half of `Pastura/Pastura/Engine/ScenarioLoader.swift`, ported to Kotlin. Closes the seven `null, // C2b` gaps predecessor PR C2a (#1559) deliberately left in `ScenarioLoader.kt`'s `mapPhase`, and retires the three "gap artefacts" C2a planted to describe them. With this, `ScenarioLoader.swift` is **fully ported** — its `SPLIT` ledger row (`InferenceEstimator.kt` + `ScenarioLoader.kt`) is complete on both paths.

New in `shared/engine/.../ScenarioLoader.kt`: `parseAssignTarget`, `parsePairing`, `parseLogic`, `parsePayoff`, `parseActionDeltas`, `parseOutputSchema`, `mapBranch` + the depth-1 conditional recursion. All seven are `private`, so the exported Obj-C header is unchanged and no new `@Throws` pin is needed.

Three things worth knowing about the shape:

- **The three enum parses reuse C2a's generic `serialNameLookup`**, exactly as its KDoc pre-committed, and `InvalidLogic`'s `allowed:` fragment is *derived* from that map's key order rather than hand-written — so a sixth `ScoreCalcLogic` case joins the lookup and the user-visible message in one edit. `.claude/rules/kmp-interop.md` Pattern 4's "TWO Kotlin maps that no compiler catches" therefore **stays at two**; the plan had flagged it might become three.
- **`parseOutputSchema` / `parseActionDeltas` are per-key throw, not whole-collection.** Swift's `as? [String: Any]` succeeds on any mapping and names the offending key, unlike the `STRING_LIST` / `OBJECT_LIST` sites ten lines up that read as the house style. Both carry a KDoc line saying why they do not follow them.
- **No new numbered divergence.** C2a's divergence 4 (`Int` is 32-bit here, 64-bit in Swift) is extended in place to the phase-level integral fields. Width was never a live choice — `PayoffRule.points` is `List<Int>` in `shared/models`, so it is fixed by the mirrored type.

**The loader is still NOT wired into `SimulationEngine`**, deliberately and unchanged: ADR-023 §4 puts the preflight gate on the validator *and* the ADR-024 linter together, the linter is unported, and `DivergenceLedger.VALIDATOR_UNPORTED` stays. The production iOS graph is untouched — YAML → `Scenario` decoding still runs Swift-side.

## Test plan

- `:shared:engine:jvmTest` — **841 tests, 0 failures** (`ScenarioLoaderTests` 88 of them).
- `:shared:models:jvmTest` — **216 tests, 0 failures**.
- `scripts/xcodebuild.sh test -skip-testing:PasturaUITests` — **3557 tests**, TEST SUCCEEDED.
- `swift build` (ADR-013 harness) — green. No `SimulationEvent` case added, so `EventLineMapper` is untouched.
- `swiftlint lint --quiet --strict` — clean.

**Condition 2** — 25 Swift cases transcribed 1:1 with byte-identical YAML fixtures (4 from `ScenarioLoaderTests.swift`, all 5 of `+Payoff`, the 1 of `+MaxSentences`, 11 enum/`output` arms of `+StrictTypes`, 4 loader-facing arms of `ConditionalScenarioIOTests.swift`), plus `parsesPhaseSpeakAll` regaining the third assertion C2a dropped while `output:` was unmapped. The suite is now 69 complete transcriptions; the two groups of Swift cases still absent are restated as *deliberate* (the estimator tests belong to `InferenceEstimatorTests.kt`; `roundTrip*` belongs to the Swift-only serializer, `STAY` per §4).

**Condition 4** — 41 mutations, 40 red, 1 green (the negative control), over an 88-test baseline measured green before the first mutation and after the last revert. Full table in `ScenarioLoaderTests.kt`'s class KDoc; §12 condition-2 + condition-4 record posted to #501.

C2a's ingest surface was **not** re-swept (operator decision — it was swept whole in #1558). Four C2a-surface mutations *were* re-run, because deleting the gap pin orphaned three cells of that table and C2a's note 4 booked the nested-`conditional` depth guard as "C2b must claim it". Those four appear as rows rather than as a claim in prose.

Six mechanisms turned out to have no claimant on **either** side — a bad `points` value in a well-sized `payoff:` row, and separately that guard's boolean and quoted-scalar exclusions; a non-mapping `action_deltas:`; `mapBranch`'s `"Phase K.then[N]"` sub-phase label; and `mapBranch`'s cast. Each gained one. Divergence 4's two new message claims gained detectors too, on note 5's standing rule that a KDoc claim with nothing behind it is not a claim. One assertion was strengthened: `rejectsScoreCalcWithUnknownLogic` only checked that loading throws, so re-ordering the derived `allowed:` fragment left the suite green — the drift-proofing had nothing behind it.

## Review

Reviewer: **Opus**, in four passes (the branch exceeded the reviewer's split budget twice, so it was reviewed as production+prose, fixture/value transcriptions, strict-types + the perturbation record, and finally the fix diff).

Passes 1 and 2 returned PASS. Pass 3 returned FAIL on four warnings, and the re-review of the fix returned FAIL on five more — every one of them the same class: **the perturbation record describing itself more strongly than it had measured.** All nine applied:

- the "three cells were re-measured" claim had no rows behind it → the mutations were actually run and recorded;
- note 4's discharge pointed at a differently-named row that mutates the recursion, not the guard → the guard mutation re-run, both rows kept distinct;
- divergence 4's two new claims had no detector → two tests added;
- the extras arithmetic did not close (69 + regions ≠ 88) → spelled out;
- two rows implied an edit to the *shared* `YamlType.INT` cast, which would have made their `Incidental | none` false → restated as the site-local mutations that actually ran, with note 11 on why site-local was the point;
- rewriting C2a's depth-guard cell broke C2a's own "3 green" header → the cell keeps its C2a-time verdict alongside the C2b one;
- "every non-transcription is a sweep claimant" was untrue of the two divergence pins;
- note 2's exception clause named two of three;
- the relocated `throwsOnScalarThenBranch` contradicted its new region's preamble.

Also applied from suggestions: `contains("'<value>'")` on three enum-throw cases so a `label`/`value` argument swap cannot stay green; an `AssignTarget.ALL` assertion nothing in the suite made; divergence 6 widened to name `parseOutputSchema` / `parseActionDeltas`, which C2b gave the same first-key-in-insertion-order property; and three KDoc corrections (a stale call-site count, "names the key" on a message with no key parameter, the `parseOptional`-first order restated on `parsePairing`).

**One finding rejected**: `throwsOnNonIntActionDeltaValue`'s `assertTrue(error is ScenarioValidationFailed)` was flagged as unlabelled strengthening over its Swift twin. It is this suite's baseline idiom, present on ~20 pre-existing cases; labelling it would imply the other twenty are deviations.

## Device QA

実機QA不要 — the diff is `shared/engine` Kotlin, its `commonTest` sibling, and doc comments. No `#if !targetEnvironment(simulator)` block, no Metal / llama.cpp path, no `nonisolated async` executor change, and the Kotlin loader is not on the production iOS graph at all.

Part of #1560
