### PR TITLE
✨ feat: ADR-023 Stage 3 — detector/logger injection seams (close-out)

### DIFF
--- a/.claude/rules/kmp-interop.md
+++ b/.claude/rules/kmp-interop.md
@@ -36,6 +36,14 @@ catch it — fix the conformers in the same PR. Re-grep `@optional` in the regen
 `PasturaSharedEngine.h` after a Kotlin bump: a section appearing flips this rule, and that edit
 loads no rule file. See `LLMBackend.kt`.
 
+**A defaulted Kotlin parameter is not a default in Swift.** K/N drops default arguments and exports
+one full-arity selector, so adding a defaulted constructor / function parameter stays
+source-compatible in Kotlin while breaking **every** Swift construction site — same shape as the
+`@optional` trap above, same nightly-only signal, same remedy: update the Swift callers in the same
+PR. Measured on `SimulationEngine(detector:logger:)` (#1603), where the previously no-arg
+`SimulationEngine()` gained two defaulted seams and each Swift caller had to spell out
+`SimulationEngine(detector: nil, logger: NoopEngineLogger())`.
+
 ## Pattern 4 — traps inside the Kotlin port (`commonMain`, `commonTest`, the port gates)
 
 **Roster completeness is a pin, not a proof.** `KClass.sealedSubclasses` is JVM-only and

--- a/Pastura/PasturaTests/Engine/EngineLoggerSeamTests.swift
+++ b/Pastura/PasturaTests/Engine/EngineLoggerSeamTests.swift
@@ -85,6 +85,42 @@ struct EngineLoggerSeamTests {
     #expect(retry?.privacy == .public)
   }
 
+  /// Through-runner reach pin: a logger injected via
+  /// ``SimulationRunner/init(detector:logger:)`` must actually reach the run
+  /// path — `SimulationRunner` → `ExecutionContext` → `PhaseContext` →
+  /// handler → ``LLMCaller``. The suite's other cases construct `LLMCaller`
+  /// directly, so none of them would notice a runner that dropped the seam on
+  /// the floor and fell back to ``NoopEngineLogger``.
+  ///
+  /// Landed as the Swift half of the Kotlin injection-seam PR (the D2d
+  /// Swift-pin-then-Kotlin-twin pairing); the Kotlin twin is
+  /// `SimulationEngineSeamInjectionTests.injectedLoggerReachesTheRunPath` in
+  /// `shared/engine/src/commonTest`. Swift is already wired, so this passes on
+  /// arrival — its job is to be the parity spec that twin mirrors.
+  @Test func runnerInjectedLoggerReachesTheRunPath() async throws {
+    // Alice: attempt 1 unparseable → one `retryCause … parse_failed` line,
+    // attempt 2 valid. Bob: valid on attempt 1. Deterministic, and the only
+    // StreamingDiag emission in the run.
+    let valid = #"{"statement": "a statement"}"#
+    let mock = MockLLMService(responses: ["not json at all", valid, valid])
+    try await mock.loadModel()
+    let spy = SpyEngineLogger()
+
+    let scenario = makeTestScenario(
+      agentNames: ["Alice", "Bob"],
+      language: "en",
+      rounds: 1,
+      phases: [Phase(type: .speakAll, prompt: "Speak", outputSchema: ["statement": "string"])]
+    )
+    let runner = SimulationRunner(logger: spy)
+    let events = await collectAllEvents(
+      runner.run(scenario: scenario, llm: mock, suspendController: SuspendController()))
+
+    #expect(events.contains { if case .simulationCompleted = $0 { true } else { false } })
+    let diag = spy.entries.filter { $0.category == "StreamingDiag" }.map(\.message)
+    #expect(diag.contains("retryCause agent=Alice attempt=1 cause=parse_failed"))
+  }
+
   /// Adapter smoke: every (level, privacy) combination is callable and the
   /// switch is exhaustive. OSLog's actual off-device redaction is
   /// real-device-verifiable only (documented manual `log stream` step in the

--- a/Pastura/PasturaTests/Engine/EngineLoggerSeamTests.swift
+++ b/Pastura/PasturaTests/Engine/EngineLoggerSeamTests.swift
@@ -29,7 +29,9 @@ final class SpyEngineLogger: EngineLogger, @unchecked Sendable {
   var entries: [Entry] { lock.withLock { $0 } }
 }
 
-@Suite(.timeLimit(.minutes(1)))
+// Serialized: SimulationRunner tests create Tasks and AsyncStreams that can
+// interfere with each other when run in parallel on the simulator.
+@Suite(.serialized, .timeLimit(.minutes(1)))
 struct EngineLoggerSeamTests {
   /// Parse failure → the StreamingDiag `retryCause parse_failed` line (the
   /// load-bearing `scripts/analyze-streaming-diag.sh` wire format) and the
@@ -101,8 +103,12 @@ struct EngineLoggerSeamTests {
     // Alice: attempt 1 unparseable → one `retryCause … parse_failed` line,
     // attempt 2 valid. Bob: valid on attempt 1. Deterministic, and the only
     // StreamingDiag emission in the run.
+    //
+    // One spare response beyond the 3 the run consumes: a retry-budget
+    // regression must redden on the seam assertion below, not on the mock
+    // running out of scripts before that assertion is ever reached.
     let valid = #"{"statement": "a statement"}"#
-    let mock = MockLLMService(responses: ["not json at all", valid, valid])
+    let mock = MockLLMService(responses: ["not json at all", valid, valid, valid])
     try await mock.loadModel()
     let spy = SpyEngineLogger()
 

--- a/docs/decisions/ADR-023.md
+++ b/docs/decisions/ADR-023.md
@@ -372,8 +372,19 @@ precisely how §4 went stale in the first place.)
   parity fixture carries a non-finite or non-ASCII condition operand) names the two D2d stated
   divergences above, which the wiring turns from invisible into transcript-visible `⚠️` summaries.
   The "not wired" prose across `shared/` and `.claude/rules/kmp-interop.md` Pattern 4 was swept
-  by grep, not by list. What the row still lacks is the `LanguageDetector` / `EngineLogger`
-  injection seams, which are Stage-3 freight of their own.
+  by grep, not by list.
+  **Detector / logger injection seams** (#1603, 2026-08-28, landed) closed the freight this row
+  last named: `SimulationEngine(detector: LanguageDetector? = null, logger: EngineLogger =
+  NoopEngineLogger())` threads both through `RunLoop` into every top-level `PhaseContext`, so the
+  ADR-010 Step E adherence check and the `StreamingDiag` channel are fed by the run path rather
+  than by a construction-site default. The Kotlin side is therefore **complete** for this row.
+  `LanguageDetector` / `EngineLogger` / `EngineLogLevel` / `EngineLogPrivacy` / `NoopEngineLogger`
+  widened `internal → public` to make Swift constructor injection possible, so all five now cross
+  K/N (§5's 2026-08-28 note). The concrete implementations — `NLLanguageDetector` (App layer,
+  NaturalLanguage) and `OSLogEngineLogger` — stay Swift per §4's `STAY` list and are handed across
+  only when a production consumer constructs the engine, which is Stage-5 freight — today's two
+  callers, `SharedEngineRunner` and `EngineParityTests`, both take the defaults
+  (`DivergenceLedger.DETECTOR_UNINJECTED` records the parity-harness half of that).
 
 ### How this section went stale, and what changed
 
@@ -410,6 +421,26 @@ section previously accounted for. Two things that figure is *not*:
 
 Two directions cross K/N. Shared principle (Decision 2): callbacks at the boundary,
 structured concurrency inside each language.
+
+**Refinement 2026-08-28 (#1603) — a third crossing: the two injection seams.** §5.1/§5.2
+enumerate the *event*, *control* and *inference* contracts, and they are unchanged. Alongside
+them, the ADR-010 Step E detector and the S0.2 diagnostic seam now also cross as exported
+protocols: `LanguageDetector` and `EngineLogger`, plus the `EngineLogLevel` / `EngineLogPrivacy`
+enums they use and the `NoopEngineLogger` default. All five widened `internal → public` because
+the seams are consumed by *Swift constructor injection* —
+`SimulationEngine(detector:logger:)` — and a K/N-exported constructor parameter cannot name an
+`internal` type. This is §5.2's `LLMBackend` precedent applied unchanged (a plain interface,
+injected at construction, no `expect`/`actual`), which is why it needs no new contract of its
+own; the concrete implementations stay Swift App-side per §4. **A Swift conformer must be
+`nonisolated`**: like `LLMBackend`, these are unannotated Obj-C protocols to Swift and are called
+from `Dispatchers.Default`, so a default-MainActor conformer compiles clean and traps at runtime
+(`.claude/rules/swift-isolation.md` Pattern 7).
+
+That widening puts the exported surface past the roster §11 (i)/(iii) counted. **The 24-declaration
+shim budget is not renumbered**: it is a frozen Stage-2 gate measurement, taken 2026-07-18 on the
+gate slice, and §11 already says the figure moves as sources are added and that a Stage-3 reader
+must compare like for like. It stands as the historical gate-day figure; the live count is whatever
+the `ShimInventory` scanner in `tools/kmp-gate-spike` reports today.
 
 ### 5.1 Event + control boundary (Kotlin → Swift events; Swift → Kotlin control)
 

--- a/docs/decisions/ADR-023.md
+++ b/docs/decisions/ADR-023.md
@@ -383,7 +383,9 @@ precisely how §4 went stale in the first place.)
   K/N (§5's 2026-08-28 note). The concrete implementations — `NLLanguageDetector` (App layer,
   NaturalLanguage) and `OSLogEngineLogger` — stay Swift per §4's `STAY` list and are handed across
   only when a production consumer constructs the engine, which is Stage-5 freight — today's two
-  callers, `SharedEngineRunner` and `EngineParityTests`, both take the defaults
+  callers, `SharedEngineRunner` and `EngineParityTests`, both pass the default values explicitly
+  (`nil` / `NoopEngineLogger`) — K/N exports no default arguments, so no no-arg initializer exists
+  on the Swift side
   (`DivergenceLedger.DETECTOR_UNINJECTED` records the parity-harness half of that).
 
 ### How this section went stale, and what changed
@@ -434,7 +436,10 @@ injected at construction, no `expect`/`actual`), which is why it needs no new co
 own; the concrete implementations stay Swift App-side per §4. **A Swift conformer must be
 `nonisolated`**: like `LLMBackend`, these are unannotated Obj-C protocols to Swift and are called
 from `Dispatchers.Default`, so a default-MainActor conformer compiles clean and traps at runtime
-(`.claude/rules/swift-isolation.md` Pattern 7).
+(`.claude/rules/swift-isolation.md` Pattern 7). That last clause is **stated from the seams' own
+KDoc and by analogy to `LLMBackend`, not yet confirmed by the Pattern 7 probe against the staged
+framework** — mirroring how the rule itself hedges its `LLMBackend` paragraph. Run the probe
+before Stage 5 relies on it.
 
 That widening puts the exported surface past the roster §11 (i)/(iii) counted. **The 24-declaration
 shim budget is not renumbered**: it is a frozen Stage-2 gate measurement, taken 2026-07-18 on the

--- a/docs/decisions/ADR-023.md
+++ b/docs/decisions/ADR-023.md
@@ -383,9 +383,9 @@ precisely how §4 went stale in the first place.)
   K/N (§5's 2026-08-28 note). The concrete implementations — `NLLanguageDetector` (App layer,
   NaturalLanguage) and `OSLogEngineLogger` — stay Swift per §4's `STAY` list and are handed across
   only when a production consumer constructs the engine, which is Stage-5 freight — today's two
-  callers, `SharedEngineRunner` and `EngineParityTests`, both pass the default values explicitly
-  (`nil` / `NoopEngineLogger`) — K/N exports no default arguments, so no no-arg initializer exists
-  on the Swift side
+  callers, `SharedEngineRunner` and `EngineParityTests`, both take the defaults; the Swift one
+  spells them out (`SimulationEngine(detector: nil, logger: NoopEngineLogger())`) because K/N
+  exports no default arguments, so no no-arg initializer exists on the Swift side
   (`DivergenceLedger.DETECTOR_UNINJECTED` records the parity-harness half of that).
 
 ### How this section went stale, and what changed

--- a/docs/kmp-migration-status.md
+++ b/docs/kmp-migration-status.md
@@ -45,7 +45,7 @@ Legend: ✅ done · 🔄 in progress · 🟡 partial · ⬜ not started.
 | Wave A — non-handler run-path (scoring, mechanisms, prompt/LLM glue) | ✅ done | #1207 #1212 #1217 |
 | Wave B — 14 phase handlers | ✅ 14/14 | checklist ↓ |
 | code-phase track | ✅ done | CP1 #1226 · CP2 #1230 · CP3 #1232 |
-| Loader / validator port + `detector`·`logger` wiring | ✅ done | validator prerequisites in ([#1464](https://github.com/tyabu12/pastura/issues/1464)); validator fully ported — run gate + commit gate ([#1552](https://github.com/tyabu12/pastura/issues/1552) B1/B2); loader fully ported — YAML ingest + top-level mapping ([#1558](https://github.com/tyabu12/pastura/issues/1558) C2a) then phase specialisation ([#1560](https://github.com/tyabu12/pastura/issues/1560) C2b), upstream of the run gate on both sides — the Kotlin loader itself still has no caller in `shared/engine`; linter message prep in — `ScenarioLintMessage` Swift + Kotlin mirror ([#1562](https://github.com/tyabu12/pastura/issues/1562) D1a) and `PlaceholderAvailability.kt` ([#1564](https://github.com/tyabu12/pastura/issues/1564) D1b); linter base types + Ordering rules ported as `ScenarioSemanticLinter.kt` ([#1574](https://github.com/tyabu12/pastura/issues/1574) D2a); Config rules R7/R8/R9/R17/R18/R20a/R20b ported and joined into `lint()` ([#1579](https://github.com/tyabu12/pastura/issues/1579) D2b); Placeholders R10/R11/R12 ported and joined ([#1582](https://github.com/tyabu12/pastura/issues/1582) D2c); Conditions R13–R16 ported and joined ([#1587](https://github.com/tyabu12/pastura/issues/1587) D2d) — linter fully ported; **preflight wired** — validator + linter gate `SimulationEngine.run` via `SimulationPreflight.kt`, `VALIDATOR_UNPORTED` retired ([#1591](https://github.com/tyabu12/pastura/issues/1591) D3); `detector`·`logger` seams wired via `SimulationEngine(detector:logger:)` ([#1603](https://github.com/tyabu12/pastura/issues/1603)) — Kotlin-side complete; concrete impls remain Stage 5 · [ADR-023](decisions/ADR-023.md) §4 · #501 |
+| Loader / validator port + `detector`·`logger` wiring | ✅ done | #1464 #1552 #1558 #1560 #1562 #1564 #1574 #1579 #1582 #1587 #1591 #1603 · [ADR-023](decisions/ADR-023.md) §4 · #501 |
 
 ### Wave B handler checklist
 
@@ -99,5 +99,6 @@ machine-checked — see the maintenance invariant above.
   deciding which side changes moves shipped Swift behaviour). `SimulationEvent.ErrorEvent`'s
   projection is known to disagree across languages and is unexercised by every fixture — S4 is
   the likely first driver.
-- **Stage 5** (iOS switch + code-merge): ⬜ not started — the remaining iOS integration. See
+- **Stage 5** (iOS switch + code-merge): ⬜ not started — the remaining iOS integration; the ported
+  Kotlin loader still has no caller in `shared/engine`. See
   [ADR-023](decisions/ADR-023.md) §6 Stage 5.

--- a/docs/kmp-migration-status.md
+++ b/docs/kmp-migration-status.md
@@ -22,7 +22,7 @@ At-a-glance progress for the KMP Engine migration (ADR-023 / [#501](https://gith
 > other section is hand-maintained; refresh it when a KMP PR merges (see
 > [`.claude/rules/kmp-interop.md`](../.claude/rules/kmp-interop.md)).
 
-_Last updated: 2026-08-26._
+_Last updated: 2026-08-28._
 
 ## Stages
 
@@ -31,13 +31,13 @@ _Last updated: 2026-08-26._
 | 0 | Pre-port refactors on `main` | ✅ done | #990 #991 #1051 #1000 |
 | 1 | `shared/models` + CI infrastructure | ✅ done | #1052 #1055 #1059 |
 | 2 | Two-boundary vertical slice = GO/NO-GO gate | ✅ **GO** (2026-07-18) | #1063 #1137 #1172 · [ADR-023 §12](decisions/ADR-023.md) |
-| 3 | Bulk port to `commonMain` | 🔄 in progress | ↓ Stage 3 breakdown |
+| 3 | Bulk port to `commonMain` | ✅ done | ↓ Stage 3 breakdown |
 | 4 | Cross-language parity harness | 🔄 in progress | slice 1a landed ([#1387](https://github.com/tyabu12/pastura/issues/1387), closed); 1b next · [#501](https://github.com/tyabu12/pastura/issues/501) |
 | 5 | iOS consumption switch + code-merge | ⬜ not started | the remaining integration · adapter traps: [`kmp-interop.md`](../.claude/rules/kmp-interop.md) · ⚠️ en-only `ScenarioValidationMessage.render()` / `ScenarioLintMessage.render()` block this — [#1464](https://github.com/tyabu12/pastura/issues/1464), [#1562](https://github.com/tyabu12/pastura/issues/1562) |
 
 Legend: ✅ done · 🔄 in progress · 🟡 partial · ⬜ not started.
 
-## Stage 3 — bulk port (in progress)
+## Stage 3 — bulk port (done)
 
 | Slice | Status | Pointer |
 |---|:--:|---|
@@ -45,7 +45,7 @@ Legend: ✅ done · 🔄 in progress · 🟡 partial · ⬜ not started.
 | Wave A — non-handler run-path (scoring, mechanisms, prompt/LLM glue) | ✅ done | #1207 #1212 #1217 |
 | Wave B — 14 phase handlers | ✅ 14/14 | checklist ↓ |
 | code-phase track | ✅ done | CP1 #1226 · CP2 #1230 · CP3 #1232 |
-| Loader / validator port + `detector`·`logger` wiring | 🟡 partial | validator prerequisites in ([#1464](https://github.com/tyabu12/pastura/issues/1464)); validator fully ported — run gate + commit gate ([#1552](https://github.com/tyabu12/pastura/issues/1552) B1/B2); loader fully ported — YAML ingest + top-level mapping ([#1558](https://github.com/tyabu12/pastura/issues/1558) C2a) then phase specialisation ([#1560](https://github.com/tyabu12/pastura/issues/1560) C2b), upstream of the run gate on both sides — the Kotlin loader itself still has no caller in `shared/engine`; linter message prep in — `ScenarioLintMessage` Swift + Kotlin mirror ([#1562](https://github.com/tyabu12/pastura/issues/1562) D1a) and `PlaceholderAvailability.kt` ([#1564](https://github.com/tyabu12/pastura/issues/1564) D1b); linter base types + Ordering rules ported as `ScenarioSemanticLinter.kt` ([#1574](https://github.com/tyabu12/pastura/issues/1574) D2a); Config rules R7/R8/R9/R17/R18/R20a/R20b ported and joined into `lint()` ([#1579](https://github.com/tyabu12/pastura/issues/1579) D2b); Placeholders R10/R11/R12 ported and joined ([#1582](https://github.com/tyabu12/pastura/issues/1582) D2c); Conditions R13–R16 ported and joined ([#1587](https://github.com/tyabu12/pastura/issues/1587) D2d) — linter fully ported; **preflight wired** — validator + linter gate `SimulationEngine.run` via `SimulationPreflight.kt`, `VALIDATOR_UNPORTED` retired ([#1591](https://github.com/tyabu12/pastura/issues/1591) D3); `detector`·`logger` injection seams left · [ADR-023](decisions/ADR-023.md) §4 · #501 |
+| Loader / validator port + `detector`·`logger` wiring | ✅ done | validator prerequisites in ([#1464](https://github.com/tyabu12/pastura/issues/1464)); validator fully ported — run gate + commit gate ([#1552](https://github.com/tyabu12/pastura/issues/1552) B1/B2); loader fully ported — YAML ingest + top-level mapping ([#1558](https://github.com/tyabu12/pastura/issues/1558) C2a) then phase specialisation ([#1560](https://github.com/tyabu12/pastura/issues/1560) C2b), upstream of the run gate on both sides — the Kotlin loader itself still has no caller in `shared/engine`; linter message prep in — `ScenarioLintMessage` Swift + Kotlin mirror ([#1562](https://github.com/tyabu12/pastura/issues/1562) D1a) and `PlaceholderAvailability.kt` ([#1564](https://github.com/tyabu12/pastura/issues/1564) D1b); linter base types + Ordering rules ported as `ScenarioSemanticLinter.kt` ([#1574](https://github.com/tyabu12/pastura/issues/1574) D2a); Config rules R7/R8/R9/R17/R18/R20a/R20b ported and joined into `lint()` ([#1579](https://github.com/tyabu12/pastura/issues/1579) D2b); Placeholders R10/R11/R12 ported and joined ([#1582](https://github.com/tyabu12/pastura/issues/1582) D2c); Conditions R13–R16 ported and joined ([#1587](https://github.com/tyabu12/pastura/issues/1587) D2d) — linter fully ported; **preflight wired** — validator + linter gate `SimulationEngine.run` via `SimulationPreflight.kt`, `VALIDATOR_UNPORTED` retired ([#1591](https://github.com/tyabu12/pastura/issues/1591) D3); `detector`·`logger` seams wired via `SimulationEngine(detector:logger:)` ([#1603](https://github.com/tyabu12/pastura/issues/1603)) — Kotlin-side complete; concrete impls remain Stage 5 · [ADR-023](decisions/ADR-023.md) §4 · #501 |
 
 ### Wave B handler checklist
 

--- a/docs/kmp-migration-status.md
+++ b/docs/kmp-migration-status.md
@@ -45,7 +45,7 @@ Legend: ✅ done · 🔄 in progress · 🟡 partial · ⬜ not started.
 | Wave A — non-handler run-path (scoring, mechanisms, prompt/LLM glue) | ✅ done | #1207 #1212 #1217 |
 | Wave B — 14 phase handlers | ✅ 14/14 | checklist ↓ |
 | code-phase track | ✅ done | CP1 #1226 · CP2 #1230 · CP3 #1232 |
-| Loader / validator port + `detector`·`logger` wiring | ✅ done | #1464 #1552 #1558 #1560 #1562 #1564 #1574 #1579 #1582 #1587 #1591 #1603 · [ADR-023](decisions/ADR-023.md) §4 · #501 |
+| Loader / validator port + `detector`·`logger` wiring | ✅ done | #1464 · #1552 (B1/B2) · #1558 (C2a) · #1560 (C2b) · #1562 (D1a) · #1564 (D1b) · #1574 (D2a) · #1579 (D2b) · #1582 (D2c) · #1587 (D2d) · #1591 (D3) · #1603 (seams) · [ADR-023](decisions/ADR-023.md) §4 · #501 |
 
 ### Wave B handler checklist
 

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/EngineLogger.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/EngineLogger.kt
@@ -11,7 +11,7 @@ package com.pastura.engine
  *
  * Swift original: `Pastura/Pastura/Engine/EngineLogger.swift`.
  */
-internal enum class EngineLogLevel {
+public enum class EngineLogLevel {
     DEBUG,
     INFO,
     WARNING,
@@ -25,7 +25,7 @@ internal enum class EngineLogLevel {
  * renders as `<private>` off-device, [PUBLIC] renders verbatim. The Engine
  * classifies each call site; the Swift OSLog adapter applies it.
  */
-internal enum class EngineLogPrivacy {
+public enum class EngineLogPrivacy {
     PUBLIC,
     PRIVATE,
 }
@@ -46,8 +46,18 @@ internal enum class EngineLogPrivacy {
  * an `os.Logger(subsystem:category:)` and applies level + privacy. Callers must
  * NOT pre-redact — they pass the real content and let `privacy` govern
  * off-device exposure.
+ *
+ * **Injectable from the run path**: pass an implementation to
+ * `SimulationEngine(logger = …)` and the runner threads it into every
+ * [PhaseContext]; [NoopEngineLogger] is the default, so the Engine still emits
+ * nothing unless a platform adapter is handed in.
+ *
+ * **A Swift conformer must be declared `nonisolated`.** K/N exports this as an
+ * unannotated Obj-C protocol and [log] is called from `Dispatchers.Default`, so
+ * a default-MainActor conformance compiles clean and traps at runtime — the
+ * `LLMBackend` precedent, `.claude/rules/swift-isolation.md` Pattern 7.
  */
-internal interface EngineLogger {
+public interface EngineLogger {
     /**
      * Emit one diagnostic line.
      *
@@ -59,15 +69,16 @@ internal interface EngineLogger {
      *   governs off-device exposure of the whole line.
      * @param privacy Whether [message] is shown or redacted in Release captures.
      */
-    fun log(level: EngineLogLevel, category: String, message: String, privacy: EngineLogPrivacy)
+    public fun log(level: EngineLogLevel, category: String, message: String, privacy: EngineLogPrivacy)
 }
 
 /**
  * A no-op [EngineLogger] used as the injection default so Engine unit tests and
  * non-App consumers (e.g. the ADR-013 headless harness, which reuses Engine but
- * not App) construct handlers without wiring OSLog. Production injects
- * `OSLogEngineLogger` at the View boundary — see `SimulationView`.
+ * not App) construct handlers without wiring OSLog. It is the default of both
+ * `SimulationEngine(logger = …)` and [PhaseContext.logger]; production injects
+ * `OSLogEngineLogger` at the Swift View boundary — see `SimulationView`.
  */
-internal class NoopEngineLogger : EngineLogger {
+public class NoopEngineLogger : EngineLogger {
     override fun log(level: EngineLogLevel, category: String, message: String, privacy: EngineLogPrivacy) {}
 }

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/LanguageDetector.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/LanguageDetector.kt
@@ -13,13 +13,22 @@ package com.pastura.engine
  * D8, `import NaturalLanguage` is forbidden in Engine / LLM / Models / Data
  * layers — only this abstraction crosses the boundary. The Swift consumer
  * threads a nullable `(any LanguageDetector)?` (nil = skip the check), so there
- * is deliberately **no Noop impl** here; the interface is landed as an unwired
- * seam, mirroring [EngineLogger].
+ * is deliberately **no Noop impl** here; `null` IS the "skip" value, mirroring
+ * [EngineLogger]'s [NoopEngineLogger].
+ *
+ * **Injectable from the run path**: pass an implementation to
+ * `SimulationEngine(detector = …)` and the runner threads it into every
+ * [PhaseContext]; the default `null` keeps the adherence check off.
+ *
+ * **A Swift conformer must be declared `nonisolated`.** K/N exports this as an
+ * unannotated Obj-C protocol and [detect] is called from `Dispatchers.Default`,
+ * so a default-MainActor conformance compiles clean and traps at runtime — the
+ * `LLMBackend` precedent, `.claude/rules/swift-isolation.md` Pattern 7.
  *
  * Swift original: `Pastura/Pastura/LLM/LanguageDetector.swift`.
  * Ported for the ADR-023 §6 Stage-3 Engine migration (#501).
  */
-internal interface LanguageDetector {
+public interface LanguageDetector {
     /**
      * Detect the dominant natural language of [text].
      *
@@ -32,5 +41,5 @@ internal interface LanguageDetector {
      *   threshold. The consumer treats `null` as "skip the adherence check"
      *   rather than "mismatch".
      */
-    fun detect(text: String): String?
+    public fun detect(text: String): String?
 }

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/PhaseHandler.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/PhaseHandler.kt
@@ -13,9 +13,14 @@ import com.pastura.models.SimulationState
  * (CLAUDE.md § Access Modifiers). Kotlin's equivalent concern is the *exported
  * K/N surface*, and this type must not be on it: §5.1 states `pauseCheck` "stays
  * Kotlin-internal (runner -> handler), never crossing", and no Swift code ever
- * implements a [PhaseHandler]. Keeping the handler contract `internal` keeps the
- * boundary to exactly the §5.1/§5.2 types, which is also what gate measurement
- * (iii) — the K/N shim-budget re-measure — is counting. `commonTest` still sees
+ * implements a [PhaseHandler]. Keeping the handler contract `internal` keeps it
+ * off the exported surface, which is what gate measurement (iii) — the K/N
+ * shim-budget re-measure — was counting. The surface is no longer *exactly* the
+ * §5.1/§5.2 types: the two injection seams below, [LanguageDetector] and
+ * [EngineLogger] (plus `EngineLogLevel` / `EngineLogPrivacy` / [NoopEngineLogger]),
+ * are deliberate additions widened to `public` in #1603 so Swift can constructor-
+ * inject them through `SimulationEngine(detector = …, logger = …)`. The handler
+ * contract itself stays off the surface regardless. `commonTest` still sees
  * these (test source sets are associated with `commonMain`).
  *
  * ## Divergences from the Swift original, all deliberate
@@ -33,15 +38,21 @@ import com.pastura.models.SimulationState
  *
  * ## Knowingly absent — remaining named deferral
  *
- * `detector` / `logger` are now fields below — B0b wired their [LLMCaller]
- * consumers (language-adherence retry + the `StreamingDiag` channel). But being a
- * field is not the same as being fed: the sole production constructor —
- * `SimulationEngine`'s `RunLoop`, `SimulationEngine.kt` — still builds this context
- * with the defaults (`detector = null`, `logger = NoopEngineLogger`). So in the
- * real Kotlin run path the adherence check is **dormant** and `StreamingDiag` emits
- * nowhere; threading the real `NLLanguageDetector` + OSLog adapter across the K/N
- * boundary is later Stage-3 freight (#501). Named here, not a silent gap. (The
- * ADR-021 `turnGate`, once one of these, is now fed by the runner — B0a.)
+ * `detector` / `logger` are fields below, their [LLMCaller] consumers wired by B0b
+ * (language-adherence retry + the `StreamingDiag` channel), and **they are now fed
+ * from the run path**: `SimulationEngine(detector = …, logger = …)` threads both
+ * through `RunLoop` into every top-level context (#1603). The defaults
+ * (`detector = null`, `logger = NoopEngineLogger`) remain, so a caller that supplies
+ * neither still gets a dormant adherence check and a `StreamingDiag` channel that
+ * emits nowhere — that is now a property of the *caller*, not of the run path.
+ *
+ * What is still absent is only the concrete platform side: no Kotlin implementation
+ * of either seam exists or will, and the Swift `NLLanguageDetector` + OSLog adapter
+ * are not yet handed across the K/N boundary by any production consumer — the iOS
+ * app does not construct `SimulationEngine` at all yet, so that is Stage-5 freight
+ * (#501). Named here, not a silent gap. A Swift conformer must be `nonisolated`
+ * (each interface's KDoc says why). (The ADR-021 `turnGate`, once one of these, is
+ * now fed by the runner — B0a.)
  *
  * Swift original: `Pastura/Pastura/Engine/PhaseHandler.swift`.
  * Ported for the ADR-023 §6 Stage-2 gate slice (#501).

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/PhaseHandler.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/PhaseHandler.kt
@@ -109,15 +109,16 @@ internal class PhaseContext(
     val turnGate: TurnFailureGate,
     /**
      * Optional language-of-output detector for the ADR-010 Step E adherence check
-     * (see [LLMCaller.call]). `null` = skip the check — the seam is unwired in the
-     * Kotlin run path today (see § "Knowingly absent"), and the concrete
-     * `NLLanguageDetector` stays Swift App-side per ADR-010 D8. Defaulted so
-     * construction sites that don't feed it stay unchanged.
+     * (see [LLMCaller.call]). `null` = skip the check. Fed from the run path by
+     * `SimulationEngine(detector = …)`; the concrete `NLLanguageDetector` stays
+     * Swift App-side per ADR-010 D8. Defaulted so construction sites that don't
+     * feed it stay unchanged.
      */
     val detector: LanguageDetector? = null,
     /**
-     * Diagnostic seam threaded to [LLMCaller] (the `StreamingDiag` channel). The
-     * concrete `OSLogEngineLogger` stays Swift App-side; [NoopEngineLogger] is the
+     * Diagnostic seam threaded to [LLMCaller] (the `StreamingDiag` channel). Fed
+     * from the run path by `SimulationEngine(logger = …)`; the concrete
+     * `OSLogEngineLogger` stays Swift App-side; [NoopEngineLogger] is the
      * default so the Engine stays OSLog-free and non-App consumers (tests, the
      * ADR-013 harness) need no wiring. Defaulted for the same construction-site
      * reason as [detector].

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/Phases/ChooseHandler.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/Phases/ChooseHandler.kt
@@ -227,7 +227,8 @@ internal class ChooseHandler : PhaseHandler {
         succeeded: Set<String>,
     ): ChooseTurn {
         // Constructed per turn, matching Swift — a stateless value, cheap. The logger
-        // seam is threaded from the context (Noop by default in the current run path).
+        // seam is threaded from the context — whatever SimulationEngine(logger:) was
+        // given, Noop by default.
         val llmCaller = LLMCaller(logger = context.logger)
 
         val systemPrompt = promptBuilder.buildSystemPrompt(

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/Phases/ChooseHandler.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/Phases/ChooseHandler.kt
@@ -228,7 +228,7 @@ internal class ChooseHandler : PhaseHandler {
     ): ChooseTurn {
         // Constructed per turn, matching Swift — a stateless value, cheap. The logger
         // seam is threaded from the context — whatever SimulationEngine(logger:) was
-        // given, Noop by default.
+        // given, Noop by default (see PhaseContext § "Knowingly absent").
         val llmCaller = LLMCaller(logger = context.logger)
 
         val systemPrompt = promptBuilder.buildSystemPrompt(

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/Phases/ReflectHandler.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/Phases/ReflectHandler.kt
@@ -71,8 +71,9 @@ internal class ReflectHandler : PhaseHandler {
         state: SimulationState,
     ): SimulationState {
         // Constructed per turn, matching Swift — a stateless value, cheap. The
-        // logger seam is threaded from the context (Noop by default in the current
-        // run path — see PhaseContext § "Knowingly absent").
+        // logger seam is threaded from the context — whatever
+        // SimulationEngine(logger:) was given, Noop by default (see PhaseContext §
+        // "Knowingly absent").
         val llmCaller = LLMCaller(logger = context.logger)
 
         val systemPrompt = promptBuilder.buildSystemPrompt(

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/Phases/SpeakAllHandler.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/Phases/SpeakAllHandler.kt
@@ -70,8 +70,9 @@ internal class SpeakAllHandler : PhaseHandler {
         state: SimulationState,
     ): SimulationState {
         // Constructed per turn, matching Swift — a stateless value, cheap. The
-        // logger seam is threaded from the context (Noop by default in the current
-        // run path — see PhaseContext § "Knowingly absent").
+        // logger seam is threaded from the context — whatever
+        // SimulationEngine(logger:) was given, Noop by default (see PhaseContext §
+        // "Knowingly absent").
         val llmCaller = LLMCaller(logger = context.logger)
 
         val systemPrompt = promptBuilder.buildSystemPrompt(

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/Phases/VoteHandler.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/Phases/VoteHandler.kt
@@ -116,8 +116,8 @@ internal class VoteHandler : PhaseHandler {
         state: SimulationState,
     ): VoteTurn {
         // Constructed per turn, matching Swift — a stateless value, cheap. The logger
-        // seam is threaded from the context (Noop by default in the current run
-        // path — see PhaseContext § "Knowingly absent").
+        // seam is threaded from the context — whatever SimulationEngine(logger:) was
+        // given, Noop by default (see PhaseContext § "Knowingly absent").
         val llmCaller = LLMCaller(logger = context.logger)
 
         val systemPrompt = promptBuilder.buildSystemPrompt(

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/Phases/WhisperHandler.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/Phases/WhisperHandler.kt
@@ -202,7 +202,8 @@ internal class WhisperHandler : PhaseHandler {
     ): TurnOutput? {
         val language = context.scenario.engineLanguage
         // Constructed per turn, matching Swift — a stateless value, cheap. The logger
-        // seam is threaded from the context (Noop by default in the current run path).
+        // seam is threaded from the context — whatever SimulationEngine(logger:) was
+        // given, Noop by default.
         val llmCaller = LLMCaller(logger = context.logger)
 
         val systemPrompt = promptBuilder.buildSystemPrompt(

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/Phases/WhisperHandler.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/Phases/WhisperHandler.kt
@@ -203,7 +203,7 @@ internal class WhisperHandler : PhaseHandler {
         val language = context.scenario.engineLanguage
         // Constructed per turn, matching Swift — a stateless value, cheap. The logger
         // seam is threaded from the context — whatever SimulationEngine(logger:) was
-        // given, Noop by default.
+        // given, Noop by default (see PhaseContext § "Knowingly absent").
         val llmCaller = LLMCaller(logger = context.logger)
 
         val systemPrompt = promptBuilder.buildSystemPrompt(

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/SimulationEngine.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/SimulationEngine.kt
@@ -22,6 +22,8 @@ import kotlinx.coroutines.launch
  * ```kotlin
  * val handle = SimulationEngine().run(scenario, backend) { event -> /* … */ }
  * handle.pause(); handle.resume(); handle.cancel(); handle.notifyLLMResumed()
+ * // Swift: SimulationEngine(detector: nil, logger: NoopEngineLogger())
+ * //        — K/N exports no default arguments, so there is no no-arg init.
  * ```
  *
  * **Plain function + callback, no suspend/Flow** (ADR-023 Decision 2). [run]

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/SimulationEngine.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/SimulationEngine.kt
@@ -44,11 +44,26 @@ import kotlinx.coroutines.launch
  * |---|---|
  * | ~~`ScenarioValidator` preflight + `ScenarioSemanticLinter` (ADR-024)~~ | **No longer absent — wired by D3 (#1591).** Both halves land together, as §4's `Load + validate` row requires; see [preflightGate], called below before the round loop starts. |
  * | Resume (`resumingFrom` seed / `startRound`) | needs the Data layer's persisted state; D2 keeps Data in Swift |
- * | `LanguageDetector` / `EngineLogger` injection | injection is Stage-3 freight — absent from `PhaseContext`. §4 ports both **seams only** (`LanguageDetector` in PR-3, `EngineLogger` in PR-2); the concrete `OSLogEngineLogger` / `NLLanguageDetector` stay in Swift App/ |
+ * | ~~`LanguageDetector` / `EngineLogger` injection~~ | **No longer absent — both are constructor parameters below**, threaded through `RunLoop` into every [PhaseContext]. Only the concrete `OSLogEngineLogger` / `NLLanguageDetector` stay in Swift App/, as §4 intends; a Swift conformer must be `nonisolated` (see each interface's KDoc) |
  *
  * Swift original: `Pastura/Pastura/Engine/SimulationRunner.swift`.
+ *
+ * @property detector Optional language-of-output detector for the ADR-010 Step E
+ *   adherence check. When supplied alongside a `Scenario.engineLanguage`,
+ *   [LLMCaller] retries on language drift inside its existing budget and emits
+ *   `SimulationEvent.LanguageMismatch` on exhaustion. `null` (the default)
+ *   disables the check, so callers that do not feed it keep their pre-Step-E
+ *   behaviour. The concrete impl (`NLLanguageDetector`) stays Swift App-side per
+ *   ADR-010 D8.
+ * @property logger Diagnostic seam forwarded to every [PhaseContext] and from
+ *   there to [LLMCaller] (the `StreamingDiag` channel). Defaults to
+ *   [NoopEngineLogger] so Engine tests and the ADR-013 harness run without
+ *   wiring OSLog; production injects the Swift `OSLogEngineLogger`.
  */
-public class SimulationEngine {
+public class SimulationEngine(
+    private val detector: LanguageDetector? = null,
+    private val logger: EngineLogger = NoopEngineLogger(),
+) {
 
     // Swift's `SimulationRunner.validator`. A stateless value, held as a property
     // for parity with the Swift original rather than out of necessity.
@@ -86,7 +101,7 @@ public class SimulationEngine {
                 // run is emitted, so `run()` still returns its handle immediately
                 // and a rejection arrives via `onEvent` like any other error.
                 if (!preflightGate(scenario, validator, onEvent)) return@launch
-                RunLoop(scenario, backend, relay, gate, onEvent).execute()
+                RunLoop(scenario, backend, relay, gate, onEvent, detector, logger).execute()
             } catch (e: CancellationException) {
                 // Swift's runner checks `Task.isCancelled` at each checkpoint and
                 // emits `.error(.cancelled)`. Kotlin's idiomatic equivalent throws,
@@ -211,6 +226,11 @@ private class RunLoop(
     private val relay: SuspensionRelay,
     private val gate: PauseGate,
     private val onEvent: (SimulationEvent) -> Unit,
+    // Injection seams, run-scoped: fed straight into every PhaseContext below so
+    // the top-level construction site is the ONE place they are supplied. See
+    // SimulationEngine's constructor KDoc.
+    private val detector: LanguageDetector?,
+    private val logger: EngineLogger,
 ) {
 
     private val dispatcher = PhaseDispatcher()
@@ -284,6 +304,8 @@ private class RunLoop(
                         pauseCheck = { nested -> checkPaused(round, nested) },
                         phasePath = phasePath,
                         turnGate = turnGate,
+                        detector = detector,
+                        logger = logger,
                     ),
                     state = state,
                 )

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/ConditionalHandlerTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/ConditionalHandlerTests.kt
@@ -195,6 +195,9 @@ class ConditionalHandlerTests {
     private fun summaries(events: List<SimulationEvent>) =
         events.filterIsInstance<SimulationEvent.Summary>()
 
+    // Deliberately NOT the shared doubles in SeamTestSupport.kt: this suite drives
+    // the handler directly on runTest's single thread, so the unsynchronized shape
+    // is safe and the nested names shadow the package-scope ones on purpose.
     private class SpyLanguageDetector(private val canned: String?) : LanguageDetector {
         val recorded = mutableListOf<String>()
         override fun detect(text: String): String? {

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/DivergenceLedger.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/DivergenceLedger.kt
@@ -83,11 +83,18 @@ internal object DivergenceLedger {
         // licence a later author can attach to with no enum diff at all.
 
         /**
-         * The ADR-010 language-adherence retry is dormant on the Kotlin side:
-         * `SimulationEngine` wires no detector, so `languageMismatch` events
-         * reach the Swift transcript alone.
+         * The ADR-010 language-adherence retry is dormant on the Kotlin side
+         * **of the parity harness**. `SimulationEngine` can be fed a detector
+         * since #1603 (`SimulationEngine(detector = …)`), but the parity harness
+         * constructs `SimulationEngine()` with no detector, so `languageMismatch`
+         * events reach the Swift transcript alone. Retiring this requires feeding
+         * a scripted detector through the parity fixtures — a Stage-4 fixture
+         * change, deliberately not #1603.
          */
-        DETECTOR_UNWIRED("SimulationEngine.kt class KDoc; ADR-023 §4"),
+        DETECTOR_UNINJECTED(
+            "SimulationEngine.kt class KDoc § Knowingly absent (the struck-through " +
+                "`LanguageDetector` / `EngineLogger` injection row); ADR-023 §4",
+        ),
 
         /**
          * The preflight linter's D2d conditions group carries two stated
@@ -321,7 +328,7 @@ internal object DivergenceLedger {
     internal val unreachableClasses: Map<DivergenceClass, String> = mapOf(
         DivergenceClass.CANCELLATION_EVENT_TAIL to
             "needs a mid-run cancellation `ParityFixtureEmitter` never performs (ADR-023 S4)",
-        DivergenceClass.DETECTOR_UNWIRED to
+        DivergenceClass.DETECTOR_UNINJECTED to
             "the emitter deliberately injects no detector — a real one wraps " +
             "NLLanguageRecognizer and would make the golden vary by host " +
             "(`parityRunEmitsNoLanguageMismatch` guards the omission)",

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/EngineLoggerSeamTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/EngineLoggerSeamTests.kt
@@ -6,12 +6,13 @@ import kotlin.test.assertEquals
 /**
  * Seam-shape parity spec for [EngineLogger] / [NoopEngineLogger].
  *
- * Behavioral parity is deferred to Wave B: the Swift behavioral tests drive
- * `LLMCaller(logger:)` consumption and the unported `OSLogEngineLogger`, but
- * Kotlin `LLMCaller` does not consume the seam yet (ADR-023 §12 condition-2 seam
- * carve-out, PR0-b precedent). This spec asserts only the seam's shape: the
- * interface records what it is handed, the Noop swallows every combination, and
- * the enum case-sets stay complete.
+ * Behavioral parity is deferred to Wave B: the Swift behavioral tests drive the
+ * unported `OSLogEngineLogger`. Kotlin `LLMCaller` does consume the seam
+ * (`LLMCaller(logger:)`, B0b), and `SimulationEngine(logger = …)` now threads it
+ * through `RunLoop` into every top-level [PhaseContext] (#1603, pinned end-to-end
+ * by [SimulationEngineSeamInjectionTests]). This spec asserts only the seam's
+ * shape: the interface records what it is handed, the Noop swallows every
+ * combination, and the enum case-sets stay complete.
  */
 class EngineLoggerSeamTests {
 

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/EngineLoggerSeamTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/EngineLoggerSeamTests.kt
@@ -8,7 +8,7 @@ import kotlin.test.assertEquals
  *
  * Behavioral parity is deferred to Wave B: the Swift behavioral tests drive the
  * unported `OSLogEngineLogger`. Kotlin `LLMCaller` does consume the seam
- * (`LLMCaller(logger:)`, B0b), and `SimulationEngine(logger = …)` now threads it
+ * (`LLMCaller(logger = …)`, B0b), and `SimulationEngine(logger = …)` now threads it
  * through `RunLoop` into every top-level [PhaseContext] (#1603, pinned end-to-end
  * by [SimulationEngineSeamInjectionTests]). This spec asserts only the seam's
  * shape: the interface records what it is handed, the Noop swallows every
@@ -16,26 +16,12 @@ import kotlin.test.assertEquals
  */
 class EngineLoggerSeamTests {
 
-    private data class Entry(
-        val level: EngineLogLevel,
-        val category: String,
-        val message: String,
-        val privacy: EngineLogPrivacy,
-    )
-
-    private class SpyEngineLogger : EngineLogger {
-        val entries = mutableListOf<Entry>()
-        override fun log(level: EngineLogLevel, category: String, message: String, privacy: EngineLogPrivacy) {
-            entries.add(Entry(level, category, message, privacy))
-        }
-    }
-
     @Test
     fun loggerRecordsWhatItIsHanded() {
         val spy = SpyEngineLogger()
         spy.log(EngineLogLevel.WARNING, "StreamingDiag", "boom", EngineLogPrivacy.PUBLIC)
         assertEquals(
-            Entry(EngineLogLevel.WARNING, "StreamingDiag", "boom", EngineLogPrivacy.PUBLIC),
+            SpyEngineLogger.Entry(EngineLogLevel.WARNING, "StreamingDiag", "boom", EngineLogPrivacy.PUBLIC),
             spy.entries.single(),
         )
     }

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/LLMCallerLanguageAdherenceTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/LLMCallerLanguageAdherenceTests.kt
@@ -26,41 +26,15 @@ import kotlin.test.assertTrue
  * - Schema-aware carve-out: author-defined [OutputSchema.Kind.Choice] fields are
  *   excluded from the detection input.
  *
- * The `SpyEngineLogger` assertions defend the `StreamingDiag` **wire format** the
- * external `scripts/analyze-streaming-diag.sh` parses — the full rendered line, not
- * a substring, so a field-order or `attempt`-index regression fails here.
+ * The [SpyEngineLogger] / [SequencedDetector] doubles are shared, at package
+ * scope, with the other seam suites — see `SeamTestSupport.kt`. The spy's
+ * assertions defend the `StreamingDiag` **wire format** the external
+ * `scripts/analyze-streaming-diag.sh` parses — the full rendered line, not a
+ * substring, so a field-order or `attempt`-index regression fails here.
  *
  * Ported for the ADR-023 §6 Stage-3 Engine migration (#501, B0b).
  */
 class LLMCallerLanguageAdherenceTests {
-
-    /**
-     * A [LanguageDetector] whose verdict is a queue drained one entry per call;
-     * returns null when empty. Mirrors Swift's `StubLanguageDetector`.
-     */
-    private class StubLanguageDetector(verdicts: List<String?>) : LanguageDetector {
-        private val queue = verdicts.toMutableList()
-        override fun detect(text: String): String? =
-            if (queue.isEmpty()) null else queue.removeAt(0)
-    }
-
-    /** Records every rendered log line so tests can assert the wire format exactly. */
-    private class SpyEngineLogger : EngineLogger {
-        data class Entry(
-            val level: EngineLogLevel,
-            val category: String,
-            val message: String,
-            val privacy: EngineLogPrivacy,
-        )
-
-        val entries = mutableListOf<Entry>()
-        override fun log(level: EngineLogLevel, category: String, message: String, privacy: EngineLogPrivacy) {
-            entries += Entry(level, category, message, privacy)
-        }
-
-        /** Rendered messages emitted on the `StreamingDiag` channel, in order. */
-        fun diagLines(): List<String> = entries.filter { it.category == "StreamingDiag" }.map { it.message }
-    }
 
     private fun speakAllSchema() =
         OutputSchema(listOf(OutputSchema.Field("statement", OutputSchema.Kind.StringKind)))
@@ -107,7 +81,7 @@ class LLMCallerLanguageAdherenceTests {
         val spy = SpyEngineLogger()
         val result = call(
             backend,
-            detector = StubLanguageDetector(listOf("ja", "en")),
+            detector = SequencedDetector(listOf("ja", "en")),
             expectedLanguage = "en",
             logger = spy,
             events = events,
@@ -135,7 +109,7 @@ class LLMCallerLanguageAdherenceTests {
         val events = mutableListOf<SimulationEvent>()
         val result = call(
             backend,
-            detector = StubLanguageDetector(listOf("ja", "ja", "ja")),
+            detector = SequencedDetector(listOf("ja", "ja", "ja")),
             expectedLanguage = "en",
             events = events,
         )
@@ -157,7 +131,7 @@ class LLMCallerLanguageAdherenceTests {
         val backend = ScriptedLLMBackend(
             listOf(says("""{"statement": "some ambiguous output that the detector cannot classify"}""")),
         )
-        val result = call(backend, detector = StubLanguageDetector(listOf(null)), expectedLanguage = "en")
+        val result = call(backend, detector = SequencedDetector(listOf(null)), expectedLanguage = "en")
         assertTrue(result.fields["statement"]?.contains("ambiguous") ?: false)
         assertEquals(1, backend.callCount, "detector null → no retry")
     }
@@ -168,7 +142,7 @@ class LLMCallerLanguageAdherenceTests {
         val backend = ScriptedLLMBackend(
             listOf(says("""{"statement": "ja statement that would normally be flagged as wrong"}""")),
         )
-        call(backend, detector = StubLanguageDetector(listOf("ja")), expectedLanguage = null)
+        call(backend, detector = SequencedDetector(listOf("ja")), expectedLanguage = null)
         assertEquals(1, backend.callCount)
     }
 
@@ -191,7 +165,7 @@ class LLMCallerLanguageAdherenceTests {
         val spy = SpyEngineLogger()
         val result = call(
             backend,
-            detector = StubLanguageDetector(listOf("ja")),
+            detector = SequencedDetector(listOf("ja")),
             expectedLanguage = "en",
             schema = voteSchema,
             logger = spy,
@@ -232,7 +206,7 @@ class LLMCallerLanguageAdherenceTests {
         )
         val result = call(
             backend,
-            detector = StubLanguageDetector(listOf("en")),
+            detector = SequencedDetector(listOf("en")),
             expectedLanguage = "en",
             schema = schema,
             events = events,
@@ -255,7 +229,7 @@ class LLMCallerLanguageAdherenceTests {
         // queue + callCount==1 proves it is NOT asked.
         val result = call(
             backend,
-            detector = StubLanguageDetector(emptyList()),
+            detector = SequencedDetector(emptyList()),
             expectedLanguage = "ja",
             schema = chooseSchemaWithChoiceField(),
         )
@@ -279,7 +253,7 @@ class LLMCallerLanguageAdherenceTests {
         val backend = ScriptedLLMBackend(listOf(says("""{"action": "$longAction"}""")))
         val result = call(
             backend,
-            detector = StubLanguageDetector(listOf("en")),
+            detector = SequencedDetector(listOf("en")),
             expectedLanguage = "ja",
             schema = chooseSchemaWithChoiceField(),
         )

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/LanguageDetectorSeamTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/LanguageDetectorSeamTests.kt
@@ -7,8 +7,10 @@ import kotlin.test.assertEquals
  * Seam-shape parity spec for [LanguageDetector].
  *
  * Behavioral parity is deferred: the Swift behavioral coverage drives
- * `NLLanguageDetector` + `LLMCaller` consumption, but no Kotlin consumer
- * threads the seam yet (unwired-seam precedent, cf. [EngineLogger]). This spec
+ * `NLLanguageDetector` + `LLMCaller` consumption, and the run path now threads
+ * `SimulationEngine(detector = …)` through to every [PhaseContext] (#1603,
+ * pinned end-to-end by [SimulationEngineSeamInjectionTests]) — but no Kotlin
+ * implementation of the detector exists yet, cf. [EngineLogger]. This spec
  * asserts only the seam's shape via a test-local spy: the interface records the
  * text it is handed and returns whatever the implementation is told to return.
  */

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/SeamTestSupport.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/SeamTestSupport.kt
@@ -1,0 +1,63 @@
+package com.pastura.engine
+
+import kotlin.concurrent.atomics.AtomicReference
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
+import kotlin.concurrent.atomics.fetchAndUpdate
+import kotlin.concurrent.atomics.update
+
+/**
+ * Test doubles for the ADR-023 §4 [LanguageDetector] / [EngineLogger] injection
+ * seams.
+ *
+ * At package scope, not nested in one suite, for [Collector]'s reason:
+ * [EngineLoggerSeamTests], [LLMCallerLanguageAdherenceTests] and
+ * [SimulationEngineSeamInjectionTests] all need these, and three copies of a
+ * primitive whose whole point is cross-thread safety would drift — and the
+ * drift would present as a flake on the Kotlin/Native rung only.
+ */
+
+/**
+ * Thread-safe spy [EngineLogger] recording every line it is handed.
+ *
+ * **The atomic is load-bearing for the same reason [Collector]'s is**: a run
+ * started from [SimulationEngine] logs from its `Dispatchers.Default` worker
+ * context while the test body reads from `runBlockingTest`'s thread, and on
+ * Kotlin/Native an unsynchronized list across that edge is undefined behaviour
+ * rather than a stale read. Suites that drive [LLMCaller] directly on one
+ * thread pay only an allocation per line for it.
+ */
+@OptIn(ExperimentalAtomicApi::class)
+internal class SpyEngineLogger : EngineLogger {
+    data class Entry(
+        val level: EngineLogLevel,
+        val category: String,
+        val message: String,
+        val privacy: EngineLogPrivacy,
+    )
+
+    private val ref = AtomicReference<List<Entry>>(emptyList())
+
+    override fun log(level: EngineLogLevel, category: String, message: String, privacy: EngineLogPrivacy) {
+        ref.update { it + Entry(level, category, message, privacy) }
+    }
+
+    val entries: List<Entry> get() = ref.load()
+
+    /** Rendered messages emitted on the `StreamingDiag` channel, in order. */
+    fun diagLines(): List<String> = entries.filter { it.category == "StreamingDiag" }.map { it.message }
+}
+
+/**
+ * [LanguageDetector] whose verdicts are a queue drained one entry per call,
+ * returning `null` once empty. Mirrors Swift's `StubLanguageDetector`.
+ *
+ * Atomic for the same cross-thread reason as [SpyEngineLogger] — under a
+ * through-runner test the calls themselves land on the worker context.
+ */
+@OptIn(ExperimentalAtomicApi::class)
+internal class SequencedDetector(verdicts: List<String?>) : LanguageDetector {
+    private val queue = AtomicReference(verdicts)
+
+    override fun detect(text: String): String? =
+        queue.fetchAndUpdate { it.drop(1) }.firstOrNull()
+}

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/SeamTestSupport.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/SeamTestSupport.kt
@@ -5,16 +5,12 @@ import kotlin.concurrent.atomics.ExperimentalAtomicApi
 import kotlin.concurrent.atomics.fetchAndUpdate
 import kotlin.concurrent.atomics.update
 
-/**
- * Test doubles for the ADR-023 §4 [LanguageDetector] / [EngineLogger] injection
- * seams.
- *
- * At package scope, not nested in one suite, for [Collector]'s reason:
- * [EngineLoggerSeamTests], [LLMCallerLanguageAdherenceTests] and
- * [SimulationEngineSeamInjectionTests] all need these, and three copies of a
- * primitive whose whole point is cross-thread safety would drift — and the
- * drift would present as a flake on the Kotlin/Native rung only.
- */
+// Test doubles for the ADR-023 §4 LanguageDetector / EngineLogger injection
+// seams. At package scope, not nested in one suite, for Collector's reason:
+// EngineLoggerSeamTests, LLMCallerLanguageAdherenceTests and
+// SimulationEngineSeamInjectionTests all need these, and three copies of a
+// primitive whose whole point is cross-thread safety would drift — and the
+// drift would present as a flake on the Kotlin/Native rung only.
 
 /**
  * Thread-safe spy [EngineLogger] recording every line it is handed.

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/SimulationEngineSeamInjectionTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/SimulationEngineSeamInjectionTests.kt
@@ -5,8 +5,6 @@ import com.pastura.models.Phase
 import com.pastura.models.PhaseType
 import com.pastura.models.Scenario
 import com.pastura.models.SimulationEvent
-import kotlin.concurrent.atomics.AtomicReference
-import kotlin.concurrent.atomics.ExperimentalAtomicApi
 import kotlin.test.Test
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
@@ -15,7 +13,8 @@ import kotlin.test.assertTrue
 /**
  * Through-runner reach pins for the [LanguageDetector] / [EngineLogger]
  * injection seams: `SimulationEngine(detector = …, logger = …)` → `RunLoop` →
- * the top-level [PhaseContext] → handler → [LLMCaller].
+ * the top-level [PhaseContext] → handler → [LLMCaller], and on into the nested
+ * [PhaseContext] a `conditional` branch builds.
  *
  * ## Why these are distinct from the existing seam suites
  *
@@ -24,13 +23,17 @@ import kotlin.test.assertTrue
  * hand-built argument list. Both stay green against a runner that constructs
  * its contexts with the defaults — which is exactly what `RunLoop` did before
  * this PR. Only a run started from [SimulationEngine] witnesses the wiring.
+ * [ConditionalHandlerTests] does pin the nested sub-context, but from a
+ * hand-built parent [PhaseContext]; only [injectedDetectorReachesANestedPhase]
+ * proves the whole chain from the constructor down.
  *
  * Kotlin twin of Swift's
- * `EngineLoggerSeamTests.runnerInjectedLoggerReachesTheRunPath` and
+ * `EngineLoggerSeamTests.runnerInjectedLoggerReachesTheRunPath`,
  * `SimulationRunnerTests+LanguageMismatch.runnerEmitsLanguageMismatchEventWhenDetectorConfigured`
+ * and `SimulationRunnerTests+LanguageMismatch.runnerWithoutDetectorSkipsAdherenceCheck`
  * (the D2d Swift-pin-then-Kotlin-twin pairing).
  *
- * Real threads, not `runTest` — see [RunBlockingTest][runBlockingTest] and
+ * Real threads, not `runTest` — see [runBlockingTest] and
  * [SimulationEngineTests]' KDoc: [SimulationEngine.run] owns its own
  * `Dispatchers.Default` scope, so a virtual scheduler would measure the
  * scheduler rather than the engine.
@@ -42,14 +45,27 @@ import kotlin.test.assertTrue
  * | a | drop `detector = detector` from `RunLoop`'s top-level `PhaseContext(…)` | [injectedDetectorReachesTheRunPath] |
  * | b | drop `logger = logger` from the same construction site | [injectedLoggerReachesTheRunPath] |
  * | c | thread `NoopEngineLogger()` into `RunLoop` instead of the ctor's `logger` | [injectedLoggerReachesTheRunPath] |
+ * | d | drop `detector = context.detector` from `ConditionalHandler`'s sub-context | [injectedDetectorReachesANestedPhase] |
+ * | e | give `SimulationEngine.detector` a non-null always-`"ja"` default | [defaultConstructorSkipsAdherenceCheck] |
+ *
+ * Row e is what keeps the back-compat pin from being a negative assertion that
+ * nothing can falsify: it is the only mutation that turns the default
+ * constructor's seams *on*.
  *
  * Ported for the ADR-023 §6 Stage-3 Engine migration (#501).
  */
 class SimulationEngineSeamInjectionTests {
 
+    private fun speakAll() = Phase(
+        type = PhaseType.SPEAK_ALL,
+        prompt = "Speak.",
+        outputSchema = mapOf("statement" to "string"),
+    )
+
     private fun scenario(
         agents: List<String> = listOf("Alice", "Bob"),
         language: String = "en",
+        phases: List<Phase> = listOf(speakAll()),
     ) = Scenario(
         id = "t",
         name = "T",
@@ -59,75 +75,28 @@ class SimulationEngineSeamInjectionTests {
         rounds = 1,
         context = "A test.",
         personas = agents.map { Persona(name = it, description = "$it's persona.") },
-        phases = listOf(
-            Phase(type = PhaseType.SPEAK_ALL, prompt = "Speak.", outputSchema = mapOf("statement" to "string")),
-        ),
+        phases = phases,
     )
 
     private fun says(text: String) =
         ScriptedLLMBackend.Script.completing("""{"statement": "$text"}""")
 
-    /**
-     * Thread-safe spy logger.
-     *
-     * The atomics are load-bearing for the same reason [Collector]'s are: the
-     * engine logs from its worker context while the test body reads from
-     * `runBlockingTest`'s thread, and on Kotlin/Native an unsynchronized list
-     * across that edge is undefined behaviour rather than a stale read.
-     */
-    @OptIn(ExperimentalAtomicApi::class)
-    private class SpyEngineLogger : EngineLogger {
-        data class Entry(
-            val level: EngineLogLevel,
-            val category: String,
-            val message: String,
-            val privacy: EngineLogPrivacy,
-        )
-
-        private val ref = AtomicReference<List<Entry>>(emptyList())
-
-        override fun log(level: EngineLogLevel, category: String, message: String, privacy: EngineLogPrivacy) {
-            val entry = Entry(level, category, message, privacy)
-            while (true) {
-                val current = ref.load()
-                if (ref.compareAndSet(current, current + entry)) return
-            }
-        }
-
-        val entries: List<Entry> get() = ref.load()
-
-        /** Rendered messages emitted on the `StreamingDiag` channel, in order. */
-        fun diagLines(): List<String> = entries.filter { it.category == "StreamingDiag" }.map { it.message }
-    }
-
-    /**
-     * Detector whose verdicts are a queue drained one entry per call, returning
-     * `null` once empty. Atomic for the same cross-thread reason as
-     * [SpyEngineLogger] — here the calls themselves land on the worker context.
-     */
-    @OptIn(ExperimentalAtomicApi::class)
-    private class SequencedDetector(verdicts: List<String?>) : LanguageDetector {
-        private val queue = AtomicReference(verdicts)
-
-        override fun detect(text: String): String? {
-            while (true) {
-                val current = queue.load()
-                if (current.isEmpty()) return null
-                if (queue.compareAndSet(current, current.drop(1))) return current.first()
-            }
-        }
-    }
-
     @Test
     fun injectedLoggerReachesTheRunPath() = runBlockingTest {
-        // Alice's attempt 1 is unparseable → exactly one `retryCause … parse_failed`
-        // line; attempt 2 and Bob's single attempt succeed. The full rendered line is
-        // asserted because scripts/analyze-streaming-diag.sh parses that wire format.
+        // Alice's attempt 1 is unparseable → a `retryCause … parse_failed` line;
+        // attempt 2 and Bob's single attempt succeed. The full rendered line is
+        // asserted because scripts/analyze-streaming-diag.sh parses that wire format
+        // (containment, not "exactly one" — the Swift twin is the same shape).
+        //
+        // One spare script beyond the 3 the run consumes: a retry-budget regression
+        // must redden on the assertion below, not on ScriptedLLMBackend exhausting
+        // first (kmp-interop.md § "exhaustion is a harness fault").
         val backend = ScriptedLLMBackend(
             listOf(
                 ScriptedLLMBackend.Script.completing("not json at all"),
                 says("a"),
                 says("b"),
+                says("spare"),
             ),
         )
         val spy = SpyEngineLogger()
@@ -150,10 +119,13 @@ class SimulationEngineSeamInjectionTests {
         // "en" verdict passes on attempt 1, proving one agent's exhaustion does not
         // poison the next. Twin of Swift's
         // runnerEmitsLanguageMismatchEventWhenDetectorConfigured.
+        //
+        // 5 scripts for 4 expected calls: the spare keeps the callCount assertion
+        // below the detector of a retry-budget regression.
         val wrong = "ja-language statement that is long enough to pass the detector gate"
         val right = "en-language statement that is long enough to pass the detector gate"
         val backend = ScriptedLLMBackend(
-            listOf(says(wrong), says(wrong), says(wrong), says(right)),
+            listOf(says(wrong), says(wrong), says(wrong), says(right), says(right)),
         )
         val c = Collector()
 
@@ -178,13 +150,60 @@ class SimulationEngineSeamInjectionTests {
     }
 
     @Test
-    fun defaultsLeaveBothSeamsOff() {
+    fun injectedDetectorReachesANestedPhase() = runBlockingTest {
+        // Same exhaustion shape, but the `speak_all` sits inside a `conditional`
+        // branch, so the detector must survive the SECOND context construction —
+        // ConditionalHandler's sub-context. `detector` is DEFAULTED on PhaseContext,
+        // so dropping it there compiles clean and unwires nested phases only; the
+        // top-level pins above stay green. One spare script, as above.
+        //
+        // Two agents, not one: `RunLoop` ends a round early once fewer than two
+        // agents are active, so a single-agent scenario never reaches the branch.
+        // Alice burns the 3 "ja" verdicts; Bob's call finds the queue empty →
+        // `null` → check skipped, so the mismatch count stays 1.
+        val wrong = "ja-language statement that is long enough to pass the detector gate"
+        val backend = ScriptedLLMBackend(
+            listOf(says(wrong), says(wrong), says(wrong), says(wrong), says(wrong)),
+        )
+        val nested = scenario(
+            phases = listOf(
+                Phase(
+                    type = PhaseType.CONDITIONAL,
+                    condition = "1 == 1",
+                    thenPhases = listOf(speakAll()),
+                ),
+            ),
+        )
+        val c = Collector()
+
+        SimulationEngine(detector = SequencedDetector(listOf("ja", "ja", "ja")))
+            .run(nested, backend) { c.record(it) }
+        awaitTerminal(c)
+
+        val events = c.snapshot()
+        val mismatches = events.filterIsInstance<SimulationEvent.LanguageMismatch>()
+        assertEquals(1, mismatches.size, "the nested PhaseContext must carry the detector")
+        assertEquals("Alice", mismatches.single().agent)
+        // The sub-phase really did run nested: its path is [0, 0], not [0].
+        assertTrue(
+            events.filterIsInstance<SimulationEvent.PhaseStarted>()
+                .any { it.phaseType == PhaseType.SPEAK_ALL && it.phasePath == listOf(0, 0) },
+            "the speak_all must have executed as a conditional sub-phase",
+        )
+        assertTrue(events.any { it is SimulationEvent.SimulationCompleted })
+    }
+
+    @Test
+    fun defaultConstructorSkipsAdherenceCheck() {
         // Back-compat pin: the no-argument constructor must keep the pre-wiring
-        // behaviour — no detector (no adherence check, hence no retry on
-        // wrong-language output) and a silent logger.
+        // behaviour — no detector, hence no adherence check and no retry on
+        // wrong-language output. The default logger is unobservable by
+        // construction (NoopEngineLogger records nothing), so only the detector
+        // half is assertable here; perturbation row e is what gives this negative
+        // pin something that can falsify it.
         runBlockingTest {
             val wrong = "ja-language statement that is long enough to pass the detector gate"
-            val backend = ScriptedLLMBackend(listOf(says(wrong), says(wrong)))
+            val backend = ScriptedLLMBackend(listOf(says(wrong), says(wrong), says(wrong)))
             val c = Collector()
 
             SimulationEngine().run(scenario(), backend) { c.record(it) }

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/SimulationEngineSeamInjectionTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/SimulationEngineSeamInjectionTests.kt
@@ -1,0 +1,200 @@
+package com.pastura.engine
+
+import com.pastura.models.Persona
+import com.pastura.models.Phase
+import com.pastura.models.PhaseType
+import com.pastura.models.Scenario
+import com.pastura.models.SimulationEvent
+import kotlin.concurrent.atomics.AtomicReference
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Through-runner reach pins for the [LanguageDetector] / [EngineLogger]
+ * injection seams: `SimulationEngine(detector = …, logger = …)` → `RunLoop` →
+ * the top-level [PhaseContext] → handler → [LLMCaller].
+ *
+ * ## Why these are distinct from the existing seam suites
+ *
+ * [EngineLoggerSeamTests] asserts the seam's *shape*, and
+ * [LLMCallerLanguageAdherenceTests] drives [LLMCaller] directly with a
+ * hand-built argument list. Both stay green against a runner that constructs
+ * its contexts with the defaults — which is exactly what `RunLoop` did before
+ * this PR. Only a run started from [SimulationEngine] witnesses the wiring.
+ *
+ * Kotlin twin of Swift's
+ * `EngineLoggerSeamTests.runnerInjectedLoggerReachesTheRunPath` and
+ * `SimulationRunnerTests+LanguageMismatch.runnerEmitsLanguageMismatchEventWhenDetectorConfigured`
+ * (the D2d Swift-pin-then-Kotlin-twin pairing).
+ *
+ * Real threads, not `runTest` — see [RunBlockingTest][runBlockingTest] and
+ * [SimulationEngineTests]' KDoc: [SimulationEngine.run] owns its own
+ * `Dispatchers.Default` scope, so a virtual scheduler would measure the
+ * scheduler rather than the engine.
+ *
+ * ## ADR-023 §12 condition-4 perturbation record (measured 2026-08-28, jvmTest)
+ *
+ * | # | Mutation | Reddens |
+ * |---|---|---|
+ * | a | drop `detector = detector` from `RunLoop`'s top-level `PhaseContext(…)` | [injectedDetectorReachesTheRunPath] |
+ * | b | drop `logger = logger` from the same construction site | [injectedLoggerReachesTheRunPath] |
+ * | c | thread `NoopEngineLogger()` into `RunLoop` instead of the ctor's `logger` | [injectedLoggerReachesTheRunPath] |
+ *
+ * Ported for the ADR-023 §6 Stage-3 Engine migration (#501).
+ */
+class SimulationEngineSeamInjectionTests {
+
+    private fun scenario(
+        agents: List<String> = listOf("Alice", "Bob"),
+        language: String = "en",
+    ) = Scenario(
+        id = "t",
+        name = "T",
+        description = "d",
+        language = language,
+        agentCount = agents.size,
+        rounds = 1,
+        context = "A test.",
+        personas = agents.map { Persona(name = it, description = "$it's persona.") },
+        phases = listOf(
+            Phase(type = PhaseType.SPEAK_ALL, prompt = "Speak.", outputSchema = mapOf("statement" to "string")),
+        ),
+    )
+
+    private fun says(text: String) =
+        ScriptedLLMBackend.Script.completing("""{"statement": "$text"}""")
+
+    /**
+     * Thread-safe spy logger.
+     *
+     * The atomics are load-bearing for the same reason [Collector]'s are: the
+     * engine logs from its worker context while the test body reads from
+     * `runBlockingTest`'s thread, and on Kotlin/Native an unsynchronized list
+     * across that edge is undefined behaviour rather than a stale read.
+     */
+    @OptIn(ExperimentalAtomicApi::class)
+    private class SpyEngineLogger : EngineLogger {
+        data class Entry(
+            val level: EngineLogLevel,
+            val category: String,
+            val message: String,
+            val privacy: EngineLogPrivacy,
+        )
+
+        private val ref = AtomicReference<List<Entry>>(emptyList())
+
+        override fun log(level: EngineLogLevel, category: String, message: String, privacy: EngineLogPrivacy) {
+            val entry = Entry(level, category, message, privacy)
+            while (true) {
+                val current = ref.load()
+                if (ref.compareAndSet(current, current + entry)) return
+            }
+        }
+
+        val entries: List<Entry> get() = ref.load()
+
+        /** Rendered messages emitted on the `StreamingDiag` channel, in order. */
+        fun diagLines(): List<String> = entries.filter { it.category == "StreamingDiag" }.map { it.message }
+    }
+
+    /**
+     * Detector whose verdicts are a queue drained one entry per call, returning
+     * `null` once empty. Atomic for the same cross-thread reason as
+     * [SpyEngineLogger] — here the calls themselves land on the worker context.
+     */
+    @OptIn(ExperimentalAtomicApi::class)
+    private class SequencedDetector(verdicts: List<String?>) : LanguageDetector {
+        private val queue = AtomicReference(verdicts)
+
+        override fun detect(text: String): String? {
+            while (true) {
+                val current = queue.load()
+                if (current.isEmpty()) return null
+                if (queue.compareAndSet(current, current.drop(1))) return current.first()
+            }
+        }
+    }
+
+    @Test
+    fun injectedLoggerReachesTheRunPath() = runBlockingTest {
+        // Alice's attempt 1 is unparseable → exactly one `retryCause … parse_failed`
+        // line; attempt 2 and Bob's single attempt succeed. The full rendered line is
+        // asserted because scripts/analyze-streaming-diag.sh parses that wire format.
+        val backend = ScriptedLLMBackend(
+            listOf(
+                ScriptedLLMBackend.Script.completing("not json at all"),
+                says("a"),
+                says("b"),
+            ),
+        )
+        val spy = SpyEngineLogger()
+        val c = Collector()
+
+        SimulationEngine(logger = spy).run(scenario(), backend) { c.record(it) }
+        awaitTerminal(c)
+
+        assertTrue(
+            c.snapshot().any { it is SimulationEvent.SimulationCompleted },
+            "the run must complete — a retry, not a failure",
+        )
+        assertContains(spy.diagLines(), "retryCause agent=Alice attempt=1 cause=parse_failed")
+    }
+
+    @Test
+    fun injectedDetectorReachesTheRunPath() = runBlockingTest {
+        // Alice exhausts the adherence budget (3 "ja" verdicts against an `en`
+        // scenario) → LanguageMismatch, and her output is still delivered; Bob's
+        // "en" verdict passes on attempt 1, proving one agent's exhaustion does not
+        // poison the next. Twin of Swift's
+        // runnerEmitsLanguageMismatchEventWhenDetectorConfigured.
+        val wrong = "ja-language statement that is long enough to pass the detector gate"
+        val right = "en-language statement that is long enough to pass the detector gate"
+        val backend = ScriptedLLMBackend(
+            listOf(says(wrong), says(wrong), says(wrong), says(right)),
+        )
+        val c = Collector()
+
+        SimulationEngine(detector = SequencedDetector(listOf("ja", "ja", "ja", "en")))
+            .run(scenario(), backend) { c.record(it) }
+        awaitTerminal(c)
+
+        val events = c.snapshot()
+        val mismatches = events.filterIsInstance<SimulationEvent.LanguageMismatch>()
+        assertEquals(1, mismatches.size, "exactly one exhaustion, from Alice")
+        assertEquals("Alice", mismatches.single().agent)
+        assertEquals("ja", mismatches.single().detected)
+        assertEquals("en", mismatches.single().expected)
+
+        assertEquals(
+            2,
+            events.filterIsInstance<SimulationEvent.AgentOutput>().size,
+            "the sim continues — both agents' output is delivered",
+        )
+        assertEquals(4, backend.callCount, "Alice 3 attempts (exhausted) + Bob 1")
+        assertTrue(events.any { it is SimulationEvent.SimulationCompleted })
+    }
+
+    @Test
+    fun defaultsLeaveBothSeamsOff() {
+        // Back-compat pin: the no-argument constructor must keep the pre-wiring
+        // behaviour — no detector (no adherence check, hence no retry on
+        // wrong-language output) and a silent logger.
+        runBlockingTest {
+            val wrong = "ja-language statement that is long enough to pass the detector gate"
+            val backend = ScriptedLLMBackend(listOf(says(wrong), says(wrong)))
+            val c = Collector()
+
+            SimulationEngine().run(scenario(), backend) { c.record(it) }
+            awaitTerminal(c)
+
+            assertTrue(
+                c.snapshot().none { it is SimulationEvent.LanguageMismatch },
+                "no detector → no adherence check → no event",
+            )
+            assertEquals(2, backend.callCount, "one call per agent, no retry consumed")
+        }
+    }
+}

--- a/tools/kmp-gate-spike/Sources/KMPGateSpike/SharedEngineRunner.swift
+++ b/tools/kmp-gate-spike/Sources/KMPGateSpike/SharedEngineRunner.swift
@@ -10,8 +10,20 @@ import Synchronization
 // an immutable value carrier — so `@unchecked` records a checked-by-contract
 // claim rather than a shrug.
 extension SimulationEvent: @retroactive @unchecked Sendable {}
-// `SimulationEngine` is stateless — `run` allocates the coroutine scope it owns
-// per call — so an instance carries nothing to race on.
+// `SimulationEngine` is no longer stateless: it holds a `ScenarioValidator`
+// (D3's preflight gate) plus the constructor-injected detector and logger
+// seams. Every one of them is a Kotlin `val` assigned at init and never
+// mutated, and each implementation is itself thread-safe (the validator is a
+// stateless value), while `run` still allocates the coroutine scope it owns per
+// call. So the claim is all-`val` immutability plus thread-safe members, not
+// "there is no state" — a future `var` field would invalidate it (Pattern 1 of
+// `.claude/rules/kmp-interop.md` says the same for the retroactive
+// conformance).
+//
+// It follows that anything injected into that constructor must be
+// Sendable-safe on the Swift side too: Kotlin calls `LanguageDetector.detect`
+// and `EngineLogger.log` from `Dispatchers.Default`, which is why both
+// interfaces' KDoc requires a Swift conformer to be declared `nonisolated`.
 extension SimulationEngine: @retroactive @unchecked Sendable {}
 
 /// Reconstructs an `AsyncStream<SimulationEvent>` over the KMP engine's
@@ -29,7 +41,14 @@ extension SimulationEngine: @retroactive @unchecked Sendable {}
 /// even though the package compiles under default-`MainActor` isolation, so it
 /// keeps the same semantics it will have inside `Engine/`.
 nonisolated public final class SharedEngineRunner: Sendable {
-  private let engine = SimulationEngine()
+  // Both arguments are spelled out because Kotlin default arguments do not
+  // survive the K/N export: the header declares exactly one initializer,
+  // `init(detector:logger:)`, with no no-arg overload. `nil` keeps the
+  // language-adherence check off and `NoopEngineLogger` swallows diagnostics —
+  // the Kotlin defaults, restated here. The spike deliberately injects neither
+  // seam; Stage 5 hands in `NLLanguageDetector` / `OSLogEngineLogger` from the
+  // App layer.
+  private let engine = SimulationEngine(detector: nil, logger: NoopEngineLogger())
   private let suspendController: SuspendController
 
   /// - Parameter suspendController: The controller the platform signals on

--- a/tools/kmp-gate-spike/Sources/KMPGateSpike/SharedEngineRunner.swift
+++ b/tools/kmp-gate-spike/Sources/KMPGateSpike/SharedEngineRunner.swift
@@ -24,6 +24,9 @@ extension SimulationEvent: @retroactive @unchecked Sendable {}
 // Sendable-safe on the Swift side too: Kotlin calls `LanguageDetector.detect`
 // and `EngineLogger.log` from `Dispatchers.Default`, which is why both
 // interfaces' KDoc requires a Swift conformer to be declared `nonisolated`.
+// `nonisolated` alone is not enough, though: it only removes the actor hop, so
+// the injected instances must themselves be `Sendable` / internally
+// thread-safe, or this conformance launders a real race into a checked claim.
 extension SimulationEngine: @retroactive @unchecked Sendable {}
 
 /// Reconstructs an `AsyncStream<SimulationEvent>` over the KMP engine's


### PR DESCRIPTION
## Summary

ADR-023 Stage 3 **close-out** — the last Stage-3 freight: the `LanguageDetector` / `EngineLogger` injection seams.

- **`SimulationEngine(detector: LanguageDetector? = null, logger: EngineLogger = NoopEngineLogger())`** — Swift `SimulationRunner.init(detector:logger:)` parity — threads both seams through `RunLoop` into every top-level `PhaseContext`. `ConditionalHandler` already forwarded them; the top-level construction site was the one missing link, so the whole Kotlin run had silently fallen to the defaults.
- **`internal → public`** on `LanguageDetector` / `EngineLogger` / `EngineLogLevel` / `EngineLogPrivacy` / `NoopEngineLogger` (a public ctor param cannot name an internal type; the §5.2 `LLMBackend` precedent). Both interfaces' KDoc requires Swift conformers to be `nonisolated` (called from `Dispatchers.Default`). Concrete impls (`NLLanguageDetector` / `OSLogEngineLogger`) stay Swift App-side per ADR-010 D8 / §4 — real injection is Stage-5 freight.
- **K/N export follow-through**: K/N collapses Kotlin default args into one exported initializer, so the gate spike now calls `SimulationEngine(detector: nil, logger: NoopEngineLogger())`; its `@unchecked Sendable` rationale rewritten (all-`val` immutability, not the stale statelessness claim). Both exported-header gates green; no `@optional` section; the defaulted-parameter trap is now a `kmp-interop.md` Pattern 3 rule, written from this measured instance.
- **Records**: ADR-023 §4 close-out + §5 "third crossing" note (with the Pattern 7 hedge — the `nonisolated` requirement is stated from KDoc/analogy, not yet probed); §11's 24-declaration shim budget pinned as the frozen gate-day figure. `DETECTOR_UNWIRED` → `DETECTOR_UNINJECTED` (the parity harness, not the engine, is what injects nothing now). Status board: **Stage 3 ✅ done**.
- Test support consolidated: three per-suite spy copies → `SeamTestSupport.kt` (atomic, K/N-safe).

## Test plan

- Swift-first pin then Kotlin twins (D2d pairing): `EngineLoggerSeamTests.runnerInjectedLoggerReachesTheRunPath` (new, `.serialized` added per `swift-testing-parallelism.md`) ↔ `SimulationEngineSeamInjectionTests` (4 tests: logger reach, detector reach, nested-phase reach through `ConditionalHandler`, default-ctor back-compat).
- §12 condition-4 perturbation rows a–e measured and recorded in the class KDoc (top-level drop ×2, ctor bypass, nested drop, non-null default).
- iOS full suite **3577 / 0** (21 skipped — device-only); `swiftlint --strict` clean; `:shared:models:jvmTest` + `:shared:engine:jvmTest` + `:shared:engine:macosArm64Test` + `compileCommonMainKotlinMetadata` green; `linkDebugFrameworkMacosArm64` with both header gates green; gate-spike `swift build` green; `check-kmp-status.py` / `check-adr023-port-coverage.py` pass.

## Review

Reviewer: Opus (`code-reviewer`), split into three slices after `SCOPE_TOO_LARGE` (commonMain / commonTest / Swift+docs). All three **PASS**, 0 Critical, 8 warnings — all applied (`.serialized`; spare scripted responses so `callCount` pins are the real detectors; spy consolidation; nested-phase reach pin; Swift-callable KDoc example; ADR nonisolated hedge; status-board cell collapse; ADR §4 caller wording). Fix-diff re-review: **PASS**, 0 Critical; its 2 warnings + 2 suggestions applied (ADR caller wording corrected — `EngineParityTests` is a Kotlin caller; deliberate-shadowing note on `ConditionalHandlerTests`' doubles; support-file header de-KDoc'd; slice labels restored to the board cell). Rejected: none.

## Device QA

実機QA不要 — Kotlin run-path + test/doc changes; no simulator-excluded code, Metal / llama.cpp path, or executor-affecting Swift change (the one Swift production-adjacent file is the nightly-only gate spike).

Closes #1603 · Part of #501

🤖 Generated with [Claude Code](https://claude.com/claude-code)
