### PR TITLE
🔧 chore: bump MARKETING_VERSION to 1.2

### DIFF
--- a/Pastura/Pastura.xcodeproj/project.pbxproj
+++ b/Pastura/Pastura.xcodeproj/project.pbxproj
@@ -451,7 +451,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1;
+				MARKETING_VERSION = 1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "app.pastura.Pastura$(BUNDLE_ID_SUFFIX)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -493,7 +493,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1;
+				MARKETING_VERSION = 1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "app.pastura.Pastura$(BUNDLE_ID_SUFFIX)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;


### PR DESCRIPTION
## Summary

Bump the app target's `MARKETING_VERSION` from 1.1 to 1.2. This is `/release` Step 2:
`scripts/release.sh` asserts the archived `CFBundleShortVersionString` equals `--version`, so
1.2 has to be on a green `main` before the release run can start.

Only the app target's two entries move (Debug + Release, the blocks carrying
`PRODUCT_BUNDLE_IDENTIFIER = "app.pastura.Pastura$(BUNDLE_ID_SUFFIX)"`). The `PasturaTests` /
`PasturaUITests` entries stay at 1.0. The build number derives from `git rev-list --count HEAD`,
so it advances with this commit and satisfies release.sh's strictly-exceeds guard for free.

Edits inside `project.pbxproj` `buildSettings` are what the release skill's Step 2 prescribes;
CLAUDE.md's "never hand-edit `project.pbxproj`" applies to the file-reference entries that the
synchronized folder groups manage, which this does not touch.

**User-visible side effect (intended, not a regression):** `App/ReviewRequestPolicy.swift`
re-arms the in-app review prompt at `CFBundleShortVersionString` granularity, so users who
already saw the prompt on 1.1 become eligible again on 1.2. Build-number increments do not
re-arm it, so TestFlight build churn within 1.2 stays quiet.

## Test plan

- `scripts/xcodebuild.sh test` — 3585 tests, 0 failures, 21 skipped.
- SwiftLint skipped: `scripts/precommit-gate-classify.sh` returns `build` only for this
  changeset (no `.swift` / `.swiftlint.yml` staged), so the lint gate has nothing to run.
- Verified `grep -n MARKETING_VERSION Pastura/Pastura.xcodeproj/project.pbxproj` returns
  `1.2` x 2 (app target) and `1.0` x 4 (test targets).

## Review

Reviewer: Opus. Plan critique (`critic`, Opus) returned no Critical; three Warnings, all applied:

- Reviewer model raised from Sonnet to Opus — the two edited `buildSettings` blocks also carry
  `INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO` (ADR-005 §8.6), which puts them adjacent to
  the orchestrate sensitive-base roster's content-safety entry.
- The `ReviewRequestPolicy` re-arm documented above and in the commit body.
- Staged by explicit path rather than `git add -A`, so a manual `scripts/xcodebuild.sh` run's
  `Localizable.xcstrings` mutation could not be swept in. The staged diff is exactly two lines.

The Opus review returned PASS with no Critical or Warning findings. Its one Suggestion is
deferred by design: `docs/gallery/README.md:151` says "`MARKETING_VERSION` is 1.1 at time of
writing, so 1.2", and once 1.2 ships, the "revisit once app versions predating the QAT
descriptor are no longer worth supporting" trigger it defines goes live. The prose is
self-dated so it does not go stale, and this PR must stay pbxproj-only for the `/release`
Step 2 sequencing.

Also confirmed by the critic pass: no other marketing-version hard-code goes stale (`web/`,
`fastlane/`, `docs/` all clear), and no test asserts a bundle version — the version-aware tests
inject literals rather than reading `Bundle.main`.

## Device QA

実機QA不要 — `#if !targetEnvironment(simulator)` ブロック、llama.cpp / Metal の推論経路、Pattern-6
のエグゼキュータ凍結のいずれにも触れない、ビルド設定値の変更のみ。

Part of the 1.2 release preparation.
