### PR TITLE
✨ feat: ADR-023 Stage 3 — ScenarioLintMessage mirror (PR D1a)

### DIFF
--- a/.claude/rules/kmp-interop.md
+++ b/.claude/rules/kmp-interop.md
@@ -107,6 +107,14 @@ integral `Double` drops its `.0`. The third bites silently: `TranscriptComparato
 never the fixtures' observed lines: a field no fixture populates is the one that bites later.
 `RunLogTests.fullyPopulatedLinePinsTheWireShape` is that measurement.
 
+**A Models-layer message type is dual-landed, and no gate compares the two sides.**
+`check-prompt-literal-parity.py` only scans `Engine/` + `LLM/` files containing `pickLanguage`, so
+it never reaches `Models/`. Reword a literal in `Pastura/Pastura/Models/*Message.swift` and the
+Kotlin twin plus its commonTest pins stay stale *and agree with each other* — nothing reddens on
+either side. The Swift file is the source of truth; a reword is a three-file hand edit (Swift, the
+`.kt`, the commonTest expected string). Applies to `ScenarioValidationMessage` (53) and
+`ScenarioLintMessage` (21).
+
 ## Pattern 5 — a KDoc `@throws` does not reach K/N; only `@Throws` does
 
 An exception thrown from a function K/N exported **without** the `@Throws` annotation is not

--- a/Pastura/Pastura/Engine/ScenarioSemanticLinter+Conditions.swift
+++ b/Pastura/Pastura/Engine/ScenarioSemanticLinter+Conditions.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// Condition-expression rules R13/R14/R15/R16 (ADR-024 D3), applied to every
 /// `conditional` phase's **parsed** `if:` string (`phase.condition`) — never
 /// raw YAML, whose scalar quoting (`if: 'current_event != ""'`) is already
@@ -173,27 +171,17 @@ nonisolated extension ScenarioSemanticLinter {
   }
 
   /// The user-facing fix-hint message for a condition `ruleID`, naming the
-  /// offending operand.
+  /// offending operand, rendered via ``ScenarioLintMessage``.
   private func conditionMessage(_ ruleID: String, token: String) -> String {
     switch ruleID {
     case "single-quoted-literal-in-condition":
-      return String(
-        format: String(
-          localized:
-            "single-quoted-literal-in-condition: the operand %@ is single-quoted, but the condition evaluator treats only double quotes as string literals — it is read as an undefined identifier and the comparison is always false. Use double quotes instead."
-        ), token)
+      return ScenarioLintMessage.singleQuotedLiteralInCondition(token: token).localized
     case "bare-identifier-looks-like-literal":
-      return String(
-        format: String(
-          localized:
-            "bare-identifier-looks-like-literal: the operand '%@' matches a persona name but is unquoted, so the condition evaluator reads it as an undefined identifier and the comparison is always false — wrap it in double quotes to compare against the name."
-        ), token)
+      return ScenarioLintMessage.bareIdentifierLooksLikeLiteral(token: token).localized
     default:
-      return String(
-        format: String(
-          localized:
-            "unknown-condition-identifier: '%@' is not a known condition variable (a derived variable, score, persona, extraData key, or engine-injected name), so it resolves to no value at runtime — check for a typo."
-        ), token)
+      // Falls to `unknown-condition-identifier`: the only other ruleID
+      // `classifyOperand` builds via this helper.
+      return ScenarioLintMessage.unknownConditionIdentifier(token: token).localized
     }
   }
 }

--- a/Pastura/Pastura/Engine/ScenarioSemanticLinter+Config.swift
+++ b/Pastura/Pastura/Engine/ScenarioSemanticLinter+Config.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// Silently-inert configuration rules R7/R8/R9/R17/R18 (ADR-024 D3).
 ///
 /// Unlike the ordering rules (`ScenarioSemanticLinter+Ordering.swift`), these
@@ -229,44 +227,25 @@ nonisolated extension ScenarioSemanticLinter {
   }
 
   /// The user-facing fix-hint message for a config `ruleID` (one sentence
-  /// naming the rule + a concrete fix).
+  /// naming the rule + a concrete fix), rendered via ``ScenarioLintMessage``.
   private func configMessage(_ ruleID: String) -> String {
     switch ruleID {
     case "choose-should-declare-options":
-      return String(
-        localized:
-          "choose-should-declare-options: this 'choose' phase has no 'options' list, so the agent's action is unconstrained free text — add an 'options' list to steer the choice."
-      )
+      return ScenarioLintMessage.chooseShouldDeclareOptions.localized
     case "assign-source-nonempty":
-      return String(
-        localized:
-          "assign-source-nonempty: this 'assign' phase's source resolves to an empty list, so nothing is assigned (or every agent gets an empty value) — add at least one entry to the referenced source data."
-      )
+      return ScenarioLintMessage.assignSourceNonempty.localized
     case "summarize-pairing-placeholders":
-      return String(
-        localized:
-          "summarize-pairing-placeholders: this 'summarize' template references {agent1}-family placeholders, but no round-robin 'choose' phase runs earlier in the round, so the placeholders leak literally into the summary — add a round-robin 'choose' phase before this 'summarize', or remove the pairing placeholders."
-      )
+      return ScenarioLintMessage.summarizePairingPlaceholders.localized
     case "max-sentences-no-op":
-      return String(
-        localized:
-          "max-sentences-no-op: this phase emits no LLM statement, so its 'max_sentences' cap never reaches a prompt and has no effect — remove it, or move it to a phase that emits a statement (speak_all / speak_each / whisper)."
-      )
+      return ScenarioLintMessage.maxSentencesNoOp.localized
     case "pairwise-payoff-no-scorable-row":
-      return String(
-        localized:
-          "pairwise-payoff-no-scorable-row: no 'payoff' row's 'when' tokens match the round-robin 'choose' options, so no pairing is ever scored — add a 'payoff' table whose 'when' rows use the 'choose' option tokens."
-      )
+      return ScenarioLintMessage.pairwisePayoffNoScorableRow.localized
     case "pairwise-payoff-dead-row":
-      return String(
-        localized:
-          "pairwise-payoff-dead-row: one or more 'payoff' rows use 'when' tokens that aren't in the round-robin 'choose' options, so those rows never fire — fix the tokens to match the 'choose' options, or remove the unused rows."
-      )
+      return ScenarioLintMessage.pairwisePayoffDeadRow.localized
     default:
-      return String(
-        localized:
-          "log-window-below-agent-count: 'log_window' is smaller than the agent count while a 'speak_each' phase is present, so same-round earlier speakers vanish from the addressee pool — raise 'log_window' to at least the agent count."
-      )
+      // Falls to `log-window-below-agent-count`: `logWindowFindings` is the
+      // only other caller of `configMessage`, always with this ruleID.
+      return ScenarioLintMessage.logWindowBelowAgentCount.localized
     }
   }
 }

--- a/Pastura/Pastura/Engine/ScenarioSemanticLinter+Ordering.swift
+++ b/Pastura/Pastura/Engine/ScenarioSemanticLinter+Ordering.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// Producer–consumer phase-ordering rules R1–R6 (ADR-024 D3).
 ///
 /// Each rule compares **phase-list indices**: a consuming phase
@@ -229,49 +227,27 @@ nonisolated extension ScenarioSemanticLinter {
   }
 
   /// The user-facing fix-hint message for an ordering `ruleID` (one sentence
-  /// naming the rule + a concrete fix).
+  /// naming the rule + a concrete fix), rendered via ``ScenarioLintMessage``.
   private func orderingMessage(_ ruleID: String) -> String {
     switch ruleID {
     case "eliminate-needs-vote":
-      return String(
-        localized:
-          "eliminate-needs-vote: an 'eliminate' phase does nothing without a 'vote' phase in the same round — add a 'vote' phase before it."
-      )
+      return ScenarioLintMessage.eliminateNeedsVote.localized
     case "eliminate-after-vote":
-      return String(
-        localized:
-          "eliminate-after-vote: this 'eliminate' runs before every 'vote' phase, so it acts on the previous round's stale tally — move it after the 'vote' phase."
-      )
+      return ScenarioLintMessage.eliminateAfterVote.localized
     case "pd-needs-round-robin-choose":
-      return String(
-        localized:
-          "pd-needs-round-robin-choose: 'prisoners_dilemma' scoring needs a round-robin 'choose' phase earlier in the round to populate pairings, or scores never change — add one before this 'score_calc'."
-      )
+      return ScenarioLintMessage.pdNeedsRoundRobinChoose.localized
     case "pairwise-payoff-needs-round-robin-choose":
-      return String(
-        localized:
-          "pairwise-payoff-needs-round-robin-choose: 'pairwise_payoff' scoring needs a round-robin 'choose' phase earlier in the round to populate pairings, or scores never change — add one before this 'score_calc'."
-      )
+      return ScenarioLintMessage.pairwisePayoffNeedsRoundRobinChoose.localized
     case "wordwolf-needs-assign-and-vote":
-      return String(
-        localized:
-          "wordwolf-needs-assign-and-vote: 'wordwolf_judge' scoring needs both an 'assign' phase with target 'random_one' and a 'vote' phase earlier in the round, or it judges nothing — add the missing phase(s) before this 'score_calc'."
-      )
+      return ScenarioLintMessage.wordwolfNeedsAssignAndVote.localized
     case "event-reactive-needs-event-inject":
-      return String(
-        localized:
-          "event-reactive-needs-event-inject: 'event_reactive' scoring needs an earlier 'event_inject' phase with a dictionary event source and the default 'as: current_event', or the favored action is never scored — fix the 'event_inject' before this 'score_calc'."
-      )
+      return ScenarioLintMessage.eventReactiveNeedsEventInject.localized
     case "relationship-update-placement":
-      return String(
-        localized:
-          "relationship-update-placement: this 'relationship_update' cannot see its vote/choose signals — place it after the producing 'vote'/'choose' phase and before any 'prisoners_dilemma' 'score_calc', with no 'speak'/'choose' phase between the vote and it."
-      )
+      return ScenarioLintMessage.relationshipUpdatePlacement.localized
     default:
-      return String(
-        localized:
-          "vote-tally-needs-vote: 'vote_tally' scoring has no 'vote' phase earlier in the round, so it scores nothing or re-adds a stale tally — add a 'vote' phase before this 'score_calc'."
-      )
+      // Falls to `vote-tally-needs-vote`: the only remaining `score_calc`
+      // logic arm (`.voteTally`) that reaches `finding(_:_:at:)`.
+      return ScenarioLintMessage.voteTallyNeedsVote.localized
     }
   }
 

--- a/Pastura/Pastura/Engine/ScenarioSemanticLinter+Placeholders.swift
+++ b/Pastura/Pastura/Engine/ScenarioSemanticLinter+Placeholders.swift
@@ -195,27 +195,17 @@ nonisolated extension ScenarioSemanticLinter {
   }
 
   /// The user-facing fix-hint message for a placeholder `ruleID`, naming the
-  /// offending `{token}`.
+  /// offending `{token}`, rendered via ``ScenarioLintMessage``.
   private func placeholderMessage(_ ruleID: String, token: String) -> String {
     switch ruleID {
     case "unresolvable-placeholder":
-      return String(
-        format: String(
-          localized:
-            "unresolvable-placeholder: the placeholder '{%@}' is supplied by no phase, so it leaks into the LLM prompt verbatim — check for a typo or remove it."
-        ), token)
+      return ScenarioLintMessage.unresolvablePlaceholder(token: token).localized
     case "placeholder-phase-availability":
-      return String(
-        format: String(
-          localized:
-            "placeholder-phase-availability: the placeholder '{%@}' is only populated by a producing phase, but none runs earlier in the phase list, so it resolves to an empty value — move the producing phase before this one."
-        ), token)
+      return ScenarioLintMessage.placeholderPhaseAvailability(token: token).localized
     default:
-      return String(
-        format: String(
-          localized:
-            "per-persona-placeholder-in-summarize: the per-persona placeholder '{%@}' is never populated in a 'summarize' phase (summaries aren't per-agent), so it leaks literally — remove it or move it to an LLM phase."
-        ), token)
+      // Falls to `per-persona-placeholder-in-summarize`: the only other
+      // ruleID `placeholderFinding` builds via this helper.
+      return ScenarioLintMessage.perPersonaPlaceholderInSummarize(token: token).localized
     }
   }
 }

--- a/Pastura/Pastura/Models/ScenarioLintMessage.swift
+++ b/Pastura/Pastura/Models/ScenarioLintMessage.swift
@@ -85,7 +85,7 @@ nonisolated public enum ScenarioLintMessage: Sendable {
 
 // `nonisolated` on the extension is load-bearing: the enum is a `nonisolated`
 // Models type, but a sibling `extension` inherits the project's default
-// MainActor isolation unless annotated (`.claude/rules/swift-isolation.md`
+// MainActor isolation unless annotated (`docs/swift-isolation-compile-time-patterns.md`
 // Pattern 3), which would break the synchronous `nonisolated` Engine callers.
 nonisolated extension ScenarioLintMessage {
 

--- a/Pastura/Pastura/Models/ScenarioLintMessage.swift
+++ b/Pastura/Pastura/Models/ScenarioLintMessage.swift
@@ -1,0 +1,222 @@
+import Foundation
+
+/// A parameter-carrying description of an ADR-024 semantic-lint finding
+/// message.
+///
+/// This is the ADR-024 linter counterpart of ``ScenarioValidationMessage``:
+/// the four `ScenarioSemanticLinter+*.swift` extensions (Ordering, Config,
+/// Placeholders, Conditions) build these instead of building user-facing
+/// strings inline. Each case is a **portable structured payload** (enum case +
+/// typed args, no Foundation), and ``localized`` is the single
+/// **platform-specific rendering leaf** that turns a case into the display
+/// string embedded in a ``LintFinding/message``.
+///
+/// This is the message-model split for the KMP Engine port (ADR-023 Stage 3):
+/// the cases move to Kotlin `commonMain` 1:1 as a sealed class
+/// (`shared/models/.../ScenarioLintMessage.kt`, landing in the same PR), while
+/// `localized` becomes an `expect`/`actual` leaf.
+///
+/// Deliberately a **separate** type from ``ScenarioValidationMessage`` rather
+/// than folded into it: the two model different surfaces — a lint finding
+/// carries a severity and is collected alongside others for the same
+/// scenario, while a validation message is thrown as the sole reason a load
+/// or commit-gate check failed. Conflating them would force a shared shape
+/// neither surface actually has.
+///
+/// The rendered text is byte-identical to the pre-refactor Engine literals so
+/// `Localizable.xcstrings` keys are unchanged.
+nonisolated public enum ScenarioLintMessage: Sendable {
+  // MARK: Ordering (ScenarioSemanticLinter+Ordering.swift, R1–R6/R19)
+  case eliminateNeedsVote
+  case eliminateAfterVote
+  case pdNeedsRoundRobinChoose
+  case pairwisePayoffNeedsRoundRobinChoose
+  case wordwolfNeedsAssignAndVote
+  case eventReactiveNeedsEventInject
+  case relationshipUpdatePlacement
+  case voteTallyNeedsVote
+
+  // MARK: Config (ScenarioSemanticLinter+Config.swift, R7/R8/R9/R17/R18/R20a/R20b)
+  case chooseShouldDeclareOptions
+  case assignSourceNonempty
+  case summarizePairingPlaceholders
+  case maxSentencesNoOp
+  case pairwisePayoffNoScorableRow
+  case pairwisePayoffDeadRow
+  case logWindowBelowAgentCount
+
+  // MARK: Placeholders (ScenarioSemanticLinter+Placeholders.swift, R10/R11/R12)
+  case unresolvablePlaceholder(token: String)
+  case placeholderPhaseAvailability(token: String)
+  case perPersonaPlaceholderInSummarize(token: String)
+
+  // MARK: Conditions (ScenarioSemanticLinter+Conditions.swift, R13/R14/R15)
+  case singleQuotedLiteralInCondition(token: String)
+  case bareIdentifierLooksLikeLiteral(token: String)
+  case unknownConditionIdentifier(token: String)
+
+  /// Every rule ID, in declaration order, one per case above. Stands in for
+  /// `CaseIterable` — unavailable here because four cases carry an associated
+  /// `token: String` value.
+  public static let ruleIDs: [String] = [
+    "eliminate-needs-vote",
+    "eliminate-after-vote",
+    "pd-needs-round-robin-choose",
+    "pairwise-payoff-needs-round-robin-choose",
+    "wordwolf-needs-assign-and-vote",
+    "event-reactive-needs-event-inject",
+    "relationship-update-placement",
+    "vote-tally-needs-vote",
+    "choose-should-declare-options",
+    "assign-source-nonempty",
+    "summarize-pairing-placeholders",
+    "max-sentences-no-op",
+    "pairwise-payoff-no-scorable-row",
+    "pairwise-payoff-dead-row",
+    "log-window-below-agent-count",
+    "unresolvable-placeholder",
+    "placeholder-phase-availability",
+    "per-persona-placeholder-in-summarize",
+    "single-quoted-literal-in-condition",
+    "bare-identifier-looks-like-literal",
+    "unknown-condition-identifier"
+  ]
+}
+
+// `nonisolated` on the extension is load-bearing: the enum is a `nonisolated`
+// Models type, but a sibling `extension` inherits the project's default
+// MainActor isolation unless annotated (`.claude/rules/swift-isolation.md`
+// Pattern 3), which would break the synchronous `nonisolated` Engine callers.
+nonisolated extension ScenarioLintMessage {
+
+  /// Renders the case to its user-facing string.
+  ///
+  /// The **only** Foundation-touching member — the KMP `expect`/`actual` leaf
+  /// (see the type doc). Literals are byte-identical to the pre-refactor
+  /// Engine callsites so `Localizable.xcstrings` keys stay stable. No-arg
+  /// cases use `String(localized:)` directly (never `String(format:)`, which
+  /// would misread a stray `%` in a future literal); the single-`%@`
+  /// token-bearing cases use `String(format:)` with exactly one argument.
+  ///
+  /// **These literals are dual-landed with `ScenarioLintMessage.kt`'s
+  /// `render()`** (`shared/models`, ADR-023) — reword here and the Kotlin twin
+  /// plus its expected-string pins stay stale *and agree with each other*, so
+  /// nothing reddens. No gate covers it: `check-prompt-literal-parity.py` only
+  /// looks at `Engine/` + `LLM/` files containing `pickLanguage`, which never
+  /// reaches `Models/`.
+  public var localized: String {
+    switch self {
+    case .eliminateNeedsVote:
+      return String(
+        localized:
+          "eliminate-needs-vote: an 'eliminate' phase does nothing without a 'vote' phase in the same round — add a 'vote' phase before it."
+      )
+    case .eliminateAfterVote:
+      return String(
+        localized:
+          "eliminate-after-vote: this 'eliminate' runs before every 'vote' phase, so it acts on the previous round's stale tally — move it after the 'vote' phase."
+      )
+    case .pdNeedsRoundRobinChoose:
+      return String(
+        localized:
+          "pd-needs-round-robin-choose: 'prisoners_dilemma' scoring needs a round-robin 'choose' phase earlier in the round to populate pairings, or scores never change — add one before this 'score_calc'."
+      )
+    case .pairwisePayoffNeedsRoundRobinChoose:
+      return String(
+        localized:
+          "pairwise-payoff-needs-round-robin-choose: 'pairwise_payoff' scoring needs a round-robin 'choose' phase earlier in the round to populate pairings, or scores never change — add one before this 'score_calc'."
+      )
+    case .wordwolfNeedsAssignAndVote:
+      return String(
+        localized:
+          "wordwolf-needs-assign-and-vote: 'wordwolf_judge' scoring needs both an 'assign' phase with target 'random_one' and a 'vote' phase earlier in the round, or it judges nothing — add the missing phase(s) before this 'score_calc'."
+      )
+    case .eventReactiveNeedsEventInject:
+      return String(
+        localized:
+          "event-reactive-needs-event-inject: 'event_reactive' scoring needs an earlier 'event_inject' phase with a dictionary event source and the default 'as: current_event', or the favored action is never scored — fix the 'event_inject' before this 'score_calc'."
+      )
+    case .relationshipUpdatePlacement:
+      return String(
+        localized:
+          "relationship-update-placement: this 'relationship_update' cannot see its vote/choose signals — place it after the producing 'vote'/'choose' phase and before any 'prisoners_dilemma' 'score_calc', with no 'speak'/'choose' phase between the vote and it."
+      )
+    case .voteTallyNeedsVote:
+      return String(
+        localized:
+          "vote-tally-needs-vote: 'vote_tally' scoring has no 'vote' phase earlier in the round, so it scores nothing or re-adds a stale tally — add a 'vote' phase before this 'score_calc'."
+      )
+    case .chooseShouldDeclareOptions:
+      return String(
+        localized:
+          "choose-should-declare-options: this 'choose' phase has no 'options' list, so the agent's action is unconstrained free text — add an 'options' list to steer the choice."
+      )
+    case .assignSourceNonempty:
+      return String(
+        localized:
+          "assign-source-nonempty: this 'assign' phase's source resolves to an empty list, so nothing is assigned (or every agent gets an empty value) — add at least one entry to the referenced source data."
+      )
+    case .summarizePairingPlaceholders:
+      return String(
+        localized:
+          "summarize-pairing-placeholders: this 'summarize' template references {agent1}-family placeholders, but no round-robin 'choose' phase runs earlier in the round, so the placeholders leak literally into the summary — add a round-robin 'choose' phase before this 'summarize', or remove the pairing placeholders."
+      )
+    case .maxSentencesNoOp:
+      return String(
+        localized:
+          "max-sentences-no-op: this phase emits no LLM statement, so its 'max_sentences' cap never reaches a prompt and has no effect — remove it, or move it to a phase that emits a statement (speak_all / speak_each / whisper)."
+      )
+    case .pairwisePayoffNoScorableRow:
+      return String(
+        localized:
+          "pairwise-payoff-no-scorable-row: no 'payoff' row's 'when' tokens match the round-robin 'choose' options, so no pairing is ever scored — add a 'payoff' table whose 'when' rows use the 'choose' option tokens."
+      )
+    case .pairwisePayoffDeadRow:
+      return String(
+        localized:
+          "pairwise-payoff-dead-row: one or more 'payoff' rows use 'when' tokens that aren't in the round-robin 'choose' options, so those rows never fire — fix the tokens to match the 'choose' options, or remove the unused rows."
+      )
+    case .logWindowBelowAgentCount:
+      return String(
+        localized:
+          "log-window-below-agent-count: 'log_window' is smaller than the agent count while a 'speak_each' phase is present, so same-round earlier speakers vanish from the addressee pool — raise 'log_window' to at least the agent count."
+      )
+    case .unresolvablePlaceholder(let token):
+      return String(
+        format: String(
+          localized:
+            "unresolvable-placeholder: the placeholder '{%@}' is supplied by no phase, so it leaks into the LLM prompt verbatim — check for a typo or remove it."
+        ), token)
+    case .placeholderPhaseAvailability(let token):
+      return String(
+        format: String(
+          localized:
+            "placeholder-phase-availability: the placeholder '{%@}' is only populated by a producing phase, but none runs earlier in the phase list, so it resolves to an empty value — move the producing phase before this one."
+        ), token)
+    case .perPersonaPlaceholderInSummarize(let token):
+      return String(
+        format: String(
+          localized:
+            "per-persona-placeholder-in-summarize: the per-persona placeholder '{%@}' is never populated in a 'summarize' phase (summaries aren't per-agent), so it leaks literally — remove it or move it to an LLM phase."
+        ), token)
+    case .singleQuotedLiteralInCondition(let token):
+      return String(
+        format: String(
+          localized:
+            "single-quoted-literal-in-condition: the operand %@ is single-quoted, but the condition evaluator treats only double quotes as string literals — it is read as an undefined identifier and the comparison is always false. Use double quotes instead."
+        ), token)
+    case .bareIdentifierLooksLikeLiteral(let token):
+      return String(
+        format: String(
+          localized:
+            "bare-identifier-looks-like-literal: the operand '%@' matches a persona name but is unquoted, so the condition evaluator reads it as an undefined identifier and the comparison is always false — wrap it in double quotes to compare against the name."
+        ), token)
+    case .unknownConditionIdentifier(let token):
+      return String(
+        format: String(
+          localized:
+            "unknown-condition-identifier: '%@' is not a known condition variable (a derived variable, score, persona, extraData key, or engine-injected name), so it resolves to no value at runtime — check for a typo."
+        ), token)
+    }
+  }
+}

--- a/Pastura/Pastura/Models/ScenarioLintMessage.swift
+++ b/Pastura/Pastura/Models/ScenarioLintMessage.swift
@@ -56,7 +56,7 @@ nonisolated public enum ScenarioLintMessage: Sendable {
   case unknownConditionIdentifier(token: String)
 
   /// Every rule ID, in declaration order, one per case above. Stands in for
-  /// `CaseIterable` — unavailable here because four cases carry an associated
+  /// `CaseIterable` — unavailable here because six cases carry an associated
   /// `token: String` value.
   public static let ruleIDs: [String] = [
     "eliminate-needs-vote",

--- a/Pastura/Pastura/Models/ScenarioValidationMessage.swift
+++ b/Pastura/Pastura/Models/ScenarioValidationMessage.swift
@@ -94,7 +94,7 @@ nonisolated public enum ScenarioValidationMessage: Sendable {
 
 // `nonisolated` on the extension is load-bearing: the enum is a `nonisolated`
 // Models type, but a sibling `extension` inherits the project's default
-// MainActor isolation unless annotated (`.claude/rules/swift-isolation.md`
+// MainActor isolation unless annotated (`docs/swift-isolation-compile-time-patterns.md`
 // Pattern 3), which would break the synchronous `nonisolated` Engine callers.
 nonisolated extension ScenarioValidationMessage {
 

--- a/Pastura/PasturaTests/Models/ScenarioLintMessageTests.swift
+++ b/Pastura/PasturaTests/Models/ScenarioLintMessageTests.swift
@@ -93,6 +93,37 @@ struct ScenarioLintMessageTests {
 
   @Test func ruleIDsHasExactlyTwentyOneEntries() {
     #expect(ScenarioLintMessage.ruleIDs.count == 21)
+    #expect(Set(ScenarioLintMessage.ruleIDs).count == 21)
+  }
+
+  /// Pins the declaration order the doc comment promises — the Kotlin twin
+  /// hand-copies this list in the same order, so a Swift-side reorder must
+  /// redden here rather than only in `shared/models`.
+  @Test func ruleIDsAreInDeclarationOrder() {
+    #expect(
+      ScenarioLintMessage.ruleIDs == [
+        "eliminate-needs-vote",
+        "eliminate-after-vote",
+        "pd-needs-round-robin-choose",
+        "pairwise-payoff-needs-round-robin-choose",
+        "wordwolf-needs-assign-and-vote",
+        "event-reactive-needs-event-inject",
+        "relationship-update-placement",
+        "vote-tally-needs-vote",
+        "choose-should-declare-options",
+        "assign-source-nonempty",
+        "summarize-pairing-placeholders",
+        "max-sentences-no-op",
+        "pairwise-payoff-no-scorable-row",
+        "pairwise-payoff-dead-row",
+        "log-window-below-agent-count",
+        "unresolvable-placeholder",
+        "placeholder-phase-availability",
+        "per-persona-placeholder-in-summarize",
+        "single-quoted-literal-in-condition",
+        "bare-identifier-looks-like-literal",
+        "unknown-condition-identifier"
+      ])
   }
 
   @Test func everyMessageStartsWithItsOwnRuleID() {

--- a/Pastura/PasturaTests/Models/ScenarioLintMessageTests.swift
+++ b/Pastura/PasturaTests/Models/ScenarioLintMessageTests.swift
@@ -1,0 +1,128 @@
+import Testing
+
+@testable import Pastura
+
+/// Locks ``ScenarioLintMessage/localized`` rendering to the byte-identical
+/// strings the four `ScenarioSemanticLinter+*.swift` extensions emitted before
+/// this message-model split. One rendering test per group (Ordering / Config /
+/// Placeholders / Conditions), including both token-bearing groups with a
+/// token containing a quote and a `%` sign, plus a `ruleIDs` coverage pin.
+/// English base locale (CI default).
+@Suite(.timeLimit(.minutes(1)))
+struct ScenarioLintMessageTests {
+
+  // MARK: Ordering (no-arg cases)
+
+  @Test func eliminateNeedsVoteRendersLiteral() {
+    #expect(
+      ScenarioLintMessage.eliminateNeedsVote.localized
+        == "eliminate-needs-vote: an 'eliminate' phase does nothing without a 'vote' phase "
+        + "in the same round — add a 'vote' phase before it.")
+  }
+
+  @Test func voteTallyNeedsVoteRendersLiteral() {
+    // The `orderingMessage` `default:` arm's rule.
+    #expect(
+      ScenarioLintMessage.voteTallyNeedsVote.localized
+        == "vote-tally-needs-vote: 'vote_tally' scoring has no 'vote' phase earlier in the "
+        + "round, so it scores nothing or re-adds a stale tally — add a 'vote' phase before "
+        + "this 'score_calc'.")
+  }
+
+  // MARK: Config (no-arg cases)
+
+  @Test func chooseShouldDeclareOptionsRendersLiteral() {
+    #expect(
+      ScenarioLintMessage.chooseShouldDeclareOptions.localized
+        == "choose-should-declare-options: this 'choose' phase has no 'options' list, so the "
+        + "agent's action is unconstrained free text — add an 'options' list to steer the "
+        + "choice.")
+  }
+
+  @Test func logWindowBelowAgentCountRendersLiteral() {
+    // The `configMessage` `default:` arm's rule.
+    #expect(
+      ScenarioLintMessage.logWindowBelowAgentCount.localized
+        == "log-window-below-agent-count: 'log_window' is smaller than the agent count while "
+        + "a 'speak_each' phase is present, so same-round earlier speakers vanish from the "
+        + "addressee pool — raise 'log_window' to at least the agent count.")
+  }
+
+  // MARK: Placeholders (token-bearing — %@ substitution)
+
+  @Test func unresolvablePlaceholderInterpolatesToken() {
+    #expect(
+      ScenarioLintMessage.unresolvablePlaceholder(token: "typo_token").localized
+        == "unresolvable-placeholder: the placeholder '{typo_token}' is supplied by no phase, "
+        + "so it leaks into the LLM prompt verbatim — check for a typo or remove it.")
+  }
+
+  @Test func perPersonaPlaceholderInSummarizeInterpolatesQuoteAndPercentToken() {
+    // The `placeholderMessage` `default:` arm's rule. Token contains an
+    // embedded quote and a `%` — proves the substitution is not itself run
+    // through a second `String(format:)` pass (which would misread `%`).
+    #expect(
+      ScenarioLintMessage.perPersonaPlaceholderInSummarize(token: "my\"notes%1").localized
+        == "per-persona-placeholder-in-summarize: the per-persona placeholder "
+        + "'{my\"notes%1}' is never populated in a 'summarize' phase (summaries aren't "
+        + "per-agent), so it leaks literally — remove it or move it to an LLM phase.")
+  }
+
+  // MARK: Conditions (token-bearing — %@ substitution)
+
+  @Test func singleQuotedLiteralInConditionInterpolatesToken() {
+    #expect(
+      ScenarioLintMessage.singleQuotedLiteralInCondition(token: "'Alice'").localized
+        == "single-quoted-literal-in-condition: the operand 'Alice' is single-quoted, but "
+        + "the condition evaluator treats only double quotes as string literals — it is "
+        + "read as an undefined identifier and the comparison is always false. Use double "
+        + "quotes instead.")
+  }
+
+  @Test func unknownConditionIdentifierInterpolatesQuoteAndPercentToken() {
+    // The `conditionMessage` `default:` arm's rule. Token contains an embedded
+    // quote and a `%` for the same reason as the Placeholders case above.
+    #expect(
+      ScenarioLintMessage.unknownConditionIdentifier(token: "weird\"name%2").localized
+        == "unknown-condition-identifier: 'weird\"name%2' is not a known condition variable "
+        + "(a derived variable, score, persona, extraData key, or engine-injected name), so "
+        + "it resolves to no value at runtime — check for a typo.")
+  }
+
+  // MARK: ruleIDs coverage
+
+  @Test func ruleIDsHasExactlyTwentyOneEntries() {
+    #expect(ScenarioLintMessage.ruleIDs.count == 21)
+  }
+
+  @Test func everyMessageStartsWithItsOwnRuleID() {
+    let byRuleID: [String: ScenarioLintMessage] = [
+      "eliminate-needs-vote": .eliminateNeedsVote,
+      "eliminate-after-vote": .eliminateAfterVote,
+      "pd-needs-round-robin-choose": .pdNeedsRoundRobinChoose,
+      "pairwise-payoff-needs-round-robin-choose": .pairwisePayoffNeedsRoundRobinChoose,
+      "wordwolf-needs-assign-and-vote": .wordwolfNeedsAssignAndVote,
+      "event-reactive-needs-event-inject": .eventReactiveNeedsEventInject,
+      "relationship-update-placement": .relationshipUpdatePlacement,
+      "vote-tally-needs-vote": .voteTallyNeedsVote,
+      "choose-should-declare-options": .chooseShouldDeclareOptions,
+      "assign-source-nonempty": .assignSourceNonempty,
+      "summarize-pairing-placeholders": .summarizePairingPlaceholders,
+      "max-sentences-no-op": .maxSentencesNoOp,
+      "pairwise-payoff-no-scorable-row": .pairwisePayoffNoScorableRow,
+      "pairwise-payoff-dead-row": .pairwisePayoffDeadRow,
+      "log-window-below-agent-count": .logWindowBelowAgentCount,
+      "unresolvable-placeholder": .unresolvablePlaceholder(token: "t"),
+      "placeholder-phase-availability": .placeholderPhaseAvailability(token: "t"),
+      "per-persona-placeholder-in-summarize": .perPersonaPlaceholderInSummarize(token: "t"),
+      "single-quoted-literal-in-condition": .singleQuotedLiteralInCondition(token: "t"),
+      "bare-identifier-looks-like-literal": .bareIdentifierLooksLikeLiteral(token: "t"),
+      "unknown-condition-identifier": .unknownConditionIdentifier(token: "t")
+    ]
+    #expect(byRuleID.count == 21)
+    for ruleID in ScenarioLintMessage.ruleIDs {
+      let message = byRuleID[ruleID]
+      #expect(message?.localized.hasPrefix("\(ruleID): ") == true)
+    }
+  }
+}

--- a/docs/decisions/ADR-023.md
+++ b/docs/decisions/ADR-023.md
@@ -266,6 +266,16 @@ precisely how §4 went stale in the first place.)
   preflight gate on the validator and the ADR-024 linter together and the linter is unported.
   `docs/kmp-migration-status.md`'s hand-maintained row carries the same state in prose, but its
   machine-checked section is handler-only, so this bullet remains the record.
+- `ScenarioSemanticLinter` (+4 extensions) → still **`PORT`**, in progress under Wave D. The
+  message prep this row called for landed first as a **separate** Models type,
+  `ScenarioLintMessage` (Swift) / `ScenarioLintMessage.kt` (Kotlin) — 21 cases, en-only
+  `render()` carrying the same Stage-5 debt as `ScenarioValidationMessage` (#1562, PR D1a,
+  2026-08-26). Separate rather than folded into `ScenarioValidationMessage` because a lint
+  finding is collected with a severity, not thrown as a single failure, and the validator's
+  53-case parity pin stays untouched. The linter's four Engine extensions now build the case
+  and render it, so no `String(localized:)` / `String(format:)` remains in them. Remaining:
+  `PlaceholderAvailability` (D1b), the linter body (D2a Ordering, D2b Config / Placeholders /
+  Conditions), then the preflight wiring (D3) that this bullet and the loader's wait on.
 
 ### How this section went stale, and what changed
 

--- a/docs/kmp-migration-status.md
+++ b/docs/kmp-migration-status.md
@@ -45,7 +45,7 @@ Legend: ✅ done · 🔄 in progress · 🟡 partial · ⬜ not started.
 | Wave A — non-handler run-path (scoring, mechanisms, prompt/LLM glue) | ✅ done | #1207 #1212 #1217 |
 | Wave B — 14 phase handlers | ✅ 14/14 | checklist ↓ |
 | code-phase track | ✅ done | CP1 #1226 · CP2 #1230 · CP3 #1232 |
-| Loader / validator port + `detector`·`logger` wiring | 🟡 partial | validator prerequisites in ([#1464](https://github.com/tyabu12/pastura/issues/1464)); validator fully ported — run gate + commit gate ([#1552](https://github.com/tyabu12/pastura/issues/1552) B1/B2); loader fully ported — YAML ingest + top-level mapping ([#1558](https://github.com/tyabu12/pastura/issues/1558) C2a) then phase specialisation ([#1560](https://github.com/tyabu12/pastura/issues/1560) C2b), and like the validator it is **not wired** yet; linter / preflight wiring left · [ADR-023](decisions/ADR-023.md) §4 · #501 |
+| Loader / validator port + `detector`·`logger` wiring | 🟡 partial | validator prerequisites in ([#1464](https://github.com/tyabu12/pastura/issues/1464)); validator fully ported — run gate + commit gate ([#1552](https://github.com/tyabu12/pastura/issues/1552) B1/B2); loader fully ported — YAML ingest + top-level mapping ([#1558](https://github.com/tyabu12/pastura/issues/1558) C2a) then phase specialisation ([#1560](https://github.com/tyabu12/pastura/issues/1560) C2b), and like the validator it is **not wired** yet; linter message prep in — `ScenarioLintMessage` Swift + Kotlin mirror ([#1562](https://github.com/tyabu12/pastura/issues/1562) D1a); `PlaceholderAvailability` (D1b), linter body (D2a/D2b) and preflight wiring (D3) left · [ADR-023](decisions/ADR-023.md) §4 · #501 |
 
 ### Wave B handler checklist
 

--- a/docs/kmp-migration-status.md
+++ b/docs/kmp-migration-status.md
@@ -33,7 +33,7 @@ _Last updated: 2026-08-26._
 | 2 | Two-boundary vertical slice = GO/NO-GO gate | ✅ **GO** (2026-07-18) | #1063 #1137 #1172 · [ADR-023 §12](decisions/ADR-023.md) |
 | 3 | Bulk port to `commonMain` | 🔄 in progress | ↓ Stage 3 breakdown |
 | 4 | Cross-language parity harness | 🔄 in progress | slice 1a landed ([#1387](https://github.com/tyabu12/pastura/issues/1387), closed); 1b next · [#501](https://github.com/tyabu12/pastura/issues/501) |
-| 5 | iOS consumption switch + code-merge | ⬜ not started | the remaining integration · adapter traps: [`kmp-interop.md`](../.claude/rules/kmp-interop.md) · ⚠️ en-only `ScenarioValidationMessage.render()` blocks this — [#1464](https://github.com/tyabu12/pastura/issues/1464) |
+| 5 | iOS consumption switch + code-merge | ⬜ not started | the remaining integration · adapter traps: [`kmp-interop.md`](../.claude/rules/kmp-interop.md) · ⚠️ en-only `ScenarioValidationMessage.render()` / `ScenarioLintMessage.render()` block this — [#1464](https://github.com/tyabu12/pastura/issues/1464), [#1562](https://github.com/tyabu12/pastura/issues/1562) |
 
 Legend: ✅ done · 🔄 in progress · 🟡 partial · ⬜ not started.
 

--- a/shared/models/src/commonMain/kotlin/com/pastura/models/ScenarioLintMessage.kt
+++ b/shared/models/src/commonMain/kotlin/com/pastura/models/ScenarioLintMessage.kt
@@ -1,0 +1,277 @@
+package com.pastura.models
+
+/**
+ * A parameter-carrying description of an ADR-024 semantic-lint finding message.
+ *
+ * Kotlin port of `Pastura/Pastura/Models/ScenarioLintMessage.swift`, **1:1
+ * across all 21 cases** — the Swift enum is the single source of truth for the
+ * set, the declaration order, and every literal. Each subtype is a portable
+ * structured payload (name + typed args); [render] is the single rendering leaf
+ * that turns one into a display string.
+ *
+ * ## Deliberately separate from [ScenarioValidationMessage]
+ *
+ * The two model different surfaces, and folding the 21 cases into
+ * [ScenarioValidationMessage] was considered and rejected (issue #1562): a lint
+ * finding carries a severity and is collected alongside other findings for the
+ * same scenario, while a validation message is thrown as the sole reason a load
+ * or commit-gate check failed. Conflating them would force a shared shape
+ * neither surface actually has. [ScenarioValidationMessage]'s 53-case count pin
+ * therefore stays at 53 — these cases never join it.
+ *
+ * ## Naming
+ *
+ * A subtype's name is its Swift case name with the first character uppercased,
+ * with **no** other rewriting (so `pdNeedsRoundRobinChoose` →
+ * [PdNeedsRoundRobinChoose], not `PDNeedsRoundRobinChoose`). That keeps the
+ * mapping mechanical, which is what lets the commonTest case-set check compare a
+ * hand-transcribed Swift name list against this hierarchy without a translation
+ * table. Constructor parameter names likewise reuse the Swift argument labels —
+ * every token-bearing case here uses the label `token`.
+ *
+ * ## Landed as infra
+ *
+ * There is **no Kotlin consumer yet** — `ScenarioSemanticLinter` itself is
+ * unported. This type is the dependency that must exist before the linter port
+ * (D2a / D2b) can compile, and that port is what will consume it. Ported for the
+ * ADR-023 §6 Stage-3 Engine migration (#501 / #1562).
+ */
+public sealed class ScenarioLintMessage {
+
+    // ── Ordering (ScenarioSemanticLinter+Ordering.swift, R1–R6/R19) ─────────
+
+    public object EliminateNeedsVote : ScenarioLintMessage()
+
+    public object EliminateAfterVote : ScenarioLintMessage()
+
+    public object PdNeedsRoundRobinChoose : ScenarioLintMessage()
+
+    public object PairwisePayoffNeedsRoundRobinChoose : ScenarioLintMessage()
+
+    public object WordwolfNeedsAssignAndVote : ScenarioLintMessage()
+
+    public object EventReactiveNeedsEventInject : ScenarioLintMessage()
+
+    public object RelationshipUpdatePlacement : ScenarioLintMessage()
+
+    public object VoteTallyNeedsVote : ScenarioLintMessage()
+
+    // ── Config (ScenarioSemanticLinter+Config.swift, R7/R8/R9/R17/R18/R20a/R20b) ──
+
+    public object ChooseShouldDeclareOptions : ScenarioLintMessage()
+
+    public object AssignSourceNonempty : ScenarioLintMessage()
+
+    public object SummarizePairingPlaceholders : ScenarioLintMessage()
+
+    public object MaxSentencesNoOp : ScenarioLintMessage()
+
+    public object PairwisePayoffNoScorableRow : ScenarioLintMessage()
+
+    public object PairwisePayoffDeadRow : ScenarioLintMessage()
+
+    public object LogWindowBelowAgentCount : ScenarioLintMessage()
+
+    // ── Placeholders (ScenarioSemanticLinter+Placeholders.swift, R10/R11/R12) ──
+
+    public data class UnresolvablePlaceholder(public val token: String) : ScenarioLintMessage()
+
+    public data class PlaceholderPhaseAvailability(public val token: String) : ScenarioLintMessage()
+
+    public data class PerPersonaPlaceholderInSummarize(
+        public val token: String,
+    ) : ScenarioLintMessage()
+
+    // ── Conditions (ScenarioSemanticLinter+Conditions.swift, R13/R14/R15) ───
+
+    public data class SingleQuotedLiteralInCondition(
+        public val token: String,
+    ) : ScenarioLintMessage()
+
+    public data class BareIdentifierLooksLikeLiteral(
+        public val token: String,
+    ) : ScenarioLintMessage()
+
+    public data class UnknownConditionIdentifier(public val token: String) : ScenarioLintMessage()
+
+    /**
+     * Renders the case to its display string, in **English only**.
+     *
+     * The literals are byte-identical to the `String(localized:)` base values in
+     * Swift's `ScenarioLintMessage.localized`, with each `%@` replaced by the
+     * case's `token`. Swift substitutes through `String(format:)` with exactly
+     * one argument, which interpolates the token **verbatim** — no quoting, no
+     * escaping, and no second format pass over the result — so a plain Kotlin
+     * string template is the faithful port, and a token containing a quote or a
+     * `%` must survive untouched (the commonTest roster pins exactly that).
+     *
+     * ## Why en-only, and the Stage-5 debt it creates
+     *
+     * `commonMain` has no string catalog, and Kotlin/Native has no path to
+     * `Localizable.xcstrings`. ADR-023 §5 defines no boundary for this type and
+     * nothing consumes it in production until the linter port, so there is no
+     * localization contract to satisfy yet, and inventing one here would be
+     * guessing at Stage-5's design.
+     *
+     * Every one of these 21 literals **already has a `ja` translation** in
+     * `Pastura/Pastura/Resources/Localizable.xcstrings`. Lint findings are more
+     * exposed than validation messages: they surface in the scenario **editor
+     * UI**, one row per finding, as ordinary browsing output rather than as a
+     * rare failure. If iOS starts consuming the Kotlin engine (Stage 5) while
+     * this is still en-only, Japanese users read English lint findings in the
+     * editor — a user-visible regression with **no compiler and no test signal**,
+     * since the Kotlin side would be internally consistent and the commonTest
+     * pins would stay green. A KDoc is only read by someone already in this file,
+     * which is the wrong audience for a debt that fires at Stage 5, so it is also
+     * recorded on the Stage-5 row of `docs/kmp-migration-status.md`.
+     *
+     * The Stage-5 fix is to make the rendering an `expect`/`actual` leaf, or to
+     * route the Apple side back through the Swift `localized`. Member naming here
+     * is chosen so either lands without moving callers: `render()` keeps its name
+     * and signature, and only its body delegates to the platform leaf. When
+     * budgeting that, count **source sets, not targets** — re-derive from
+     * `shared/models/build.gradle.kts`, whose four Apple targets share a parent
+     * source set under the default hierarchy template.
+     *
+     * ## No gate covers the dual landing of these 21 literals
+     *
+     * These literals are dual-landed with Swift's `ScenarioLintMessage.localized`
+     * (that property's own doc comment says the same from the other side).
+     * Reword one there and the twin here, plus this module's expected-string
+     * pins, stay stale *and agree with each other* — so nothing reddens on either
+     * side. `check-prompt-literal-parity.py` does not close it: it only looks at
+     * `Engine/` + `LLM/` files containing `pickLanguage`, which never reaches
+     * `Models/`. The mitigation is procedural only — the Swift file is the source
+     * of truth, and a reword there is a two-file edit by hand.
+     */
+    public fun render(): String = when (this) {
+        // ── Ordering ────────────────────────────────────────────────────────
+        is EliminateNeedsVote ->
+            "eliminate-needs-vote: an 'eliminate' phase does nothing without a 'vote' phase " +
+                "in the same round — add a 'vote' phase before it."
+        is EliminateAfterVote ->
+            "eliminate-after-vote: this 'eliminate' runs before every 'vote' phase, so it " +
+                "acts on the previous round's stale tally — move it after the 'vote' phase."
+        is PdNeedsRoundRobinChoose ->
+            "pd-needs-round-robin-choose: 'prisoners_dilemma' scoring needs a round-robin " +
+                "'choose' phase earlier in the round to populate pairings, or scores never " +
+                "change — add one before this 'score_calc'."
+        is PairwisePayoffNeedsRoundRobinChoose ->
+            "pairwise-payoff-needs-round-robin-choose: 'pairwise_payoff' scoring needs a " +
+                "round-robin 'choose' phase earlier in the round to populate pairings, or " +
+                "scores never change — add one before this 'score_calc'."
+        is WordwolfNeedsAssignAndVote ->
+            "wordwolf-needs-assign-and-vote: 'wordwolf_judge' scoring needs both an 'assign' " +
+                "phase with target 'random_one' and a 'vote' phase earlier in the round, or it " +
+                "judges nothing — add the missing phase(s) before this 'score_calc'."
+        is EventReactiveNeedsEventInject ->
+            "event-reactive-needs-event-inject: 'event_reactive' scoring needs an earlier " +
+                "'event_inject' phase with a dictionary event source and the default " +
+                "'as: current_event', or the favored action is never scored — fix the " +
+                "'event_inject' before this 'score_calc'."
+        is RelationshipUpdatePlacement ->
+            "relationship-update-placement: this 'relationship_update' cannot see its " +
+                "vote/choose signals — place it after the producing 'vote'/'choose' phase and " +
+                "before any 'prisoners_dilemma' 'score_calc', with no 'speak'/'choose' phase " +
+                "between the vote and it."
+        is VoteTallyNeedsVote ->
+            "vote-tally-needs-vote: 'vote_tally' scoring has no 'vote' phase earlier in the " +
+                "round, so it scores nothing or re-adds a stale tally — add a 'vote' phase " +
+                "before this 'score_calc'."
+        // ── Config ──────────────────────────────────────────────────────────
+        is ChooseShouldDeclareOptions ->
+            "choose-should-declare-options: this 'choose' phase has no 'options' list, so " +
+                "the agent's action is unconstrained free text — add an 'options' list to steer " +
+                "the choice."
+        is AssignSourceNonempty ->
+            "assign-source-nonempty: this 'assign' phase's source resolves to an empty list, " +
+                "so nothing is assigned (or every agent gets an empty value) — add at least one " +
+                "entry to the referenced source data."
+        is SummarizePairingPlaceholders ->
+            "summarize-pairing-placeholders: this 'summarize' template references " +
+                "{agent1}-family placeholders, but no round-robin 'choose' phase runs earlier " +
+                "in the round, so the placeholders leak literally into the summary — add a " +
+                "round-robin 'choose' phase before this 'summarize', or remove the pairing " +
+                "placeholders."
+        is MaxSentencesNoOp ->
+            "max-sentences-no-op: this phase emits no LLM statement, so its 'max_sentences' " +
+                "cap never reaches a prompt and has no effect — remove it, or move it to a " +
+                "phase that emits a statement (speak_all / speak_each / whisper)."
+        is PairwisePayoffNoScorableRow ->
+            "pairwise-payoff-no-scorable-row: no 'payoff' row's 'when' tokens match the " +
+                "round-robin 'choose' options, so no pairing is ever scored — add a 'payoff' " +
+                "table whose 'when' rows use the 'choose' option tokens."
+        is PairwisePayoffDeadRow ->
+            "pairwise-payoff-dead-row: one or more 'payoff' rows use 'when' tokens that " +
+                "aren't in the round-robin 'choose' options, so those rows never fire — fix the " +
+                "tokens to match the 'choose' options, or remove the unused rows."
+        is LogWindowBelowAgentCount ->
+            "log-window-below-agent-count: 'log_window' is smaller than the agent count " +
+                "while a 'speak_each' phase is present, so same-round earlier speakers vanish " +
+                "from the addressee pool — raise 'log_window' to at least the agent count."
+        // ── Placeholders ────────────────────────────────────────────────────
+        is UnresolvablePlaceholder ->
+            "unresolvable-placeholder: the placeholder '{$token}' is supplied by no " +
+                "phase, so it leaks into the LLM prompt verbatim — check for a typo or remove it."
+        is PlaceholderPhaseAvailability ->
+            "placeholder-phase-availability: the placeholder '{$token}' is only " +
+                "populated by a producing phase, but none runs earlier in the phase list, so it " +
+                "resolves to an empty value — move the producing phase before this one."
+        is PerPersonaPlaceholderInSummarize ->
+            "per-persona-placeholder-in-summarize: the per-persona placeholder " +
+                "'{$token}' is never populated in a 'summarize' phase (summaries aren't " +
+                "per-agent), so it leaks literally — remove it or move it to an LLM phase."
+        // ── Conditions ──────────────────────────────────────────────────────
+        is SingleQuotedLiteralInCondition ->
+            "single-quoted-literal-in-condition: the operand $token is single-quoted, " +
+                "but the condition evaluator treats only double quotes as string literals — it " +
+                "is read as an undefined identifier and the comparison is always false. Use " +
+                "double quotes instead."
+        is BareIdentifierLooksLikeLiteral ->
+            "bare-identifier-looks-like-literal: the operand '$token' matches a persona " +
+                "name but is unquoted, so the condition evaluator reads it as an undefined " +
+                "identifier and the comparison is always false — wrap it in double quotes to " +
+                "compare against the name."
+        is UnknownConditionIdentifier ->
+            "unknown-condition-identifier: '$token' is not a known condition " +
+                "variable (a derived variable, score, persona, extraData key, or " +
+                "engine-injected name), so it resolves to no value at runtime — check for a typo."
+    }
+
+    public companion object {
+        /**
+         * Every rule ID, in declaration order, one per subtype above — the port
+         * of Swift's `ScenarioLintMessage.ruleIDs`, which stands in for
+         * `CaseIterable` (unavailable there because six cases carry an
+         * associated `token: String`).
+         *
+         * The order is part of the contract, not incidental: it is what lets the
+         * commonTest suite zip this list against the roster and assert that each
+         * rendering starts with its own rule ID. Add a subtype and this list, the
+         * roster, and the `21` pins all move together.
+         */
+        public val ruleIDs: List<String> = listOf(
+            "eliminate-needs-vote",
+            "eliminate-after-vote",
+            "pd-needs-round-robin-choose",
+            "pairwise-payoff-needs-round-robin-choose",
+            "wordwolf-needs-assign-and-vote",
+            "event-reactive-needs-event-inject",
+            "relationship-update-placement",
+            "vote-tally-needs-vote",
+            "choose-should-declare-options",
+            "assign-source-nonempty",
+            "summarize-pairing-placeholders",
+            "max-sentences-no-op",
+            "pairwise-payoff-no-scorable-row",
+            "pairwise-payoff-dead-row",
+            "log-window-below-agent-count",
+            "unresolvable-placeholder",
+            "placeholder-phase-availability",
+            "per-persona-placeholder-in-summarize",
+            "single-quoted-literal-in-condition",
+            "bare-identifier-looks-like-literal",
+            "unknown-condition-identifier",
+        )
+    }
+}

--- a/shared/models/src/commonMain/kotlin/com/pastura/models/ScenarioValidationMessage.kt
+++ b/shared/models/src/commonMain/kotlin/com/pastura/models/ScenarioValidationMessage.kt
@@ -12,12 +12,14 @@ package com.pastura.models
  *
  * These 53 cases come from `ScenarioValidator` (+ its extensions) and
  * `ScenarioLoader` **only**. The ADR-024 semantic linter is a *separate* surface
- * with its own 21 messages (Ordering 8 / Config 7 / Conditions 3 /
- * Placeholders 3 — measured against
- * `Pastura/Pastura/Engine/ScenarioSemanticLinter+*.swift`), which are not here
- * and grow this type when `ScenarioSemanticLinter` is ported — at which point
- * `ScenarioValidationMessageTests`' count pin fails by design, not as a
- * regression.
+ * with its own 21 messages (Ordering 8 / Config 7 / Placeholders 3 /
+ * Conditions 3), and they live in their own type — [ScenarioLintMessage],
+ * mirroring `Pastura/Pastura/Models/ScenarioLintMessage.swift`. That split is a
+ * decision (#1562), not a staging accident: a lint finding carries a severity
+ * and is collected alongside others for the same scenario, while a validation
+ * message is thrown as the sole reason a load or commit-gate check failed.
+ * So the `53` pins in `ScenarioValidationMessageTests` **stay at 53** when
+ * `ScenarioSemanticLinter` is ported — the linter's cases never join this type.
  *
  * ## Landed as infra
  *

--- a/shared/models/src/commonTest/kotlin/com/pastura/models/ScenarioLintMessageTests.kt
+++ b/shared/models/src/commonTest/kotlin/com/pastura/models/ScenarioLintMessageTests.kt
@@ -29,9 +29,10 @@ import kotlin.test.assertTrue
  * Swift renders the six token-bearing cases through
  * `String(format: String(localized: "…%@…"), token)`, which interpolates the
  * token **verbatim** — no quoting, no escaping, and no second format pass. The
- * tokens below therefore contain both a quote character and a `%`, exactly as
- * `ScenarioLintMessageTests.swift` does: a Kotlin `render()` that tried to be
- * clever about either would redden here. They are also mutually distinguishable
+ * tokens below therefore contain both a quote character and a `%` on **all six**
+ * token-bearing cases (the Swift suite does so on only two, so this side is the
+ * stricter pin): a Kotlin `render()` that tried to be clever about either would
+ * redden here. They are also mutually distinguishable
  * across cases, so a roster entry pasted onto the wrong case cannot pass.
  *
  * ## En-only pin is Stage-5-scoped

--- a/shared/models/src/commonTest/kotlin/com/pastura/models/ScenarioLintMessageTests.kt
+++ b/shared/models/src/commonTest/kotlin/com/pastura/models/ScenarioLintMessageTests.kt
@@ -1,0 +1,359 @@
+package com.pastura.models
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Locks [ScenarioLintMessage.render] to byte-identical strings against the
+ * Swift original (`Pastura/Pastura/Models/ScenarioLintMessage.swift`), the
+ * single source of truth for both the case set and every expected literal below
+ * — this file never sources an expected string from `ScenarioLintMessage.kt`
+ * itself (the file under test), which would blind it to a transcription error.
+ *
+ * Four parts, per issue #1562 / ADR-023 §12, mirroring
+ * [ScenarioValidationMessageTests] — the precedent for this shape:
+ *
+ * (a) [caseSetMatchesSwiftEnumBidirectionally] — the 21 hand-transcribed Swift
+ *     case names vs. the Kotlin subtype names, both directions.
+ * (b) [rosterAndSwiftTranscriptionAgreeOn21Cases] — a count pin plus an
+ *     else-free `when` roster ([swiftCaseNameOf]).
+ * (c) [rendersAllTwentyOneCasesWithTokenInterpolationIntact] and
+ *     [ruleIDsMatchRosterOrderAndPrefixEveryRendering] — every one of the 21
+ *     cases rendered and asserted by full-string equality, seeded from the
+ *     Swift `String(localized:)` base literals; plus the `ruleIDs` order pin.
+ * (d) this KDoc's perturbation-record table, below.
+ *
+ * ## Why the test tokens carry a quote and a `%`
+ *
+ * Swift renders the six token-bearing cases through
+ * `String(format: String(localized: "…%@…"), token)`, which interpolates the
+ * token **verbatim** — no quoting, no escaping, and no second format pass. The
+ * tokens below therefore contain both a quote character and a `%`, exactly as
+ * `ScenarioLintMessageTests.swift` does: a Kotlin `render()` that tried to be
+ * clever about either would redden here. They are also mutually distinguishable
+ * across cases, so a roster entry pasted onto the wrong case cannot pass.
+ *
+ * ## En-only pin is Stage-5-scoped
+ *
+ * [ScenarioLintMessage.render] is a single common-code function today, so
+ * pinning its English output here is sound. The day `render()` becomes an
+ * `expect`/`actual` leaf (or delegates to the Swift `localized`), these
+ * single-locale full-string pins go stale for every target whose `actual`
+ * localizes — see `render()`'s own KDoc, "The Stage-5 debt this creates".
+ *
+ * ## §12 condition-4 perturbation record
+ *
+ * Baseline before the first mutation: **4 tests, 0 failures** (this class, under
+ * `:shared:models:jvmTest`), green. Each mutation's anchor text was confirmed to
+ * match **exactly once** in `ScenarioLintMessage.kt` before applying — a
+ * replacement that silently no-ops leaves the original behaviour and reads as
+ * verified. The unmutated baseline was reconfirmed green after the last revert;
+ * that reconfirmation is the evidence the mutations were reverted, and it is the
+ * only evidence there is (this file and `ScenarioLintMessage.kt` are both *added*
+ * by the PR, so a `git diff` against `main` cannot distinguish "reverted" from
+ * "never applied"). Counts are measured, not derived. Measured 2026-08-26, #1562.
+ *
+ * | # | Mutation applied to `ScenarioLintMessage.kt` | Test that reddened | Other tests reddened |
+ * |---|---|---|---|
+ * | 1 | swapped the render arms of `EliminateNeedsVote` and `EliminateAfterVote` | [rendersAllTwentyOneCasesWithTokenInterpolationIntact] (eliminateNeedsVote entry) and [ruleIDsMatchRosterOrderAndPrefixEveryRendering] | 0 |
+ * | 2 | dropped the token interpolation from `UnknownConditionIdentifier` (rendered the literal word `token` instead) | [rendersAllTwentyOneCasesWithTokenInterpolationIntact] (unknownConditionIdentifier entry) | 0 |
+ * | 3 | reordered `ruleIDs` — swapped `"choose-should-declare-options"` and `"assign-source-nonempty"` | [ruleIDsMatchRosterOrderAndPrefixEveryRendering] | 0 |
+ *
+ * Mutation 1 reddens two tests because the rule-ID prefix is part of every
+ * literal, so swapping two arms breaks the prefix contract as well as the
+ * literals; that is a property of the design, not a duplicated assertion.
+ * Mutation 3 reddens **only** the order/prefix test — the roster and the render
+ * pins say nothing about `ruleIDs` order, which is precisely why that test
+ * exists. No mutation left the suite green.
+ */
+class ScenarioLintMessageTests {
+
+    /**
+     * Hand-transcribed from `Pastura/Pastura/Models/ScenarioLintMessage.swift`,
+     * in file (declaration) order, grouped as the Swift `// MARK`s group them.
+     * The Kotlin naming rule is "Swift case name with the first character
+     * uppercased, nothing else rewritten" (`ScenarioLintMessage.kt`'s own
+     * "Naming" KDoc section), so this list needs no translation table beyond
+     * that capitalisation.
+     */
+    private val swiftCaseNames: List<String> = listOf(
+        // Ordering
+        "eliminateNeedsVote",
+        "eliminateAfterVote",
+        "pdNeedsRoundRobinChoose",
+        "pairwisePayoffNeedsRoundRobinChoose",
+        "wordwolfNeedsAssignAndVote",
+        "eventReactiveNeedsEventInject",
+        "relationshipUpdatePlacement",
+        "voteTallyNeedsVote",
+        // Config
+        "chooseShouldDeclareOptions",
+        "assignSourceNonempty",
+        "summarizePairingPlaceholders",
+        "maxSentencesNoOp",
+        "pairwisePayoffNoScorableRow",
+        "pairwisePayoffDeadRow",
+        "logWindowBelowAgentCount",
+        // Placeholders
+        "unresolvablePlaceholder",
+        "placeholderPhaseAvailability",
+        "perPersonaPlaceholderInSummarize",
+        // Conditions
+        "singleQuotedLiteralInCondition",
+        "bareIdentifierLooksLikeLiteral",
+        "unknownConditionIdentifier",
+    )
+
+    // ── (a) Case-set completeness ───────────────────────────────────────────
+
+    @Test
+    fun caseSetMatchesSwiftEnumBidirectionally() {
+        assertEquals(21, swiftCaseNames.size, "swiftCaseNames transcription itself must list 21")
+        val expectedKotlinNames = swiftCaseNames.map { it.replaceFirstChar(Char::uppercaseChar) }.toSet()
+        val actualKotlinNames = roster().map { it::class.simpleName }.toSet()
+        val missingInKotlin = expectedKotlinNames - actualKotlinNames
+        val extraInKotlin = actualKotlinNames - expectedKotlinNames
+        assertTrue(
+            missingInKotlin.isEmpty() && extraInKotlin.isEmpty(),
+            "Case-set mismatch. In Swift but not Kotlin: $missingInKotlin. " +
+                "In Kotlin but not Swift: $extraInKotlin.",
+        )
+    }
+
+    // ── (b) Count pin + else-free `when` roster ─────────────────────────────
+
+    /**
+     * This is a **pin, not a proof.** `KClass.sealedSubclasses` is JVM-only and
+     * ADR-023 Decision 5 requires the `macosArm64` rung, so commonTest cannot
+     * enumerate a sealed hierarchy reflectively — see
+     * `.claude/rules/kmp-interop.md` Pattern 4. The count pin below, plus the
+     * else-free `when` in [swiftCaseNameOf] (which fails to *compile* if a
+     * subtype is added without a matching arm), is the strongest available
+     * substitute for real reflective completeness.
+     *
+     * **The residual hole, stated so the name cannot be read as covering it.**
+     * [roster] is derived from the hand-written [rosterWithExpectedRenderings],
+     * so nothing ties `21` to the number of sealed subtypes. Add a 22nd subtype
+     * *and* its [swiftCaseNameOf] arm (which the compiler forces) but forget the
+     * roster entry and the [swiftCaseNames] entry, and the case-set and roster
+     * tests still pass. (Unlike the validation-message precedent, a 22nd
+     * `ruleIDs` entry would then redden
+     * [ruleIDsMatchRosterOrderAndPrefixEveryRendering] on the size check — but
+     * only if the author remembered `ruleIDs`, so that is a partial backstop,
+     * not a guard.) The compile-time `when` is the only real hierarchy guard.
+     * The `21`s here and in `ScenarioLintMessage.ruleIDs` are hand-maintained in
+     * lockstep — treat them as one edit.
+     */
+    @Test
+    fun rosterAndSwiftTranscriptionAgreeOn21Cases() {
+        val entries = roster()
+        assertEquals(21, entries.size, "Roster size pin — see kmp-interop.md Pattern 4")
+        val caseNames = entries.map(::swiftCaseNameOf)
+        assertEquals(
+            caseNames.size,
+            caseNames.toSet().size,
+            "Roster has a duplicate subtype: $caseNames",
+        )
+        assertEquals(swiftCaseNames.toSet(), caseNames.toSet())
+    }
+
+    /**
+     * Deliberately has **no `else` branch** — a Kotlin subtype added to
+     * [ScenarioLintMessage] without an arm here fails the build, which is the
+     * compile-time half of the "pin, not proof" substitute described on
+     * [rosterAndSwiftTranscriptionAgreeOn21Cases].
+     */
+    private fun swiftCaseNameOf(msg: ScenarioLintMessage): String = when (msg) {
+        is ScenarioLintMessage.EliminateNeedsVote -> "eliminateNeedsVote"
+        is ScenarioLintMessage.EliminateAfterVote -> "eliminateAfterVote"
+        is ScenarioLintMessage.PdNeedsRoundRobinChoose -> "pdNeedsRoundRobinChoose"
+        is ScenarioLintMessage.PairwisePayoffNeedsRoundRobinChoose -> "pairwisePayoffNeedsRoundRobinChoose"
+        is ScenarioLintMessage.WordwolfNeedsAssignAndVote -> "wordwolfNeedsAssignAndVote"
+        is ScenarioLintMessage.EventReactiveNeedsEventInject -> "eventReactiveNeedsEventInject"
+        is ScenarioLintMessage.RelationshipUpdatePlacement -> "relationshipUpdatePlacement"
+        is ScenarioLintMessage.VoteTallyNeedsVote -> "voteTallyNeedsVote"
+        is ScenarioLintMessage.ChooseShouldDeclareOptions -> "chooseShouldDeclareOptions"
+        is ScenarioLintMessage.AssignSourceNonempty -> "assignSourceNonempty"
+        is ScenarioLintMessage.SummarizePairingPlaceholders -> "summarizePairingPlaceholders"
+        is ScenarioLintMessage.MaxSentencesNoOp -> "maxSentencesNoOp"
+        is ScenarioLintMessage.PairwisePayoffNoScorableRow -> "pairwisePayoffNoScorableRow"
+        is ScenarioLintMessage.PairwisePayoffDeadRow -> "pairwisePayoffDeadRow"
+        is ScenarioLintMessage.LogWindowBelowAgentCount -> "logWindowBelowAgentCount"
+        is ScenarioLintMessage.UnresolvablePlaceholder -> "unresolvablePlaceholder"
+        is ScenarioLintMessage.PlaceholderPhaseAvailability -> "placeholderPhaseAvailability"
+        is ScenarioLintMessage.PerPersonaPlaceholderInSummarize -> "perPersonaPlaceholderInSummarize"
+        is ScenarioLintMessage.SingleQuotedLiteralInCondition -> "singleQuotedLiteralInCondition"
+        is ScenarioLintMessage.BareIdentifierLooksLikeLiteral -> "bareIdentifierLooksLikeLiteral"
+        is ScenarioLintMessage.UnknownConditionIdentifier -> "unknownConditionIdentifier"
+    }
+
+    // ── (c) Rendering assertions ────────────────────────────────────────────
+
+    @Test
+    fun rendersAllTwentyOneCasesWithTokenInterpolationIntact() {
+        rosterWithExpectedRenderings().forEach { (msg, expected) ->
+            assertEquals(expected, msg.render(), "Render mismatch for ${swiftCaseNameOf(msg)}")
+        }
+    }
+
+    /**
+     * `ruleIDs` stands in for `CaseIterable` on the Swift side, so its **order**
+     * is load-bearing in a way the render pins cannot see: they assert literals,
+     * not the list. This asserts both halves of the contract Swift's
+     * `everyMessageStartsWithItsOwnRuleID` asserts — 21 IDs, in the declaration
+     * order the roster walks, each one prefixing its own case's rendering.
+     */
+    @Test
+    fun ruleIDsMatchRosterOrderAndPrefixEveryRendering() {
+        val ruleIDs = ScenarioLintMessage.ruleIDs
+        assertEquals(21, ruleIDs.size, "ruleIDs must carry one entry per case")
+        assertEquals(ruleIDs.size, ruleIDs.toSet().size, "ruleIDs has a duplicate: $ruleIDs")
+        assertEquals(expectedRuleIDsInSwiftOrder, ruleIDs, "ruleIDs order drifted from Swift")
+        val messages = roster()
+        assertEquals(ruleIDs.size, messages.size)
+        ruleIDs.zip(messages).forEach { (ruleID, msg) ->
+            assertTrue(
+                msg.render().startsWith("$ruleID: "),
+                "Rendering for ${swiftCaseNameOf(msg)} does not start with \"$ruleID: \" — " +
+                    "got: ${msg.render()}",
+            )
+        }
+    }
+
+    /**
+     * Hand-transcribed from `ScenarioLintMessage.swift`'s `ruleIDs` literal, in
+     * declaration order — never copied from `ScenarioLintMessage.kt`.
+     */
+    private val expectedRuleIDsInSwiftOrder: List<String> = listOf(
+        "eliminate-needs-vote",
+        "eliminate-after-vote",
+        "pd-needs-round-robin-choose",
+        "pairwise-payoff-needs-round-robin-choose",
+        "wordwolf-needs-assign-and-vote",
+        "event-reactive-needs-event-inject",
+        "relationship-update-placement",
+        "vote-tally-needs-vote",
+        "choose-should-declare-options",
+        "assign-source-nonempty",
+        "summarize-pairing-placeholders",
+        "max-sentences-no-op",
+        "pairwise-payoff-no-scorable-row",
+        "pairwise-payoff-dead-row",
+        "log-window-below-agent-count",
+        "unresolvable-placeholder",
+        "placeholder-phase-availability",
+        "per-persona-placeholder-in-summarize",
+        "single-quoted-literal-in-condition",
+        "bare-identifier-looks-like-literal",
+        "unknown-condition-identifier",
+    )
+
+    private fun roster(): List<ScenarioLintMessage> =
+        rosterWithExpectedRenderings().map { it.first }
+
+    /**
+     * Every one of the 21 cases, in Swift declaration order, paired with its
+     * expected rendered string transcribed from `ScenarioLintMessage.swift`'s
+     * `String(localized:)` base literals with `%@` replaced by the token —
+     * never copied from `ScenarioLintMessage.kt`.
+     *
+     * The six token-bearing cases are constructed **positionally**: each carries
+     * exactly one `String`, so there is no argument-order hazard of the kind the
+     * validation-message suite guards against, but a positional call still pins
+     * that the parameter exists and is the first one.
+     */
+    private fun rosterWithExpectedRenderings(): List<Pair<ScenarioLintMessage, String>> = listOf(
+        // ── Ordering ────────────────────────────────────────────────────────
+        ScenarioLintMessage.EliminateNeedsVote to
+            "eliminate-needs-vote: an 'eliminate' phase does nothing without a 'vote' phase " +
+            "in the same round — add a 'vote' phase before it.",
+        ScenarioLintMessage.EliminateAfterVote to
+            "eliminate-after-vote: this 'eliminate' runs before every 'vote' phase, so it " +
+            "acts on the previous round's stale tally — move it after the 'vote' phase.",
+        ScenarioLintMessage.PdNeedsRoundRobinChoose to
+            "pd-needs-round-robin-choose: 'prisoners_dilemma' scoring needs a round-robin " +
+            "'choose' phase earlier in the round to populate pairings, or scores never " +
+            "change — add one before this 'score_calc'.",
+        ScenarioLintMessage.PairwisePayoffNeedsRoundRobinChoose to
+            "pairwise-payoff-needs-round-robin-choose: 'pairwise_payoff' scoring needs a " +
+            "round-robin 'choose' phase earlier in the round to populate pairings, or " +
+            "scores never change — add one before this 'score_calc'.",
+        ScenarioLintMessage.WordwolfNeedsAssignAndVote to
+            "wordwolf-needs-assign-and-vote: 'wordwolf_judge' scoring needs both an 'assign' " +
+            "phase with target 'random_one' and a 'vote' phase earlier in the round, or it " +
+            "judges nothing — add the missing phase(s) before this 'score_calc'.",
+        ScenarioLintMessage.EventReactiveNeedsEventInject to
+            "event-reactive-needs-event-inject: 'event_reactive' scoring needs an earlier " +
+            "'event_inject' phase with a dictionary event source and the default " +
+            "'as: current_event', or the favored action is never scored — fix the " +
+            "'event_inject' before this 'score_calc'.",
+        ScenarioLintMessage.RelationshipUpdatePlacement to
+            "relationship-update-placement: this 'relationship_update' cannot see its " +
+            "vote/choose signals — place it after the producing 'vote'/'choose' phase and " +
+            "before any 'prisoners_dilemma' 'score_calc', with no 'speak'/'choose' phase " +
+            "between the vote and it.",
+        ScenarioLintMessage.VoteTallyNeedsVote to
+            "vote-tally-needs-vote: 'vote_tally' scoring has no 'vote' phase earlier in the " +
+            "round, so it scores nothing or re-adds a stale tally — add a 'vote' phase " +
+            "before this 'score_calc'.",
+        // ── Config ──────────────────────────────────────────────────────────
+        ScenarioLintMessage.ChooseShouldDeclareOptions to
+            "choose-should-declare-options: this 'choose' phase has no 'options' list, so " +
+            "the agent's action is unconstrained free text — add an 'options' list to steer " +
+            "the choice.",
+        ScenarioLintMessage.AssignSourceNonempty to
+            "assign-source-nonempty: this 'assign' phase's source resolves to an empty list, " +
+            "so nothing is assigned (or every agent gets an empty value) — add at least one " +
+            "entry to the referenced source data.",
+        ScenarioLintMessage.SummarizePairingPlaceholders to
+            "summarize-pairing-placeholders: this 'summarize' template references " +
+            "{agent1}-family placeholders, but no round-robin 'choose' phase runs earlier " +
+            "in the round, so the placeholders leak literally into the summary — add a " +
+            "round-robin 'choose' phase before this 'summarize', or remove the pairing " +
+            "placeholders.",
+        ScenarioLintMessage.MaxSentencesNoOp to
+            "max-sentences-no-op: this phase emits no LLM statement, so its 'max_sentences' " +
+            "cap never reaches a prompt and has no effect — remove it, or move it to a " +
+            "phase that emits a statement (speak_all / speak_each / whisper).",
+        ScenarioLintMessage.PairwisePayoffNoScorableRow to
+            "pairwise-payoff-no-scorable-row: no 'payoff' row's 'when' tokens match the " +
+            "round-robin 'choose' options, so no pairing is ever scored — add a 'payoff' " +
+            "table whose 'when' rows use the 'choose' option tokens.",
+        ScenarioLintMessage.PairwisePayoffDeadRow to
+            "pairwise-payoff-dead-row: one or more 'payoff' rows use 'when' tokens that " +
+            "aren't in the round-robin 'choose' options, so those rows never fire — fix the " +
+            "tokens to match the 'choose' options, or remove the unused rows.",
+        ScenarioLintMessage.LogWindowBelowAgentCount to
+            "log-window-below-agent-count: 'log_window' is smaller than the agent count " +
+            "while a 'speak_each' phase is present, so same-round earlier speakers vanish " +
+            "from the addressee pool — raise 'log_window' to at least the agent count.",
+        // ── Placeholders (token-bearing) ────────────────────────────────────
+        ScenarioLintMessage.UnresolvablePlaceholder("typo'token%1") to
+            "unresolvable-placeholder: the placeholder '{typo'token%1}' is supplied by no " +
+            "phase, so it leaks into the LLM prompt verbatim — check for a typo or remove it.",
+        ScenarioLintMessage.PlaceholderPhaseAvailability("late'token%2") to
+            "placeholder-phase-availability: the placeholder '{late'token%2}' is only " +
+            "populated by a producing phase, but none runs earlier in the phase list, so it " +
+            "resolves to an empty value — move the producing phase before this one.",
+        ScenarioLintMessage.PerPersonaPlaceholderInSummarize("my\"note's%3") to
+            "per-persona-placeholder-in-summarize: the per-persona placeholder " +
+            "'{my\"note's%3}' is never populated in a 'summarize' phase (summaries aren't " +
+            "per-agent), so it leaks literally — remove it or move it to an LLM phase.",
+        // ── Conditions (token-bearing) ──────────────────────────────────────
+        ScenarioLintMessage.SingleQuotedLiteralInCondition("'Alice's%4'") to
+            "single-quoted-literal-in-condition: the operand 'Alice's%4' is single-quoted, " +
+            "but the condition evaluator treats only double quotes as string literals — it " +
+            "is read as an undefined identifier and the comparison is always false. Use " +
+            "double quotes instead.",
+        ScenarioLintMessage.BareIdentifierLooksLikeLiteral("Bob's%5") to
+            "bare-identifier-looks-like-literal: the operand 'Bob's%5' matches a persona " +
+            "name but is unquoted, so the condition evaluator reads it as an undefined " +
+            "identifier and the comparison is always false — wrap it in double quotes to " +
+            "compare against the name.",
+        ScenarioLintMessage.UnknownConditionIdentifier("weird\"na'me%6") to
+            "unknown-condition-identifier: 'weird\"na'me%6' is not a known condition " +
+            "variable (a derived variable, score, persona, extraData key, or " +
+            "engine-injected name), so it resolves to no value at runtime — check for a typo.",
+    )
+}


### PR DESCRIPTION
## Summary

ADR-023 Stage 3 「Load + validate」グループの最後の未着手モジュール、ADR-024 セマンティックリンターの port 系列 **Wave D** の第 1 スライス **PR D1a（土台: メッセージ型）**。#1464（PR A）が validator に対して行ったのと同じ「port がコンパイルするために先に要る依存」を入れる。

- **Swift** `Models/ScenarioLintMessage.swift` — `nonisolated public enum … : Sendable`、21 case（Ordering 8 / Config 7 / Placeholders 3 / Conditions 3）+ `localized` 描画葉 + `ruleIDs`。4 つの `ScenarioSemanticLinter+*.swift` のヘルパは case を組み立てて `.localized` を返すだけになり、Engine から `String(localized:)` / `String(format:)` が消えた。描画文字列は byte-identical（レビュアーが機械照合）で `Localizable.xcstrings` は無変更。`LintFinding` の形は不変。
- **Kotlin** `shared/models/…/ScenarioLintMessage.kt` — sealed class ミラー（命名規則は `ScenarioValidationMessage.kt` と同じ）、en-only `render()`、`companion.ruleIDs`。commonTest 兄弟は case 集合の双方向照合、21 count pin + else-free roster、全 21 case の完全一致描画、`ruleIDs` 順序 pin。
- **別型**にした（`ScenarioValidationMessage` に足さない）— lint finding は severity 付きで収集され、validation message は単一失敗として throw される、異なる面。`ScenarioValidationMessage.kt` KDoc の「linter port 時にこの型が成長する」記述を訂正、53-case pin は無傷。
- 記録: ADR-023 §4 に linter 行の着地状況、進捗板の行更新（Stage-5 行に `ScenarioLintMessage.render()` の en-only 債務も追記）、`.claude/rules/kmp-interop.md` Pattern 4 に「Models のメッセージ型の二重着地はどのゲートも見ていない」を追記。

§12 condition-2 / condition-4 記録は #501 に投稿済み（3 mutations / 3 red、4-test baseline）。

**しないこと**: `PlaceholderAvailability`（D1b — ⚠️ Kotlin `object` の正格初期化順 vs Swift の遅延 `static let`、issue 本文参照）、リンター本体（D2a/D2b）、`SimulationEngine` preflight 配線（D3）。`DivergenceLedger.VALIDATOR_UNPORTED` は存置。

## Test plan

- [x] `scripts/xcodebuild.sh test -skip-testing:PasturaUITests` — 3,567 tests / 287 suites 緑（`ScenarioLintMessageTests` 11、`ScenarioSemanticLinterTests` 83 は無変更で緑）
- [x] `swiftlint lint --quiet --strict` — clean
- [x] `./gradlew :shared:models:jvmTest :shared:engine:jvmTest` — 緑（models 220 tests）
- [x] `./gradlew :shared:models:compileCommonMainKotlinMetadata` — 緑
- UI tests: skipped（Models / Engine の文字列描画のみ、UI 面に変更なし）

## Review

Reviewer: **Opus**、2 パス（1,038 追加行で split 予算超過 → Swift 側 / Kotlin+docs 側）。両パス **PASS**。

適用: Swift 側の `ruleIDs` 順序・一意性 pin / `Pattern 3` 誤引用の修正（前例 `ScenarioValidationMessage.swift` 側も）/ 進捗板 Stage-5 行の債務追記 / Kotlin テスト KDoc の誤った事実主張の訂正 / `kmp-interop.md` Pattern 4 への罠追記。

見送り: 「Engine が emit する `LintFinding.ruleID` が `ScenarioLintMessage.ruleIDs` の要素であることを pin するテスト」— D2a/D2b のリンター port が roster の実消費者になるので、その時点で自然に成立する。`is X ->` を等価比較に変える案 — 前例 `ScenarioValidationMessage.kt` が `is` なので統一を優先。

## Device QA

実機QA不要 — Models 層の文字列描画と Kotlin `commonMain` の追加のみで、simulator が実行できない面に触れていない。

Part of #501 · Closes #1562

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KFLQREbusGCYJhPLDhzb33
