### PR TITLE
✨ feat: ADR-029 gallery ハイライトの en 初回バッチ（3件）

### DIFF
--- a/docs/gallery/README.md
+++ b/docs/gallery/README.md
@@ -475,12 +475,11 @@ call, and these are what the batches so far have taught.
 - **Check a pick against the speaking persona's own worked examples** — the
   `例:` lines of a ja persona, the `e.g.` lines of an en one, whatever the
   YAML uses to show the character how to answer. Those lines are part of the
-  prompt, so when one of them
-  happens to be an ideal answer to the topic, the model reproduces it
-  verbatim rather than inventing anything. The trap is the example, not the
-  label: `iiwake_battle_v1_en`'s `Shameless Mac` opened a round-1 draw with
-  `Honestly, you should be thanking me`, which is his `e.g.` line word for
-  word, so the en batch quoted the other three speakers instead.
+  prompt, so when one of them happens to be an ideal answer to the topic, the
+  model reproduces it verbatim rather than inventing anything. The trap is the
+  example, not the label: `iiwake_battle_v1_en`'s `Shameless Mac` opened a
+  round-1 draw with `Honestly, you should be thanking me`, which is his `e.g.`
+  line word for word, so the en batch quoted the other three speakers instead.
   `oogiri_knockout_v1`'s
   `一言必殺のゼロ次` emitted its example line unchanged in two independent
   draws, so the batch-2 excerpt kept it out of both the excerpt and the hook
@@ -503,11 +502,25 @@ call, and these are what the batches so far have taught.
   one draw came out clean; each draw is its own check, and a scenario whose
   worked examples shadow its own `topics:` / `events:` entries will keep
   costing draws until the YAML is fixed.
+  **When every persona's example shadows the same topic, no draw can fix it
+  and the hook is what has to move.** In `chin_jimaku_v1_en` all four `e.g.`
+  lines render topic 1's LINE, and topic 1 is the only pickable round, so any
+  `persona` hook would have printed its own example beside the excerpt. That
+  batch published a `raw` hook of the `speak_all` phase instead, which is
+  what the excerpt actually answers, and #1577 tracks re-pointing those
+  examples at a line neither topic uses. Fixing the YAML re-hashes it, so it
+  forces a re-extract and a fresh sign-off (§ "Updating a scenario that has a
+  highlight").
+- **Captions and teasers render verbatim — no Markdown.** The app draws both
+  with `Text(verbatim:)` and the landing pages interpolate them as text, so
+  backticks, asterisks and brackets ship as literal characters. Write
+  `[Goal]` only when that bracket is literally in the YAML you are pointing
+  at.
 - **A persona that drops its own gimmick is not quotable, however good the
   line is.** `chin_jimaku_v1_en`'s `Trivia Todd` is defined entirely by the
   `(Note: …)` footnote his `[Goal]` calls his whole gimmick, and he omitted
-  it in both en draws. Quoting him would put a line that contradicts the
-  hook fragment's own instruction on the page. Dropping the speaker costs
+  it in both en draws. Quoting him would put a line that contradicts his own
+  declared gimmick on the page. Dropping the speaker costs
   nothing here — outside an `eliminate` scenario, a partial speaker set
   leaks no outcome (see the `eliminate` norm above).
 

--- a/docs/gallery/README.md
+++ b/docs/gallery/README.md
@@ -472,10 +472,16 @@ call, and these are what the batches so far have taught.
   (`理屈っぽい教授モドキ`) was precisely the speaker a two-round excerpt would
   have dropped. The safe fallback is a single-round excerpt, which carries no
   elimination-order information at all.
-- **Check a pick against the speaking persona's own `例:`.** A persona
-  description's `例:` lines are part of the prompt, so when one of them
+- **Check a pick against the speaking persona's own worked examples** — the
+  `例:` lines of a ja persona, the `e.g.` lines of an en one, whatever the
+  YAML uses to show the character how to answer. Those lines are part of the
+  prompt, so when one of them
   happens to be an ideal answer to the topic, the model reproduces it
-  verbatim rather than inventing anything. `oogiri_knockout_v1`'s
+  verbatim rather than inventing anything. The trap is the example, not the
+  label: `iiwake_battle_v1_en`'s `Shameless Mac` opened a round-1 draw with
+  `Honestly, you should be thanking me`, which is his `e.g.` line word for
+  word, so the en batch quoted the other three speakers instead.
+  `oogiri_knockout_v1`'s
   `一言必殺のゼロ次` emitted its example line unchanged in two independent
   draws, so the batch-2 excerpt kept it out of both the excerpt and the hook
   fragment; #1475 then replaced the example with one that answers none of
@@ -483,7 +489,7 @@ call, and these are what the batches so far have taught.
   draws re-checked every round against the new `例:`. Publishing
   such a line would show the flagship "real run" quoting its own prompt — and
   the full YAML is one tap away in the app, so a reader can see it. This bites
-  hardest for a `yaml_hook` persona slice, since the excerpt and the `例:`
+  hardest for a `yaml_hook` persona slice, since the excerpt and the example
   would then render on the same screen — so for a hooked persona, also reject
   a pick that merely reuses the example's sentence frame (the same closing
   phrase with the nouns swapped), which the gate cannot see.
@@ -495,8 +501,15 @@ call, and these are what the batches so far have taught.
   `例:「停電? これでようやく私の顔面も定価になった」` answers. The published
   draw drew a different twist and is clean. A scenario is not "safe" because
   one draw came out clean; each draw is its own check, and a scenario whose
-  `例:` lines shadow its own `topics:` / `events:` entries will keep costing
-  draws until the YAML is fixed.
+  worked examples shadow its own `topics:` / `events:` entries will keep
+  costing draws until the YAML is fixed.
+- **A persona that drops its own gimmick is not quotable, however good the
+  line is.** `chin_jimaku_v1_en`'s `Trivia Todd` is defined entirely by the
+  `(Note: …)` footnote his `[Goal]` calls his whole gimmick, and he omitted
+  it in both en draws. Quoting him would put a line that contradicts the
+  hook fragment's own instruction on the page. Dropping the speaker costs
+  nothing here — outside an `eliminate` scenario, a partial speaker set
+  leaks no outcome (see the `eliminate` norm above).
 
 **Excerpt** and **hook fragment** are different things. The excerpt is the
 quoted conversation; the hook fragment is the slice of YAML shown beneath it.

--- a/docs/gallery/README.md
+++ b/docs/gallery/README.md
@@ -510,7 +510,11 @@ call, and these are what the batches so far have taught.
   what the excerpt actually answers, and #1577 tracks re-pointing those
   examples at a line neither topic uses. Fixing the YAML re-hashes it, so it
   forces a re-extract and a fresh sign-off (§ "Updating a scenario that has a
-  highlight").
+  highlight"). Treat this as the exception it is: ADR-029
+  § Amendment 2026-08-08 makes `persona` the default precisely so the app can
+  draw the hook in the editor's vocabulary rather than as a monospace block,
+  so reach for `raw` when a `persona` hook would publish something false or
+  spoiling, not because it is easier to slice.
 - **Captions and teasers render verbatim — no Markdown.** The app draws both
   with `Text(verbatim:)` and the landing pages interpolate them as text, so
   backticks, asterisks and brackets ship as literal characters. Write
@@ -518,11 +522,11 @@ call, and these are what the batches so far have taught.
   at.
 - **A persona that drops its own gimmick is not quotable, however good the
   line is.** `chin_jimaku_v1_en`'s `Trivia Todd` is defined entirely by the
-  `(Note: …)` footnote his `[Goal]` calls his whole gimmick, and he omitted
-  it in both en draws. Quoting him would put a line that contradicts his own
-  declared gimmick on the page. Dropping the speaker costs
-  nothing here — outside an `eliminate` scenario, a partial speaker set
-  leaks no outcome (see the `eliminate` norm above).
+  `(Note: …)` footnote his `[Goal]` calls his whole gimmick, and he omitted it
+  in both en draws. Quoting him would put a line that contradicts his own
+  declared gimmick on the page. Dropping the speaker costs nothing here —
+  outside an `eliminate` scenario, a partial speaker set leaks no outcome (see
+  the `eliminate` norm above).
 
 **Excerpt** and **hook fragment** are different things. The excerpt is the
 quoted conversation; the hook fragment is the slice of YAML shown beneath it.

--- a/docs/gallery/gallery.json
+++ b/docs/gallery/gallery.json
@@ -695,7 +695,7 @@
       "yaml_url": "iiwake_battle_v1_en.yaml",
       "yaml_sha256": "b47f37647dcc7890cba6eca655f9a3cbe66d9e0710fa4f76456ba01a466284f3",
       "highlight_url": "highlights/iiwake_battle_v1_en.json",
-      "highlight_sha256": "6fb1412b8811805a637d9e7fc670fc658505043268a85e7498ca2674ad6a75b9",
+      "highlight_sha256": "ac1b38ca3a945efdc768f318edf1833baede865fba30d279abdaae4677fc8165",
       "added_at": "2026-07-01"
     },
     {
@@ -785,7 +785,7 @@
       "yaml_url": "chin_jimaku_v1_en.yaml",
       "yaml_sha256": "c5b2bb7b2dd0a2c5f380de4216dc6c86f39cd279921f0b3575c7ecaba9783c21",
       "highlight_url": "highlights/chin_jimaku_v1_en.json",
-      "highlight_sha256": "b29d6932be36fad777052fb6c5563c194537cde05e78b43c980700e5709019aa",
+      "highlight_sha256": "a295a054b8177171c4e44c9c05d49729a8321a3f517093e012497bbb58d2c4a3",
       "added_at": "2026-07-01"
     },
     {

--- a/docs/gallery/gallery.json
+++ b/docs/gallery/gallery.json
@@ -694,6 +694,8 @@
       "language": "en",
       "yaml_url": "iiwake_battle_v1_en.yaml",
       "yaml_sha256": "b47f37647dcc7890cba6eca655f9a3cbe66d9e0710fa4f76456ba01a466284f3",
+      "highlight_url": "highlights/iiwake_battle_v1_en.json",
+      "highlight_sha256": "6fb1412b8811805a637d9e7fc670fc658505043268a85e7498ca2674ad6a75b9",
       "added_at": "2026-07-01"
     },
     {
@@ -782,6 +784,8 @@
       "language": "en",
       "yaml_url": "chin_jimaku_v1_en.yaml",
       "yaml_sha256": "c5b2bb7b2dd0a2c5f380de4216dc6c86f39cd279921f0b3575c7ecaba9783c21",
+      "highlight_url": "highlights/chin_jimaku_v1_en.json",
+      "highlight_sha256": "b29d6932be36fad777052fb6c5563c194537cde05e78b43c980700e5709019aa",
       "added_at": "2026-07-01"
     },
     {
@@ -804,6 +808,8 @@
       "language": "en",
       "yaml_url": "shachiku_senryu_v1_en.yaml",
       "yaml_sha256": "72fa4456f8576b1290f819dfb9561f786884ac99c50f1d88237795a7674c06e2",
+      "highlight_url": "highlights/shachiku_senryu_v1_en.json",
+      "highlight_sha256": "2bce685e89d64af4985ce1a5bebb0cb5a25317dcbf78b0380527d8b3d99096ef",
       "added_at": "2026-07-01"
     },
     {

--- a/docs/gallery/gallery.json
+++ b/docs/gallery/gallery.json
@@ -785,7 +785,7 @@
       "yaml_url": "chin_jimaku_v1_en.yaml",
       "yaml_sha256": "c5b2bb7b2dd0a2c5f380de4216dc6c86f39cd279921f0b3575c7ecaba9783c21",
       "highlight_url": "highlights/chin_jimaku_v1_en.json",
-      "highlight_sha256": "a295a054b8177171c4e44c9c05d49729a8321a3f517093e012497bbb58d2c4a3",
+      "highlight_sha256": "80114cacc7f59dd941c95e645b4118f0a5e0a35f568818162264581a82f6edf2",
       "added_at": "2026-07-01"
     },
     {
@@ -809,7 +809,7 @@
       "yaml_url": "shachiku_senryu_v1_en.yaml",
       "yaml_sha256": "72fa4456f8576b1290f819dfb9561f786884ac99c50f1d88237795a7674c06e2",
       "highlight_url": "highlights/shachiku_senryu_v1_en.json",
-      "highlight_sha256": "2bce685e89d64af4985ce1a5bebb0cb5a25317dcbf78b0380527d8b3d99096ef",
+      "highlight_sha256": "58c222f79fa0b2b643996f51df71931e1faaed120e599558d3a49de0ac47d452",
       "added_at": "2026-07-01"
     },
     {

--- a/docs/gallery/highlights/chin_jimaku_v1_en.json
+++ b/docs/gallery/highlights/chin_jimaku_v1_en.json
@@ -41,7 +41,7 @@
   "yaml_hook": {
     "kind": "raw",
     "fragment": "  - type: speak_all\n    prompt: >\n      {assigned_topic}\n\n      Fully in character, write your English subtitle for this line in 1-2\n      sentences. Keep it short and commit to the bit.\n    output:\n      statement: string\n      inner_thought: string",
-    "caption": "Every subtitle above answers this one instruction. What separates them is not the prompt but the four translator descriptions it gets handed to."
+    "caption": "Every subtitle above answers this one instruction. What separates them is not the prompt but the four translator descriptions further up the same file."
   },
   "teaser": "Four subtitles, one vote each, and another famous scene still waiting to be ruined.",
   "window_override": false,

--- a/docs/gallery/highlights/chin_jimaku_v1_en.json
+++ b/docs/gallery/highlights/chin_jimaku_v1_en.json
@@ -39,9 +39,9 @@
     }
   ],
   "yaml_hook": {
-    "kind": "persona",
-    "fragment": "  - name: Literal Larry\n    description: >\n      [Role] A translator who mechanically swaps word for word.\n      [Goal] NEVER write natural English — always mangle the line into broken,\n      stilted translationese with wrong word order and clunky grammar. If it reads\n      correctly, you failed.\n      e.g. \"We are having the need for going, at the now!\" / \"You, I will be\n      forgetting never.\"\n  - name: Spoiler Queen Sofia\n    description: >\n      [Role] A translator who carelessly leaks the ending in the subtitle.\n      [Goal] Slip an unrelated ending or plot twist into this line's subtitle.\n      e.g. \"Let's go! (He's secretly a ghost the whole time, by the way.)\"",
-    "caption": "Two of the four translators on this team. One is forbidden to write a sentence that parses; the other cannot hold an ending in. Rewrite a [Goal] line and the next disaster is yours."
+    "kind": "raw",
+    "fragment": "  - type: speak_all\n    prompt: >\n      {assigned_topic}\n\n      Fully in character, write your English subtitle for this line in 1-2\n      sentences. Keep it short and commit to the bit.\n    output:\n      statement: string\n      inner_thought: string",
+    "caption": "Every subtitle above answers this one instruction. What separates them is not the prompt but the four translator descriptions it gets handed to."
   },
   "teaser": "Four subtitles, one vote each, and another famous scene still waiting to be ruined.",
   "window_override": false,

--- a/docs/gallery/highlights/chin_jimaku_v1_en.json
+++ b/docs/gallery/highlights/chin_jimaku_v1_en.json
@@ -1,0 +1,49 @@
+{
+  "schema_version": 1,
+  "scenario_ref": {
+    "id": "chin_jimaku_v1_en",
+    "yaml_sha256": "c5b2bb7b2dd0a2c5f380de4216dc6c86f39cd279921f0b3575c7ecaba9783c21"
+  },
+  "source": {
+    "model": "gemma-4-e2b-q4-k-m",
+    "run_id": "20260827-095525-aee7",
+    "generated_at": "2026-08-27"
+  },
+  "excerpt": [
+    {
+      "agent": "Literal Larry",
+      "round": 1,
+      "phase": "speak_all",
+      "phase_index": 1,
+      "persona_index": 0,
+      "source_field": "statement",
+      "text": "Need go we now! Go, need we! Explosion big, we must run!"
+    },
+    {
+      "agent": "Over-Local Ollie",
+      "round": 1,
+      "phase": "speak_all",
+      "phase_index": 1,
+      "persona_index": 1,
+      "source_field": "statement",
+      "text": "Gotta bail, fam, this ain't it anymore."
+    },
+    {
+      "agent": "Spoiler Queen Sofia",
+      "round": 1,
+      "phase": "speak_all",
+      "phase_index": 1,
+      "persona_index": 2,
+      "source_field": "statement",
+      "text": "Go now, because the secret agent is actually a talking squirrel!"
+    }
+  ],
+  "yaml_hook": {
+    "kind": "persona",
+    "fragment": "  - name: Literal Larry\n    description: >\n      [Role] A translator who mechanically swaps word for word.\n      [Goal] NEVER write natural English — always mangle the line into broken,\n      stilted translationese with wrong word order and clunky grammar. If it reads\n      correctly, you failed.\n      e.g. \"We are having the need for going, at the now!\" / \"You, I will be\n      forgetting never.\"\n  - name: Spoiler Queen Sofia\n    description: >\n      [Role] A translator who carelessly leaks the ending in the subtitle.\n      [Goal] Slip an unrelated ending or plot twist into this line's subtitle.\n      e.g. \"Let's go! (He's secretly a ghost the whole time, by the way.)\"",
+    "caption": "Two of the four translators on this team. One is forbidden to write a sentence that parses; the other cannot hold an ending in. Rewrite a [Goal] line and the next disaster is yours."
+  },
+  "teaser": "Four subtitles, one vote each, and another famous scene still waiting to be ruined.",
+  "window_override": false,
+  "content_filter_applied": true
+}

--- a/docs/gallery/highlights/iiwake_battle_v1_en.json
+++ b/docs/gallery/highlights/iiwake_battle_v1_en.json
@@ -41,7 +41,7 @@
   "yaml_hook": {
     "kind": "persona",
     "fragment": "  - name: Dr. Quantum\n    description: >\n      [Role] An excuse-maker armed with pseudo-science.\n      [Goal] Blind everyone with plausible-sounding jargon.\n      e.g. \"Until observed, my lateness remains in superposition.\" \"It was the\n      unanimous verdict of my gut microbiome.\"\n  - name: Sentimental Sam\n    description: >\n      [Role] A tear-jerking excuse-maker who tugs the heartstrings.\n      [Goal] Spin a sob story so shamelessly moving the listener wants to forgive\n      you anyway.\n      e.g. \"A stray kitten simply would not let go of me.\" \"It was a promise I made\n      to my late grandmother.\"",
-    "caption": "Two of the four alibis on the bench: pseudo-science and a sob story. The whole act lives in those `e.g.` lines. Swap them and you have replaced the school of excuse, not just the wording."
+    "caption": "Pseudo-science and a sob story: two of the four excuse-makers in the line-up. The act lives in the e.g. lines. Swap those and you have changed the school of excuse-making, not just the wording."
   },
   "teaser": "Speaking later means topping the excuse before yours, and laying it on too thick backfires. There is another screw-up to answer for after this one.",
   "window_override": false,

--- a/docs/gallery/highlights/iiwake_battle_v1_en.json
+++ b/docs/gallery/highlights/iiwake_battle_v1_en.json
@@ -1,0 +1,49 @@
+{
+  "schema_version": 1,
+  "scenario_ref": {
+    "id": "iiwake_battle_v1_en",
+    "yaml_sha256": "b47f37647dcc7890cba6eca655f9a3cbe66d9e0710fa4f76456ba01a466284f3"
+  },
+  "source": {
+    "model": "gemma-4-e2b-q4-k-m",
+    "run_id": "20260827-100042-d0e3",
+    "generated_at": "2026-08-27"
+  },
+  "excerpt": [
+    {
+      "agent": "Global George",
+      "round": 1,
+      "phase": "speak_each",
+      "phase_index": 1,
+      "persona_index": 0,
+      "source_field": "statement",
+      "text": "I apologize, but the fluctuating global shipping lanes caused an unavoidable delay in my arrival."
+    },
+    {
+      "agent": "Dr. Quantum",
+      "round": 1,
+      "phase": "speak_each",
+      "phase_index": 1,
+      "persona_index": 1,
+      "source_field": "statement",
+      "text": "My temporal coordinates were momentarily entangled with a localized distortion field, resulting in an unavoidable phase shift."
+    },
+    {
+      "agent": "Sentimental Sam",
+      "round": 1,
+      "phase": "speak_each",
+      "phase_index": 1,
+      "persona_index": 2,
+      "source_field": "statement",
+      "text": "Oh, the sheer agony of missing that meeting was due to a sudden, heartbreaking realization that I had forgotten my favorite childhood teddy bear at home."
+    }
+  ],
+  "yaml_hook": {
+    "kind": "persona",
+    "fragment": "  - name: Dr. Quantum\n    description: >\n      [Role] An excuse-maker armed with pseudo-science.\n      [Goal] Blind everyone with plausible-sounding jargon.\n      e.g. \"Until observed, my lateness remains in superposition.\" \"It was the\n      unanimous verdict of my gut microbiome.\"\n  - name: Sentimental Sam\n    description: >\n      [Role] A tear-jerking excuse-maker who tugs the heartstrings.\n      [Goal] Spin a sob story so shamelessly moving the listener wants to forgive\n      you anyway.\n      e.g. \"A stray kitten simply would not let go of me.\" \"It was a promise I made\n      to my late grandmother.\"",
+    "caption": "Two of the four alibis on the bench: pseudo-science and a sob story. The whole act lives in those `e.g.` lines. Swap them and you have replaced the school of excuse, not just the wording."
+  },
+  "teaser": "Speaking later means topping the excuse before yours, and laying it on too thick backfires. There is another screw-up to answer for after this one.",
+  "window_override": false,
+  "content_filter_applied": true
+}

--- a/docs/gallery/highlights/shachiku_senryu_v1_en.json
+++ b/docs/gallery/highlights/shachiku_senryu_v1_en.json
@@ -1,0 +1,40 @@
+{
+  "schema_version": 1,
+  "scenario_ref": {
+    "id": "shachiku_senryu_v1_en",
+    "yaml_sha256": "72fa4456f8576b1290f819dfb9561f786884ac99c50f1d88237795a7674c06e2"
+  },
+  "source": {
+    "model": "gemma-4-e2b-q4-k-m",
+    "run_id": "20260827-095401-a117",
+    "generated_at": "2026-08-27"
+  },
+  "excerpt": [
+    {
+      "agent": "Byron the Bard",
+      "round": 1,
+      "phase": "speak_all",
+      "phase_index": 1,
+      "persona_index": 2,
+      "source_field": "statement",
+      "text": "A home office felt dreadfully slow,\nWhere the Wi-Fi gave folks a low blow.\nWith slippers and sighs,\nOne barely replies,\nAs the workday begins in a glow."
+    },
+    {
+      "agent": "Old-Timer Walt",
+      "round": 1,
+      "phase": "speak_all",
+      "phase_index": 1,
+      "persona_index": 3,
+      "source_field": "statement",
+      "text": "A worker who worked from his chair,\nFound freedom and comfort out there.\nHe wore fuzzy old socks,\nIgnoring the clock's shocks,\nAnd logged in with a lazy, slow stare."
+    }
+  ],
+  "yaml_hook": {
+    "kind": "persona",
+    "fragment": "  - name: Byron the Bard\n    description: >\n      [Role] A pretentious Romantic poet drunk on his own melancholy.\n      [Goal] Inflate the pettiest office trifle into grand tragic poetry.\n      e.g. \"O, three hundred unread in my Slack / and my soul, it shall never come back.\"\n  - name: Old-Timer Walt\n    description: >\n      [Role] A weary veteran on the edge of retirement, still dragging the old days\n      along.\n      [Goal] Deliver a dry, bittersweet verse that makes you laugh and ache at once.\n      e.g. \"They rehired me, my title cut thin / just a badge and a chair to clock in.\"",
+    "caption": "Two of the four voices behind these verses. A Romantic poet who mistakes an office for a graveyard, and a veteran counting down to the exit. The form is fixed at five lines; nothing else is."
+  },
+  "teaser": "Once every limerick is in, they vote for the funniest that is not their own, and a second prompt is still waiting.",
+  "window_override": false,
+  "content_filter_applied": true
+}

--- a/docs/gallery/highlights/shachiku_senryu_v1_en.json
+++ b/docs/gallery/highlights/shachiku_senryu_v1_en.json
@@ -32,7 +32,7 @@
   "yaml_hook": {
     "kind": "persona",
     "fragment": "  - name: Byron the Bard\n    description: >\n      [Role] A pretentious Romantic poet drunk on his own melancholy.\n      [Goal] Inflate the pettiest office trifle into grand tragic poetry.\n      e.g. \"O, three hundred unread in my Slack / and my soul, it shall never come back.\"\n  - name: Old-Timer Walt\n    description: >\n      [Role] A weary veteran on the edge of retirement, still dragging the old days\n      along.\n      [Goal] Deliver a dry, bittersweet verse that makes you laugh and ache at once.\n      e.g. \"They rehired me, my title cut thin / just a badge and a chair to clock in.\"",
-    "caption": "Two of the four voices behind these verses. A Romantic poet who mistakes an office for a graveyard, and a veteran counting down to the exit. The form is fixed at five lines; nothing else is."
+    "caption": "The gloom and the ache, side by side: a Romantic poet who mistakes an office for a graveyard, and a veteran counting down to the exit. The form is fixed at five lines; nothing else is."
   },
   "teaser": "Once every limerick is in, they vote for the funniest that is not their own, and a second prompt is still waiting.",
   "window_override": false,


### PR DESCRIPTION
## Summary

ADR-029 のギャラリーハイライトを初めて英語エントリへ広げる。Decision 7 が「en 版は翻訳ではなく別途生成の別バッチ」と定めているので、en シナリオを実際に走らせた結果から作った。同 Decision の再考トリガー（初回バッチ公開後およそ1四半期）はまだ期限内で、拡張を止める条件には当たらない。

対象は ja 兄弟にハイライトを持つ3本。シナリオ適性が実証済みで、キュレーション判断を ja 版と突き合わせられる。

| id | 引き | 抜粋 | フック |
|---|---|---|---|
| `shachiku_senryu_v1_en` | `20260827-095401-a117` | ラウンド1・Byron / Walt | persona（Byron the Bard + Old-Timer Walt） |
| `chin_jimaku_v1_en` | `20260827-095525-aee7` | ラウンド1・Larry / Ollie / Sofia | **raw**（`speak_all` フェーズ） |
| `iiwake_battle_v1_en` | `20260827-100042-d0e3` | ラウンド1・George / Quantum / Sam | persona（Dr. Quantum + Sentimental Sam） |

3本とも `rounds: 2` なので既定の窓（ラウンド1のみ）に収まり `window_override: false`。`eliminate` を持つシナリオはないので、抜粋の話者集合から脱落者が漏れる罠は該当しない。

**ADR-029 Decision 2 が要求する human sign-off は取得済み**（抜粋・キャプション・ティーザーを提示して承認、レビュー反映後に再取得）。

## このバッチで確定したこと

**作例の罠はラベルではなく作例そのものにある。** README の「話者ペルソナ自身の `例:` と突き合わせよ」は日本語リテラルに紐づいて書かれていたが、en では `e.g.` として同じ罠が実在する。実測2件:

- `iiwake_battle_v1_en` の `Shameless Mac` が `e.g.「Honestly, you should be thanking me.」` を逐語で口にした → 他3人を引用。
- `chin_jimaku_v1_en` の `Trivia Todd` が、`[Goal]` が「お前の看板だ」と書いている `(Note: …)` 脚注を両ドローとも落とした → 引用不可。行の出来とは無関係に、自分の宣言と矛盾する行は載せられない。

**全員の作例が同じお題を隠している場合、ドローでは直らない。** `chin_jimaku_v1_en` は4人全員の `e.g.` が topic 1 の LINE の字幕で、引ける窓はそのラウンド1しかない。どのペルソナをフックにしても抜粋の真下に自分の作例が並ぶので、このバッチは `speak_all` フェーズの `raw` フックを出した。YAML 側の是正は #1577。#1475（`oogiri_knockout_v1`）と同型の問題。

**キャプションは Markdown を解釈しない。** アプリは `Text(verbatim:)`、LP はテキスト補間なので、バッククォートはそのまま画面に出る。初稿の `iiwake` キャプションが踏んでいた。

以上3点を README § Curation norms に反映した。

## Test plan

- `bash scripts/check-gallery-entry.sh --all` — OK（コミットのたびに pre-commit でも実行、いずれも通過）
- iOS のビルド / テストスイートはスキップ。`scripts/precommit-gate-classify.sh` の分類どおり、この差分は build / lint いずれのトークンも立てない（`docs/gallery/**` の JSON と Markdown のみ）。CI の PR パスゲートも同じスクリプトを使う。
- harness 実走: 3シナリオ × 2ドロー、`gemma-4-E2B-it-Q4_K_M`、いずれも `run_end.status == "ok"`。トランスクリプトは gitignored。

## Review

レビューア: Opus（`code-reviewer`）。初回 **Verdict: FAIL**（Critical 1 / Warning 4 / Suggestion 3）、修正差分の再レビューで **PASS**（Critical 0 / Warning 0 / Suggestion 4）。

**適用した指摘**

1. **[Critical] `iiwake` の caption にバッククォートが入っていた** — `Text(verbatim:)` で描かれるので記号がそのまま出る。除去し、ペルソナを alibis と呼ぶ誤りも直した。
2. **[Warning] `chin_jimaku` のフックが `Spoiler Queen Sofia` の作例を抜粋の隣に並べていた** — レビューアの提案（Larry + Ollie へ差し替え）は採らなかった。Ollie 自身も `fam` を作例から持ち出しており、彼をフックへ移すと同じ事故が起きる。根本原因（4人全員の作例が topic 1 を先取り）から、この窓ではどの `persona` フックも clean にならないので、`raw` フックへ切り替えた。ADR-029 § Amendment 2026-08-08 が `raw` を正規の選択肢として定義しており、消費側も両サーフェスで実装済み。既定は `persona` のままだと README に明記した。
3. **[Warning] キャプションの書き出しが3件中2件で同型だった** — 崩した。再レビューで「文中に移っただけ」と再指摘されたため、`shachiku` からは人数の言い回し自体を落とした。
4. **[Suggestion] `chin_jimaku` の caption が raw フックでは画面に出ていないペルソナ記述を指していた** — 「同じファイルの上方」と明示。
5. **[Suggestion] README のラギッドな行送り、ADR-029 の既定への言及欠落** — 両方修正。

**却下した指摘**

- **[Suggestion] `iiwake` の3行中2行が `unavoidable` で終わっており、ティーザーが約束するエスカレーションが平板に見える。別ドローなら語彙が豊かだった** — 却下。en1 ドローは `Shameless Mac` が作例を逐語再現しており、Critical 級の罠を避けるために en2 を採っている。語彙の反復（Warning ですらない）のために、より重い事故のあるドローへ戻す取引にはならない。ADR-029 の売りは「実際に端末で動かした結果」であって、磨いた行の陳列ではない。

## Device QA

実機QA不要 — Swift の変更がなく、静的な JSON / Markdown のみ。

Closes #1573
