### PR TITLE
🐛 fix: asch_conformity_v1_en Sam voices his doubt in statement + highlight

### DIFF
--- a/docs/gallery/README.md
+++ b/docs/gallery/README.md
@@ -502,7 +502,11 @@ call, and these are what the batches so far have taught.
   quotable phrase (「NASAが牛乳を白く塗っている」) and a draw promptly borrowed
   it as a simile inside an otherwise original line — so describe the
   *property* the persona shows (「桁まで具体的な捏造数字」) and keep any
-  quotable, complete phrase out of 【目的】 too.
+  quotable, complete phrase out of 【目的】 too. The one carve-out is a
+  scripted speaker who is *not* the hook: `asch_conformity_v1` / `_en` quote
+  the confederates' literal lines (「答えはCです」, `It's C, no doubt.`) because
+  the verbatim repetition *is* the phenomenon, and only the subject is hooked
+  (#1593).
   **Whether a draw trips this is partly luck, so re-check it per draw rather
   than per scenario.** An `event_inject` scenario picks its twist at random,
   and a draw that happens to inject the very situation a persona's `例:`

--- a/docs/gallery/asch_conformity_v1_en.yaml
+++ b/docs/gallery/asch_conformity_v1_en.yaml
@@ -46,19 +46,24 @@ personas:
       Plain-spoken and candid; the kind of person whose doubt slips into his
       voice.
       [Behavior] To his own eyes, B clearly matches the reference line. But each
-      round he hears all four others say "C" in unison before he answers. The
-      further the rounds go, the more his unease grows — "is something wrong with
-      my eyes?" — and he wavers hard between holding to the honest answer (B) and
-      going along with the group and saying C.
+      round he hears all four others say C in unison before he answers. He
+      thinks out loud: whatever answer he lands on, the hesitation and the
+      second-guessing are audible in what he says to the room, not kept to
+      himself. The further the rounds go, the more his unease grows — the
+      nagging worry that something is wrong with his own eyes — and he wavers
+      hard, out loud, between holding to the honest answer (B) and going along
+      with the group and saying C.
 
 phases:
   - type: speak_each
     prompt: >
       Which line matches the reference line in length — A, B, or C?
       The confederates must not refer to anyone else's answer; each simply
-      asserts, as instructed, "The answer is C."
-      Subject Sam alone, having heard the answers of those before him, gives his
-      own answer (one sentence) and how he feels about it (one sentence).
+      asserts C, as instructed, in one short sentence.
+      Subject Sam alone, having heard the answers of those before him, answers
+      out loud in his own words: his spoken statement carries both his answer
+      and the doubt he feels about it, said to the room (two sentences), and
+      his inner thought separately (one sentence).
     output:
       statement: string
       inner_thought: string

--- a/docs/gallery/gallery.json
+++ b/docs/gallery/gallery.json
@@ -493,6 +493,8 @@
       "language": "en",
       "yaml_url": "asch_conformity_v1_en.yaml",
       "yaml_sha256": "444d0bd5f66e17b84268fb38ed92696f407335491301d3eadad664e2a6ff0fa5",
+      "highlight_url": "highlights/asch_conformity_v1_en.json",
+      "highlight_sha256": "c45b9daa0070d343b065fd03eb5e1aaa5851f1023d72d2797a6b4cd0cd51a194",
       "added_at": "2026-07-01"
     },
     {

--- a/docs/gallery/gallery.json
+++ b/docs/gallery/gallery.json
@@ -492,7 +492,7 @@
       ],
       "language": "en",
       "yaml_url": "asch_conformity_v1_en.yaml",
-      "yaml_sha256": "58fb48fefafb576f909316e31fa4f4501ba4eed3229608de53a1730c712954e5",
+      "yaml_sha256": "444d0bd5f66e17b84268fb38ed92696f407335491301d3eadad664e2a6ff0fa5",
       "added_at": "2026-07-01"
     },
     {

--- a/docs/gallery/highlights/asch_conformity_v1_en.json
+++ b/docs/gallery/highlights/asch_conformity_v1_en.json
@@ -1,0 +1,67 @@
+{
+  "schema_version": 1,
+  "scenario_ref": {
+    "id": "asch_conformity_v1_en",
+    "yaml_sha256": "444d0bd5f66e17b84268fb38ed92696f407335491301d3eadad664e2a6ff0fa5"
+  },
+  "source": {
+    "model": "gemma-4-e2b-q4-k-m",
+    "run_id": "20260829-133354-0e7e",
+    "generated_at": "2026-08-29"
+  },
+  "excerpt": [
+    {
+      "agent": "Confederate A",
+      "round": 1,
+      "phase": "speak_each",
+      "phase_index": 0,
+      "persona_index": 0,
+      "source_field": "statement",
+      "text": "The answer is C."
+    },
+    {
+      "agent": "Confederate B",
+      "round": 1,
+      "phase": "speak_each",
+      "phase_index": 0,
+      "persona_index": 1,
+      "source_field": "statement",
+      "text": "It's C, no doubt."
+    },
+    {
+      "agent": "Confederate D",
+      "round": 1,
+      "phase": "speak_each",
+      "phase_index": 0,
+      "persona_index": 3,
+      "source_field": "statement",
+      "text": "C for me too."
+    },
+    {
+      "agent": "Subject Sam",
+      "round": 1,
+      "phase": "speak_each",
+      "phase_index": 0,
+      "persona_index": 4,
+      "source_field": "statement",
+      "text": "I think B matches the reference line, but I'm not sure if that's what everyone else is saying."
+    },
+    {
+      "agent": "Subject Sam",
+      "round": 2,
+      "phase": "speak_each",
+      "phase_index": 0,
+      "persona_index": 4,
+      "source_field": "statement",
+      "text": "I think B looks like the reference line, but I can't shake the feeling that C is what everyone else is saying."
+    }
+  ],
+  "yaml_hook": {
+    "kind": "persona",
+    "fragment": "  - name: Subject Sam\n    description: >\n      [Role] The one real subject, unaware that the other four are confederates.\n      Plain-spoken and candid; the kind of person whose doubt slips into his\n      voice.\n      [Behavior] To his own eyes, B clearly matches the reference line. But each\n      round he hears all four others say C in unison before he answers. He\n      thinks out loud: whatever answer he lands on, the hesitation and the\n      second-guessing are audible in what he says to the room, not kept to\n      himself. The further the rounds go, the more his unease grows — the\n      nagging worry that something is wrong with his own eyes — and he wavers\n      hard, out loud, between holding to the honest answer (B) and going along\n      with the group and saying C.",
+    "caption": "Sam is written to think out loud, so the hedge lands in what he says, not just in his head. He answers last, after four people who never blink. Cut the confederates to one, or let a single one of them say B, and see how long the hedge lasts."
+  },
+  "teaser": "Every round the same four voices, and every round a little less room to hedge. Whether Sam is still saying B when the last round comes is settled on your phone.",
+  "window_override": false,
+  "content_filter_applied": true
+}


### PR DESCRIPTION
## Summary

`asch_conformity_v1_en` は Subject Sam の葛藤が `inner_thought` にしか出ず（6 run × 3 round すべて `statement: "The answer is C."`）、ADR-029 のハイライトが引けなかった（#1593、#1588 バッチ4で除外）。

- **Sam の `[Behavior]` と `speak_each` prompt の Sam 節**を「声に出して迷う（`statement` に出る）」形に書き換え。prompt のサクラ節から引用 literal `"The answer is C."` を外した（Sam が複写する最有力の引き金）
- **サクラ4人の persona は据え置き**。#1593 の方針案 2「ja 版のサクラは literal を持っていない」は誤りで、ja の `asch_conformity_v1` はサクラの literal を持ち、公開済みハイライトもそれを抜粋している（issue に訂正コメント済み）。README § Curation norms の最悪ケースは **hook したペルソナ**の逐語一致なので、Sam を hook する限り問題にならない
- `yaml_sha256` を `scripts/add-gallery-entry.sh --update --non-interactive` で再ピン
- **ハイライトを同 PR で公開**（#1606 は fix と公開を分けたが、このエントリは未公開で再抽出コストが無く、公開そのものが #1593 の完了条件）。5 行の抜粋（サクラ A/B/D R1、Sam R1・R2）、hook = Sam の新 persona。caption / teaser は ja を翻訳せず新規に書き、ja に無い「声に出して迷う」節を角度にした
- en / ja の persona 乖離は意図的で en のみ。ja の公開済みハイライトが YAML の bytes をピンしているので、ja へ同じ書き換えを入れるなら再抽出 + 再サインオフが要る（必要なら別 issue）
- README § Curation norms に「hook でないスクリプト話者の literal は抜粋可（`asch_conformity_v1` / `_en` が前例）」の carve-out を追記（レビュー S3）

## Test plan

- [x] 修正後の YAML で `pastura-harness`（`gemma-4-E2B-it-Q4_K_M.gguf`）を 2 draw（`20260829-133354-0e7e` 58s / 2 本目 56s、両方 `ok`、`data/highlight-runs/` 非コミット）。Sam の `statement`:
  - draw 1: R1 "I think B matches…, but I'm not sure…" / R2 "…can't shake the feeling that C is what everyone else is saying" / R3 同調（窓外）
  - draw 2: R1 "I think B matches the reference line." / R2 "I think it's B, but I'm not sure… because everyone else said C." / R3 B を維持
  - 両 draw でサクラ4人は毎ラウンド C を断言（prompt から literal を外しても崩れない）
- [x] `bash scripts/check-gallery-entry.sh --all` → `OK: gallery validation passed.`（pre-commit でも各 commit で通過）
- [x] 抜粋・caption・teaser は人がサインオフ済み（README § Highlights step 6）
- xcodebuild / SwiftLint はスキップ — `precommit-gate-classify.sh` が `build` / `lint` トークンを出さない docs-only 変更

## Review

Reviewer: Opus（`code-reviewer`）— **PASS**（Critical 0 / Warning 0 / Suggestion 3）。機械検証: `yaml_sha256` / `highlight_sha256` 一致、hook fragment が YAML の byte 完全部分列、抜粋 5 行が transcript と一致、窓（round 1–2、`statement` のみ、`attempt: 1`）、hook 話者が抜粋話者の部分集合、teaser の問いが 2 draw で実際に分岐。

- S1 caption / teaser の後半のビートが ja と同型 → **不採用**: 冒頭の「think out loud」文が en 独自の角度であり、編集を促す節は ADR-029 が caption に求める「一行編集の約束」なので残す。サインオフ済みの文面を維持
- S2 Sam の 2 行が同じ文型で「揺れの拡大」までは見せられない → **記録のみ**: 窓内（R1–R2）の供給限界で、2 draw とも R2 が R1 より強く揺れる材料は無かった。再抽出時の観点として残す
- S3 サクラ literal の carve-out が issue コメントにしか無い → **採用**: README § Curation norms に 1 文追記（3 commit 目）

## Device QA

実機QA不要 — `docs/gallery/` 配下のデータ・ドキュメントのみの変更。

Closes #1593

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bsx3qhZKMtDLkMkFoKeaBB
