### PR TITLE
✅ test: linter message-mapping twins + the __favors companion pin

### DIFF
--- a/Pastura/PasturaTests/Engine/ScenarioSemanticLinterTests+ConfigMessages.swift
+++ b/Pastura/PasturaTests/Engine/ScenarioSemanticLinterTests+ConfigMessages.swift
@@ -82,7 +82,7 @@ extension ScenarioSemanticLinterTests {
     ]
   }
 
-  // MARK: - Message mapping (deliberate exception to the 1:1 mirror rule)
+  // MARK: - Message mapping (deliberate exception to the one-test-per-rule shape)
 
   /// The Config-group twin of ``orderingMessagesMapEachRuleIDToItsLintMessageCase``:
   /// no other test in this suite asserts `finding.message` for a config rule,

--- a/Pastura/PasturaTests/Engine/ScenarioSemanticLinterTests+ConfigMessages.swift
+++ b/Pastura/PasturaTests/Engine/ScenarioSemanticLinterTests+ConfigMessages.swift
@@ -1,8 +1,9 @@
-// The Config group's ruleID → ScenarioLintMessage pin (ADR-024 D3). Split
-// out into its own file for the same three SwiftLint reasons as
-// ScenarioSemanticLinterTests+OrderingMessages.swift (file_length,
-// function_body_length, large_tuple); still an extension of the existing
-// suite (not a new @Suite) per .claude/rules/testing.md.
+// The Config group's ruleID → ScenarioLintMessage pin (ADR-024 D3). Its own
+// file for symmetry with ScenarioSemanticLinterTests+OrderingMessages.swift,
+// which had to split — `+Payoff.swift` has room for this test, but keeping the
+// three group pins shaped alike is worth more than saving a file. Still an
+// extension of the existing suite (not a new @Suite) per
+// .claude/rules/testing.md.
 import Testing
 
 @testable import Pastura

--- a/Pastura/PasturaTests/Engine/ScenarioSemanticLinterTests+ConfigMessages.swift
+++ b/Pastura/PasturaTests/Engine/ScenarioSemanticLinterTests+ConfigMessages.swift
@@ -1,0 +1,113 @@
+// The Config group's ruleID → ScenarioLintMessage pin (ADR-024 D3). Split
+// out into its own file for the same three SwiftLint reasons as
+// ScenarioSemanticLinterTests+OrderingMessages.swift (file_length,
+// function_body_length, large_tuple); still an extension of the existing
+// suite (not a new @Suite) per .claude/rules/testing.md.
+import Testing
+
+@testable import Pastura
+
+extension ScenarioSemanticLinterTests {
+
+  /// One row of ``configMessagesMapEachRuleIDToItsLintMessageCase``'s pin: a
+  /// fixture expected to fire exactly `ruleID`, and the message it must render.
+  /// A struct rather than a tuple — SwiftLint caps tuples at two members.
+  private struct ConfigMessageCase {
+    let ruleID: String
+    let scenario: Scenario
+    let expected: ScenarioLintMessage
+  }
+
+  /// R7/R8/R9/R17 — the four config rules whose fixtures need no `payoff`.
+  private var configMessageCasesR7ToR17: [ConfigMessageCase] {
+    [
+      ConfigMessageCase(
+        ruleID: "choose-should-declare-options",
+        scenario: makeScenario(agents: 2, rounds: 1, phases: [Phase(type: .choose)]),
+        expected: .chooseShouldDeclareOptions),
+      ConfigMessageCase(
+        ruleID: "assign-source-nonempty",
+        scenario: makeEventScenario(
+          phases: [Phase(type: .assign, source: "events", target: .all)],
+          events: .array([])),
+        expected: .assignSourceNonempty),
+      ConfigMessageCase(
+        ruleID: "summarize-pairing-placeholders",
+        scenario: makeScenario(
+          agents: 2, rounds: 1,
+          phases: [Phase(type: .summarize, template: "{agent1} chose {action1}")]),
+        expected: .summarizePairingPlaceholders),
+      ConfigMessageCase(
+        ruleID: "log-window-below-agent-count",
+        scenario: makeLogWindowScenario(
+          agents: 3, logWindow: 2, phases: [Phase(type: .speakEach)]),
+        expected: .logWindowBelowAgentCount)
+    ]
+  }
+
+  /// R18/R20a/R20b — the remaining three.
+  private var configMessageCasesR18ToR20b: [ConfigMessageCase] {
+    [
+      ConfigMessageCase(
+        ruleID: "max-sentences-no-op",
+        scenario: makeScenario(
+          agents: 2, rounds: 1,
+          phases: [Phase(type: .summarize, template: "Round complete.", maxSentences: 3)]),
+        expected: .maxSentencesNoOp),
+      ConfigMessageCase(
+        ruleID: "pairwise-payoff-no-scorable-row",
+        scenario: makeScenario(
+          agents: 2, rounds: 1,
+          phases: [
+            Phase(type: .choose, options: ["cooperate", "betray"], pairing: .roundRobin),
+            Phase(
+              type: .scoreCalc, logic: .pairwisePayoff,
+              payoff: [PayoffRule(when: ["yes", "no"], points: [1, 1])])
+          ]),
+        expected: .pairwisePayoffNoScorableRow),
+      ConfigMessageCase(
+        ruleID: "pairwise-payoff-dead-row",
+        scenario: makeScenario(
+          agents: 2, rounds: 1,
+          phases: [
+            Phase(type: .choose, options: ["cooperate", "betray"], pairing: .roundRobin),
+            Phase(
+              type: .scoreCalc, logic: .pairwisePayoff,
+              payoff: [
+                PayoffRule(when: ["cooperate", "cooperate"], points: [3, 3]),
+                PayoffRule(when: ["unclear", "unclear"], points: [0, 0])
+              ])
+          ]),
+        expected: .pairwisePayoffDeadRow)
+    ]
+  }
+
+  // MARK: - Message mapping (deliberate exception to the 1:1 mirror rule)
+
+  /// The Config-group twin of ``orderingMessagesMapEachRuleIDToItsLintMessageCase``:
+  /// no other test in this suite asserts `finding.message` for a config rule,
+  /// so a mis-transcribed arm in the private `configMessage(_:)` — a string
+  /// switch with a `default:` fallthrough for `log-window-below-agent-count`
+  /// — would ship green with nothing to catch it. Each row fires exactly one
+  /// config rule and pins its rendered message; `count == 1` and the `ruleID`
+  /// are pinned too, so a rule that starts firing first on one of these
+  /// fixtures cannot silently change what is measured. Mirrors
+  /// `ScenarioSemanticLinterPayoffTests.configMessagesMapEachRuleIdToItsLintMessageCase`.
+  ///
+  /// Two limits, stated so nobody reads them as proofs: (1) the 7-entry list
+  /// is a hand-maintained pin — an eighth config rule must be added here by
+  /// hand, nothing reddens otherwise; (2) `log-window-below-agent-count` has
+  /// no explicit `configMessage` arm (Swift `default:` / Kotlin `else`), so
+  /// its row cannot tell "arm correct" from "fell through".
+  @Test func configMessagesMapEachRuleIDToItsLintMessageCase() {
+    let cases = configMessageCasesR7ToR17 + configMessageCasesR18ToR20b
+    // Pin, not proof: a new config rule must be added to `cases` by hand.
+    #expect(cases.count == 7)
+    for testCase in cases {
+      let findings = linter.lint(testCase.scenario)
+      #expect(findings.count == 1, "\(testCase.ruleID)")
+      #expect(findings.first?.ruleID == testCase.ruleID, "\(testCase.ruleID)")
+      #expect(findings.first?.message == testCase.expected.localized, "\(testCase.ruleID)")
+    }
+  }
+}

--- a/Pastura/PasturaTests/Engine/ScenarioSemanticLinterTests+OrderingMessages.swift
+++ b/Pastura/PasturaTests/Engine/ScenarioSemanticLinterTests+OrderingMessages.swift
@@ -92,10 +92,11 @@ extension ScenarioSemanticLinterTests {
     ]
   }
 
-  // MARK: - Message mapping (deliberate exception to the 1:1 mirror rule)
+  // MARK: - Message mapping (deliberate exception to the one-test-per-rule shape)
 
-  /// The one deliberate exception to the 1:1-mirror rule: no other test in this
-  /// suite asserts `finding.message`, so a mis-transcribed arm in the private
+  /// The deliberate exception to the one-test-per-rule shape the rest of this
+  /// suite keeps: no other test here asserts `finding.message`, so a
+  /// mis-transcribed arm in the private
   /// `orderingMessage(_:)` — a string switch with a `default:` fallthrough —
   /// would ship green with nothing to catch it. Each row fires exactly one
   /// ordering rule and pins its rendered message; `count == 1` and the `ruleID`

--- a/Pastura/PasturaTests/Engine/ScenarioSemanticLinterTests+OrderingMessages.swift
+++ b/Pastura/PasturaTests/Engine/ScenarioSemanticLinterTests+OrderingMessages.swift
@@ -1,0 +1,122 @@
+// The Ordering group's ruleID → ScenarioLintMessage pin (ADR-024 D3). Split
+// out of ScenarioSemanticLinterTests+Ordering.swift, which is already at the
+// 400-line SwiftLint cap; still an extension of the existing suite (not a new
+// @Suite) per .claude/rules/testing.md.
+import Testing
+
+@testable import Pastura
+
+extension ScenarioSemanticLinterTests {
+
+  /// One row of ``orderingMessagesMapEachRuleIDToItsLintMessageCase``'s pin: a
+  /// fixture expected to fire exactly `ruleID`, and the message it must render.
+  /// A struct rather than a tuple — SwiftLint caps tuples at two members.
+  private struct OrderingMessageCase {
+    let ruleID: String
+    let scenario: Scenario
+    let expected: ScenarioLintMessage
+  }
+
+  /// A four-row payoff table over `{cooperate, betray}²`. Inlined rather than
+  /// shared with `+Ordering.swift` / `+Payoff.swift`, whose equivalents are
+  /// `private` to their own files.
+  private var mappingPayoff: [PayoffRule] {
+    [
+      PayoffRule(when: ["cooperate", "cooperate"], points: [3, 3]),
+      PayoffRule(when: ["cooperate", "betray"], points: [0, 5]),
+      PayoffRule(when: ["betray", "cooperate"], points: [5, 0]),
+      PayoffRule(when: ["betray", "betray"], points: [1, 1])
+    ]
+  }
+
+  /// R1a/R1b/R2/R19 — the four rules whose fixtures need no `extraData`.
+  private var orderingMessageCasesR1ToR19: [OrderingMessageCase] {
+    [
+      OrderingMessageCase(
+        ruleID: "eliminate-needs-vote",
+        scenario: makeScenario(agents: 2, rounds: 1, phases: [Phase(type: .eliminate)]),
+        expected: .eliminateNeedsVote),
+      OrderingMessageCase(
+        ruleID: "eliminate-after-vote",
+        scenario: makeScenario(
+          agents: 2, rounds: 1, phases: [Phase(type: .eliminate), Phase(type: .vote)]),
+        expected: .eliminateAfterVote),
+      OrderingMessageCase(
+        ruleID: "pd-needs-round-robin-choose",
+        scenario: makeScenario(
+          agents: 2, rounds: 1,
+          phases: [
+            Phase(type: .choose, options: ["cooperate", "betray"]),
+            Phase(type: .scoreCalc, logic: .prisonersDilemma)
+          ]),
+        expected: .pdNeedsRoundRobinChoose),
+      OrderingMessageCase(
+        ruleID: "pairwise-payoff-needs-round-robin-choose",
+        scenario: makeScenario(
+          agents: 2, rounds: 1,
+          phases: [
+            Phase(type: .choose, options: ["cooperate", "betray"]),
+            Phase(type: .scoreCalc, logic: .pairwisePayoff, payoff: mappingPayoff)
+          ]),
+        expected: .pairwisePayoffNeedsRoundRobinChoose)
+    ]
+  }
+
+  /// R3/R5/R6 and the `default:`-arm rule — the remaining four.
+  private var orderingMessageCasesR3ToVoteTally: [OrderingMessageCase] {
+    [
+      OrderingMessageCase(
+        ruleID: "wordwolf-needs-assign-and-vote",
+        scenario: makeScenario(
+          agents: 2, rounds: 1, phases: [Phase(type: .scoreCalc, logic: .wordwolfJudge)]),
+        expected: .wordwolfNeedsAssignAndVote),
+      OrderingMessageCase(
+        ruleID: "event-reactive-needs-event-inject",
+        scenario: makeEventScenario(
+          phases: [
+            Phase(type: .eventInject, source: "events"),
+            Phase(type: .scoreCalc, logic: .eventReactive)
+          ],
+          events: .array(["storm", "calm"])),
+        expected: .eventReactiveNeedsEventInject),
+      OrderingMessageCase(
+        ruleID: "relationship-update-placement",
+        scenario: makeScenario(
+          agents: 2, rounds: 1, phases: [Phase(type: .relationshipUpdate, voteAgainst: -1)]),
+        expected: .relationshipUpdatePlacement),
+      OrderingMessageCase(
+        ruleID: "vote-tally-needs-vote",
+        scenario: makeScenario(
+          agents: 2, rounds: 1, phases: [Phase(type: .scoreCalc, logic: .voteTally)]),
+        expected: .voteTallyNeedsVote)
+    ]
+  }
+
+  // MARK: - Message mapping (deliberate exception to the 1:1 mirror rule)
+
+  /// The one deliberate exception to the 1:1-mirror rule: no other test in this
+  /// suite asserts `finding.message`, so a mis-transcribed arm in the private
+  /// `orderingMessage(_:)` — a string switch with a `default:` fallthrough —
+  /// would ship green with nothing to catch it. Each row fires exactly one
+  /// ordering rule and pins its rendered message; `count == 1` and the `ruleID`
+  /// are pinned too, so a rule that starts firing first on one of these
+  /// fixtures cannot silently change what is measured. Mirrors
+  /// `ScenarioSemanticLinterOrderingTests.orderingMessagesMapEachRuleIdToItsLintMessageCase`.
+  ///
+  /// Two limits, stated so nobody reads them as proofs: (1) the 8-entry list is
+  /// a hand-maintained pin — a ninth ordering rule must be added here by hand,
+  /// nothing reddens otherwise; (2) `vote-tally-needs-vote` has no explicit
+  /// `orderingMessage` arm on either side (Swift `default:` / Kotlin `else`),
+  /// so its row cannot tell "arm correct" from "fell through".
+  @Test func orderingMessagesMapEachRuleIDToItsLintMessageCase() {
+    let cases = orderingMessageCasesR1ToR19 + orderingMessageCasesR3ToVoteTally
+    // Pin, not proof: a new ordering rule must be added to `cases` by hand.
+    #expect(cases.count == 8)
+    for testCase in cases {
+      let findings = linter.lint(testCase.scenario)
+      #expect(findings.count == 1, "\(testCase.ruleID)")
+      #expect(findings.first?.ruleID == testCase.ruleID, "\(testCase.ruleID)")
+      #expect(findings.first?.message == testCase.expected.localized, "\(testCase.ruleID)")
+    }
+  }
+}

--- a/Pastura/PasturaTests/Engine/ScenarioSemanticLinterTests+PlaceholderMessages.swift
+++ b/Pastura/PasturaTests/Engine/ScenarioSemanticLinterTests+PlaceholderMessages.swift
@@ -1,0 +1,79 @@
+// The Placeholder group's ruleID → ScenarioLintMessage pin (ADR-024 D3).
+// Split into its own file for the same three SwiftLint reasons as
+// ScenarioSemanticLinterTests+OrderingMessages.swift and
+// +ConfigMessages.swift (file_length, function_body_length, large_tuple);
+// still an extension of the existing suite (not a new @Suite) per
+// .claude/rules/testing.md.
+import Testing
+
+@testable import Pastura
+
+extension ScenarioSemanticLinterTests {
+
+  /// One row of ``placeholderMessagesMapEachRuleIDToItsLintMessageCase``'s
+  /// pin: a fixture expected to fire exactly `ruleID`, and the message it
+  /// must render. A struct rather than a tuple — SwiftLint caps tuples at two
+  /// members.
+  private struct PlaceholderMessageCase {
+    let ruleID: String
+    let scenario: Scenario
+    let expected: ScenarioLintMessage
+  }
+
+  /// R10/R11/R12 — the three placeholder rules, one offending token each.
+  private var placeholderMessageCases: [PlaceholderMessageCase] {
+    [
+      PlaceholderMessageCase(
+        ruleID: "unresolvable-placeholder",
+        scenario: makeScenario(
+          agents: 2, rounds: 1,
+          phases: [Phase(type: .speakAll, prompt: "Scores: {scorebord}")]),
+        expected: .unresolvablePlaceholder(token: "scorebord")),
+      PlaceholderMessageCase(
+        ruleID: "placeholder-phase-availability",
+        scenario: makeScenario(
+          agents: 2, rounds: 1,
+          phases: [
+            Phase(type: .speakAll, prompt: "The wolf is {wolf_name}"),
+            Phase(type: .assign, target: .randomOne)
+          ]),
+        expected: .placeholderPhaseAvailability(token: "wolf_name")),
+      PlaceholderMessageCase(
+        ruleID: "per-persona-placeholder-in-summarize",
+        scenario: makeScenario(
+          agents: 2, rounds: 1,
+          phases: [Phase(type: .summarize, template: "Your notes: {my_notes}")]),
+        expected: .perPersonaPlaceholderInSummarize(token: "my_notes"))
+    ]
+  }
+
+  // MARK: - Message mapping (deliberate exception to the one-test-per-rule shape)
+
+  /// The Placeholder-group twin of
+  /// ``orderingMessagesMapEachRuleIDToItsLintMessageCase`` /
+  /// ``configMessagesMapEachRuleIDToItsLintMessageCase``: no other test in
+  /// this suite asserts `finding.message` for a placeholder rule, so a
+  /// mis-transcribed arm in the private `placeholderMessage(_:token:)` — a
+  /// string switch with a `default:` fallthrough for
+  /// `per-persona-placeholder-in-summarize` — would ship green with nothing
+  /// to catch it. Each row fires exactly one placeholder rule and pins its
+  /// rendered message, token interpolation included; `count == 1` and the
+  /// `ruleID` are pinned too, so a rule that starts firing first on one of
+  /// these fixtures cannot silently change what is measured. Mirrors
+  /// `ScenarioSemanticLinterPlaceholdersTests.placeholderMessagesMapEachRuleIdToItsLintMessageCase`.
+  ///
+  /// Limit, stated so nobody reads it as a proof: the 3-entry list is a
+  /// hand-maintained pin — a fourth placeholder rule must be added here by
+  /// hand, nothing reddens otherwise.
+  @Test func placeholderMessagesMapEachRuleIDToItsLintMessageCase() {
+    let cases = placeholderMessageCases
+    // Pin, not proof: a new placeholder rule must be added to `cases` by hand.
+    #expect(cases.count == 3)
+    for testCase in cases {
+      let findings = linter.lint(testCase.scenario)
+      #expect(findings.count == 1, "\(testCase.ruleID)")
+      #expect(findings.first?.ruleID == testCase.ruleID, "\(testCase.ruleID)")
+      #expect(findings.first?.message == testCase.expected.localized, "\(testCase.ruleID)")
+    }
+  }
+}

--- a/Pastura/PasturaTests/Engine/ScenarioSemanticLinterTests+PlaceholderMessages.swift
+++ b/Pastura/PasturaTests/Engine/ScenarioSemanticLinterTests+PlaceholderMessages.swift
@@ -1,9 +1,9 @@
-// The Placeholder group's ruleID → ScenarioLintMessage pin (ADR-024 D3).
-// Split into its own file for the same three SwiftLint reasons as
-// ScenarioSemanticLinterTests+OrderingMessages.swift and
-// +ConfigMessages.swift (file_length, function_body_length, large_tuple);
-// still an extension of the existing suite (not a new @Suite) per
-// .claude/rules/testing.md.
+// The Placeholder group's ruleID → ScenarioLintMessage pin (ADR-024 D3). Its
+// own file for symmetry with ScenarioSemanticLinterTests+OrderingMessages.swift
+// and +ConfigMessages.swift — only the Ordering one had to split (its host was
+// at the 400-line file_length cap); this one fits in `+Placeholders.swift` and
+// is kept apart so the three group pins read alike. Still an extension of the
+// existing suite (not a new @Suite) per .claude/rules/testing.md.
 import Testing
 
 @testable import Pastura

--- a/Pastura/PasturaTests/Engine/ScenarioSemanticLinterTests+Placeholders.swift
+++ b/Pastura/PasturaTests/Engine/ScenarioSemanticLinterTests+Placeholders.swift
@@ -174,4 +174,51 @@ extension ScenarioSemanticLinterTests {
       phases: [Phase(type: .summarize, template: "Scores: {scoreboard}")])
     #expect(linter.lint(scenario).isEmpty)
   }
+
+  // MARK: - The `__favors` companion of an event_inject variable (#1584)
+
+  // `event_inject` writes both its `as:` variable and that variable's
+  // `__favors` companion (`EventInjectHandler.favoredVariableName(for:)`), so
+  // both must resolve. Until these three tests, no fixture on either side
+  // referenced a companion token at all: dropping the companion from
+  // `globallyKnownTokens` reddened nothing (ADR-023 §12 condition-4 pass on
+  // D2c). The default-name and custom-`as:` rows pin that insert; the
+  // ordered-wrong row pins `isEventInjectProducing`'s companion clause, which
+  // is what makes the token producer-gated rather than merely known.
+
+  @Test func defaultFavoredCompanionAfterEventInjectPasses() {
+    let scenario = makeEventScenario(
+      phases: [
+        Phase(type: .eventInject, source: "events"),
+        Phase(type: .speakAll, prompt: "The wind favors {current_event__favors}")
+      ],
+      events: .array(["storm", "calm"]))
+    #expect(linter.lint(scenario).isEmpty)
+  }
+
+  @Test func customAsFavoredCompanionAfterEventInjectPasses() {
+    let scenario = makeEventScenario(
+      phases: [
+        Phase(type: .eventInject, source: "events", eventVariable: "my_event"),
+        Phase(type: .speakAll, prompt: "The wind favors {my_event__favors}")
+      ],
+      events: .array(["storm", "calm"]))
+    #expect(linter.lint(scenario).isEmpty)
+  }
+
+  @Test func favoredCompanionBeforeItsEventInjectFiresR11() {
+    // Known but producer-gated: R11, not R10. Reverting the companion clause in
+    // `isEventInjectProducing` drops the gating and this finding disappears.
+    let scenario = makeEventScenario(
+      phases: [
+        Phase(type: .speakAll, prompt: "The wind favors {current_event__favors}"),
+        Phase(type: .eventInject, source: "events")
+      ],
+      events: .array(["storm", "calm"]))
+    let findings = linter.lint(scenario)
+    #expect(findings.count == 1)
+    #expect(findings.first?.ruleID == "placeholder-phase-availability")
+    #expect(findings.first?.severity == .warning)
+    #expect(findings.first?.phaseIndex == 0)
+  }
 }

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/ScenarioSemanticLinterOrderingTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/ScenarioSemanticLinterOrderingTests.kt
@@ -522,7 +522,8 @@ class ScenarioSemanticLinterOrderingTests {
      * `message` against the matching [ScenarioLintMessage] case's `render()`,
      * pinning `size == 1` and the `ruleId` so a rule that fires first on one
      * of these fixtures after D2b cannot silently change what is measured.
-     * The Swift suite is NOT amended in this PR — the Swift-side twin is #1575.
+     * The Swift twin now exists: `ScenarioSemanticLinterTests+Ordering.swift`'s
+     * `orderingMessagesMapEachRuleIDToItsLintMessageCase`.
      *
      * Two limits, stated so nobody reads them as proofs: (1) the 8-entry list
      * is a hand-maintained pin — a ninth ordering rule must be added here by

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/ScenarioSemanticLinterOrderingTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/ScenarioSemanticLinterOrderingTests.kt
@@ -20,7 +20,9 @@ import kotlin.test.assertTrue
  * 1:1. Every function name below matches its Swift twin exactly — see that
  * file if a name here looks odd.
  *
- * 27 mirrored 1:1 + 1 message-mapping test = 28.
+ * 28 mirrored 1:1 — the message-mapping test included, though its Swift twin
+ * lives in the sibling `ScenarioSemanticLinterTests+OrderingMessages.swift`
+ * rather than in `+Ordering.swift` with the other 27.
  *
  * ## Condition-4 perturbation check
  *
@@ -39,10 +41,11 @@ import kotlin.test.assertTrue
  * | 5 | swapped the `"eliminate-needs-vote"` and `"pd-needs-round-robin-choose"` arms of `orderingMessage` | `orderingMessagesMapEachRuleIdToItsLintMessageCase` |
  *
  * Mutation 5 is the measurement that justifies the 28th test's existence as a
- * deliberate exception to the 1:1-mirror rule: swapping two `orderingMessage`
- * arms reddens [orderingMessagesMapEachRuleIdToItsLintMessageCase] and nothing
- * else — the 27 mirrored tests assert `ruleId` / `severity` / `phaseIndex` but
- * never `message`, so without it a mis-transcribed arm ships green.
+ * deliberate exception to the one-test-per-rule shape: swapping two
+ * `orderingMessage` arms reddens
+ * [orderingMessagesMapEachRuleIdToItsLintMessageCase] and nothing else — the
+ * other 27 tests assert `ruleId` / `severity` / `phaseIndex` but never
+ * `message`, so without it a mis-transcribed arm ships green.
  */
 class ScenarioSemanticLinterOrderingTests {
 
@@ -511,19 +514,20 @@ class ScenarioSemanticLinterOrderingTests {
         assertTrue(linter.lint(scenario).isEmpty())
     }
 
-    // MARK: - Message mapping (deliberate exception to the 1:1 mirror rule)
+    // MARK: - Message mapping (deliberate exception to the one-test-per-rule shape)
 
     /**
-     * The one deliberate exception to the 1:1-mirror rule above: neither the
-     * Swift suite nor the rest of this Kotlin suite ever asserts on
-     * `finding.message`, so a mis-transcribed arm in `orderingMessage` would
-     * stay green on both sides with nothing to catch it. This test builds a
-     * minimal scenario firing each of the 8 ordering ruleIds and checks its
-     * `message` against the matching [ScenarioLintMessage] case's `render()`,
-     * pinning `size == 1` and the `ruleId` so a rule that fires first on one
-     * of these fixtures after D2b cannot silently change what is measured.
-     * The Swift twin now exists: `ScenarioSemanticLinterTests+Ordering.swift`'s
-     * `orderingMessagesMapEachRuleIDToItsLintMessageCase`.
+     * The deliberate exception to the one-test-per-rule shape, not to the 1:1
+     * mirror: its Swift twin is
+     * `ScenarioSemanticLinterTests+OrderingMessages.swift`'s
+     * `orderingMessagesMapEachRuleIDToItsLintMessageCase`. No other test in
+     * this class asserts `finding.message`, so a mis-transcribed arm in
+     * `orderingMessage` would ship green with nothing to catch it. This test
+     * builds a minimal scenario firing each of the 8 ordering ruleIds and
+     * checks its `message` against the matching [ScenarioLintMessage] case's
+     * `render()`, pinning `size == 1` and the `ruleId` so a rule that starts
+     * firing first on one of these fixtures cannot silently change what is
+     * measured.
      *
      * Two limits, stated so nobody reads them as proofs: (1) the 8-entry list
      * is a hand-maintained pin — a ninth ordering rule must be added here by

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/ScenarioSemanticLinterPayoffTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/ScenarioSemanticLinterPayoffTests.kt
@@ -24,8 +24,11 @@ import kotlin.test.assertTrue
  * 6 mirrored 1:1 + 1 message-mapping test = 7.
  *
  * [configMessagesMapEachRuleIdToItsLintMessageCase] is the deliberate
- * exception to the 1:1-mirror rule, following
- * `ScenarioSemanticLinterOrderingTests.orderingMessagesMapEachRuleIdToItsLintMessageCase`.
+ * exception to the one-test-per-rule shape, not to the 1:1 mirror: its Swift
+ * twin is `ScenarioSemanticLinterTests+ConfigMessages.swift`'s
+ * `configMessagesMapEachRuleIDToItsLintMessageCase`, mirroring the pairing
+ * `ScenarioSemanticLinterOrderingTests.orderingMessagesMapEachRuleIdToItsLintMessageCase`
+ * already has.
  * It lives here rather than in [ScenarioSemanticLinterConfigTests] because it
  * can only cover **all seven** config ruleIds once R20a/R20b exist, and they
  * arrive with this file. It closes the gap that class's KDoc records as row 6:

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/ScenarioSemanticLinterPayoffTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/ScenarioSemanticLinterPayoffTests.kt
@@ -21,7 +21,9 @@ import kotlin.test.assertTrue
  * 1:1. Every function name below matches its Swift twin exactly — see that
  * file if a name here looks odd.
  *
- * 6 mirrored 1:1 + 1 message-mapping test = 7.
+ * 7 mirrored 1:1 — the message-mapping test included, though its Swift twin
+ * lives in `ScenarioSemanticLinterTests+ConfigMessages.swift` rather than in
+ * `+Payoff.swift` with the other 6.
  *
  * [configMessagesMapEachRuleIdToItsLintMessageCase] is the deliberate
  * exception to the one-test-per-rule shape, not to the 1:1 mirror: its Swift

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/ScenarioSemanticLinterPlaceholdersTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/ScenarioSemanticLinterPlaceholdersTests.kt
@@ -17,7 +17,9 @@ import kotlin.test.assertTrue
  * 1:1. Every function name below matches its Swift twin exactly — see that
  * file if a name here looks odd.
  *
- * 17 mirrored 1:1 + 1 message-mapping test = 18.
+ * 18 mirrored 1:1 — the message-mapping test included, though its Swift twin
+ * lives in `ScenarioSemanticLinterTests+PlaceholderMessages.swift` rather than
+ * in `+Placeholders.swift` with the other 17.
  *
  * [placeholderMessagesMapEachRuleIdToItsLintMessageCase] is the deliberate
  * exception to the one-test-per-rule shape, not to the 1:1 mirror: its Swift

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/ScenarioSemanticLinterPlaceholdersTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/ScenarioSemanticLinterPlaceholdersTests.kt
@@ -20,12 +20,13 @@ import kotlin.test.assertTrue
  * 14 mirrored 1:1 + 1 message-mapping test = 15.
  *
  * [placeholderMessagesMapEachRuleIdToItsLintMessageCase] is the deliberate
- * exception to the 1:1-mirror rule, following
- * `ScenarioSemanticLinterOrderingTests.orderingMessagesMapEachRuleIdToItsLintMessageCase`
- * and `ScenarioSemanticLinterPayoffTests.configMessagesMapEachRuleIdToItsLintMessageCase`.
- * No mirrored test here asserts `finding.message`, so without it all three
- * `placeholderMessage` arms — the fallthrough `else` especially — would ship
- * green however they were transcribed.
+ * exception to the one-test-per-rule shape, not to the 1:1 mirror: its Swift
+ * twin is `ScenarioSemanticLinterTests+PlaceholderMessages.swift`'s
+ * `placeholderMessagesMapEachRuleIDToItsLintMessageCase`, the same pairing
+ * the Ordering and Payoff mapping tests already have.
+ * No mirrored test here asserts `finding.message`, so without
+ * it all three `placeholderMessage` arms — the fallthrough `else` especially
+ * — would ship green however they were transcribed.
  *
  * **No test here pins the relative order of two findings within one phase.**
  * `placeholderTokens`' dedupe container is a seed-randomised `Set` on the Swift

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/ScenarioSemanticLinterPlaceholdersTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/ScenarioSemanticLinterPlaceholdersTests.kt
@@ -17,7 +17,7 @@ import kotlin.test.assertTrue
  * 1:1. Every function name below matches its Swift twin exactly — see that
  * file if a name here looks odd.
  *
- * 14 mirrored 1:1 + 1 message-mapping test = 15.
+ * 17 mirrored 1:1 + 1 message-mapping test = 18.
  *
  * [placeholderMessagesMapEachRuleIdToItsLintMessageCase] is the deliberate
  * exception to the one-test-per-rule shape, not to the 1:1 mirror: its Swift
@@ -38,11 +38,14 @@ import kotlin.test.assertTrue
  *
  * ## Condition-4 perturbation check
  *
- * ADR-023 §12 condition 4 (perturbation sensitivity), measured 2026-08-28 with
- * the whole `:shared:engine:jvmTest` suite (937 tests, this class's 15
- * included) green before the first mutation and after the last revert. Each
- * mutation was applied to `ScenarioSemanticLinter.kt`'s `placeholderFindings`
- * section alone and reverted exactly before the next.
+ * ADR-023 §12 condition 4 (perturbation sensitivity). Rows 1-6 measured
+ * 2026-08-28 with the whole `:shared:engine:jvmTest` suite (937 tests, this
+ * class's 15 at the time) green before the first mutation and after the last
+ * revert; rows 7-8 the same day with #1584's three tests added (940 tests, 18
+ * here). Each mutation was applied to `ScenarioSemanticLinter.kt`'s
+ * `placeholderFindings` section alone and reverted exactly before the next.
+ * Rows 7-8 were measured on both sides — the Swift twins reddened identically,
+ * which is what the 1:1 mirror is supposed to buy.
  *
  * | # | Mutation of `ScenarioSemanticLinter.kt` | Reddened |
  * |---|---|---|
@@ -52,6 +55,8 @@ import kotlin.test.assertTrue
  * | 4 | `globallyKnownTokens`: dropped `known.addAll(scenario.extraData.keys)` | [declaredExtraDataKeyPassesR10] |
  * | 5 | `scannedField`: swapped `template` / `prompt` | [unknownPlaceholderTypoFiresR10], [candidatesInSpeakAllFiresR10], [producerTokenBeforeItsProducerFiresR11], [perPersonaTokenInSummarizeFiresR12ExactlyOnce], [placeholderMessagesMapEachRuleIdToItsLintMessageCase] |
  * | 6 | `placeholderMessage`: fallthrough `else` arm swapped to `UnresolvablePlaceholder` | [placeholderMessagesMapEachRuleIdToItsLintMessageCase] |
+ * | 7 | `globallyKnownTokens`: dropped `known.add(EventInjectHandler.favoredVariableName(name))` | [defaultFavoredCompanionAfterEventInjectPasses], [customAsFavoredCompanionAfterEventInjectPasses], [favoredCompanionBeforeItsEventInjectFiresR11] |
+ * | 8 | `isEventInjectProducing`: dropped the `|| token == favoredVariableName(name)` disjunct | [favoredCompanionBeforeItsEventInjectFiresR11] |
  *
  * Row 6 is the measurement that justifies
  * [placeholderMessagesMapEachRuleIdToItsLintMessageCase]: it reddens that test
@@ -59,22 +64,22 @@ import kotlin.test.assertTrue
  * ship green — the gap row 6 of [ScenarioSemanticLinterConfigTests]'s KDoc
  * recorded for the config group.
  *
- * **Two candidate mutations measured insensitive and substituted or recorded**,
- * rather than dropped silently (same convention as
- * [ScenarioSemanticLinterPayoffTests]'s notes):
+ * **One candidate mutation measured insensitive and substituted**, rather than
+ * dropped silently (same convention as [ScenarioSemanticLinterPayoffTests]'s
+ * notes):
  *
  * - `PLACEHOLDER_REGEX`'s *first* char class `[A-Za-z_]` -> `[A-Za-z0-9_]` (the
  *   obvious leading-digit candidate) reddened **nothing**: no fixture on either
  *   side writes a digit-leading `{0token}`, so the two patterns agree on all of
  *   them. Row 3's body widening is the substitute — it measures the property
  *   that char class actually exists for (JSON-example braces must not match).
- * - `globallyKnownTokens`: dropping the `__favors` companion
- *   (`EventInjectHandler.favoredVariableName(name)`) reddened **nothing**. No
- *   fixture here references a `{<event>__favors}` token, and the Swift twin has
- *   none either, so the companion's presence in the known set is untested on
- *   both sides. Recorded as a gap rather than papered over with a Kotlin-only
- *   test, which would break the 1:1 mirror; the fix belongs on the Swift side
- *   first — tracked as #1584.
+ *
+ * The `__favors` companion drop used to sit alongside it, measured insensitive on
+ * both sides because no fixture referenced a `{<event>__favors}` token. #1584
+ * closed that gap Swift-first; it is now rows 7 and 8 above. Row 8 is the one
+ * that separates the two mechanisms: the companion has to be in the known set
+ * (row 7, R10) *and* resolve to its producing `event_inject` (row 8, R11), and
+ * only the ordered-wrong fixture can tell those apart.
  */
 class ScenarioSemanticLinterPlaceholdersTests {
 
@@ -286,7 +291,62 @@ class ScenarioSemanticLinterPlaceholdersTests {
         assertTrue(linter.lint(scenario).isEmpty())
     }
 
-    // MARK: - Message mapping (no Swift twin)
+    // MARK: - The `__favors` companion of an event_inject variable (#1584)
+
+    // `event_inject` writes both its `as:` variable and that variable's
+    // `__favors` companion (`EventInjectHandler.favoredVariableName`), so both
+    // must resolve. Until these three tests, no fixture on either side
+    // referenced a companion token at all: dropping the companion from
+    // `globallyKnownTokens` reddened nothing (the gap this class's KDoc used to
+    // record as an insensitive candidate; now row 7 of the table). The
+    // default-name and custom-`as:` rows pin that insert; the ordered-wrong row
+    // pins `isEventInjectProducing`'s companion clause, which is what makes the
+    // token producer-gated rather than merely known.
+
+    @Test
+    fun defaultFavoredCompanionAfterEventInjectPasses() {
+        val scenario = makeEventScenario(
+            phases = listOf(
+                Phase(type = PhaseType.EVENT_INJECT, source = "events"),
+                Phase(type = PhaseType.SPEAK_ALL, prompt = "The wind favors {current_event__favors}"),
+            ),
+            events = AnyCodableValue.ArrayValue(listOf("storm", "calm")),
+        )
+        assertTrue(linter.lint(scenario).isEmpty())
+    }
+
+    @Test
+    fun customAsFavoredCompanionAfterEventInjectPasses() {
+        val scenario = makeEventScenario(
+            phases = listOf(
+                Phase(type = PhaseType.EVENT_INJECT, source = "events", eventVariable = "my_event"),
+                Phase(type = PhaseType.SPEAK_ALL, prompt = "The wind favors {my_event__favors}"),
+            ),
+            events = AnyCodableValue.ArrayValue(listOf("storm", "calm")),
+        )
+        assertTrue(linter.lint(scenario).isEmpty())
+    }
+
+    @Test
+    fun favoredCompanionBeforeItsEventInjectFiresR11() {
+        // Known but producer-gated: R11, not R10. Reverting the companion clause
+        // in `isEventInjectProducing` drops the gating and this finding
+        // disappears.
+        val scenario = makeEventScenario(
+            phases = listOf(
+                Phase(type = PhaseType.SPEAK_ALL, prompt = "The wind favors {current_event__favors}"),
+                Phase(type = PhaseType.EVENT_INJECT, source = "events"),
+            ),
+            events = AnyCodableValue.ArrayValue(listOf("storm", "calm")),
+        )
+        val findings = linter.lint(scenario)
+        assertEquals(1, findings.size)
+        assertEquals("placeholder-phase-availability", findings.single().ruleId)
+        assertEquals(LintSeverity.WARNING, findings.single().severity)
+        assertEquals(0, findings.single().phaseIndex)
+    }
+
+    // MARK: - Message mapping (deliberate exception to the one-test-per-rule shape)
 
     /**
      * Pins each placeholder `ruleId` to the [ScenarioLintMessage] arm


### PR DESCRIPTION
## Summary

Two bundled test-only issues over the same linter suites.

**#1575 — the Swift side never asserted `finding.message`.** `orderingMessage`,
`configMessage`, and `placeholderMessage` are private string switches with a
`default:` fallthrough, and every mirrored Swift test pinned `ruleID` /
`severity` / `phaseIndex` only — so a mis-transcribed arm shipped green. Three
new split files port the Kotlin pins added in D2a/D2b/D2c: 8 ordering ruleIDs,
7 config ruleIDs, 3 placeholder ruleIDs, each row asserting `count == 1`, the
`ruleID`, and `message == expected.localized`.

**#1584 — the `__favors` companion was untested on both sides.** No fixture
anywhere referenced a `{<event>__favors}` token, so dropping the companion from
`globallyKnownTokens` reddened nothing. Three mirrored tests close it: default
`as:` name, custom `as:` name, and the ordered-wrong case that separates R10
(the known set) from R11 (`isEventInjectProducing`'s companion clause).

The Kotlin KDocs are updated to match: the three mapping tests are no longer
"the deliberate exception to the 1:1-mirror rule" — they are twinned now — and
the Placeholders class's ADR-023 §12 perturbation table gains rows 7 and 8.

**Out of scope**: the Conditions group. `conditionMessage` has the same
`default:`-fallthrough shape, but the group has no Kotlin twin yet, so its
mapping pin belongs with that port — #1575's own deferral ("extend when D2b
mirrors those").

## Test plan

- `scripts/xcodebuild.sh test` — 3581 swift-testing tests in 287 suites + 10 UI
  tests, `** TEST SUCCEEDED **`. `ScenarioSemanticLinterTests` went 83 → 89.
- `swiftlint lint --quiet --strict` — clean.
- `./gradlew :shared:engine:jvmTest` — 940 tests green (937 → 940).
- **Perturbation measurement for rows 7/8**, run on both sides the same day:
  - Row 7 (`globallyKnownTokens`: companion insert dropped) reddens all three
    new tests — the two `…Passes` ones pick up an R10 finding, the ordered-wrong
    one's `ruleID` flips from R11 to R10.
  - Row 8 (`isEventInjectProducing`: companion disjunct dropped) reddens only
    `favoredCompanionBeforeItsEventInjectFiresR11` — the token stays known but
    loses its producer, so R11 never fires.
  - Swift and Kotlin reddened identically, which is what the 1:1 mirror is for.
  Both production sources were restored and re-verified green before committing.

## Review

Reviewer: **Opus** (coupling rule — one plan item was Opus-tier; the defect
class here is cross-file KDoc mirror-invariant drift, which needs cross-file
reasoning rather than diff-local checking).

Verdict was FAIL with 0 Critical / 4 Warning / 3 Suggestion. Applied:

- All four Warnings — every one was stale documentation in the Kotlin KDocs.
  `ScenarioSemanticLinterOrderingTests.kt` had kept the "1:1-mirror exception"
  framing in three places and pointed at the wrong Swift filename
  (`+Ordering.swift` instead of `+OrderingMessages.swift`); the "N mirrored 1:1
  + 1 message-mapping test" arithmetic in all three group KDocs segregated a
  test that is now mirrored. Fixed in e4a1a4e8.
- Suggestion 1 — the `+ConfigMessages.swift` / `+PlaceholderMessages.swift`
  headers claimed a `file_length` split they didn't need (their hosts are 211
  and 224 lines). Restated: only `+OrderingMessages.swift` was forced out; the
  other two are split for symmetry.

Rejected:

- Suggestion 2 (promote the duplicated `{cooperate, betray}²` payoff table to an
  `internal` helper on the base suite). Out of scope for a test-only branch, and
  it widens `ScenarioSemanticLinterTests.swift`, which four sibling split files
  share — the plan deliberately kept that file untouched so the three mapping
  items couldn't collide on it. Worth doing as its own change.
- Suggestion 3 was a confirmation that `ScenarioSemanticLinterConfigTests.kt`
  is correct to leave unedited, not a change request. No action.

## Device QA

実機QA不要 — テストと doc コメントのみの差分で、プロダクションコードは1行も変わっていません（測定用のミューテーションはすべて復元済み）。

Closes #1575
Closes #1584
