### PR TITLE
🔧 chore: -exportArchive の method を app-store-connect へ改名

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -273,7 +273,7 @@ scripts/release.sh --version X.Y --notes-file /REPLACE-WITH-NOTES-PATH
 ```
 
 The script archives, re-checks the ADR-005 §8.5 Ollama-symbol guard on
-the signed binary, exports an `app-store` `.ipa`, uploads via fastlane
+the signed binary, exports an `app-store-connect` `.ipa`, uploads via fastlane
 (waiting for ASC processing), and — only on a successful upload —
 creates and pushes the annotated tag `v<version>+<build>`. Report the result
 and that the build is processing on TestFlight.

--- a/docs/decisions/ADR-014.md
+++ b/docs/decisions/ADR-014.md
@@ -99,8 +99,9 @@ created and pushed *after* a successful upload**, not before (see rationale):
    `nm -a <archived>.app/Pastura | xcrun swift-demangle | grep -i ollama`
    must return zero matches. (Rationale below.)
 5. **Export** — `xcodebuild -exportArchive` to an `.ipa` with export method
-   **`app-store`** (a `development`/`release-testing` method produces a
-   silently un-uploadable `.ipa`). `release.sh` owns archive + export via raw
+   **`app-store-connect`** (renamed from `app-store`, deprecated as of
+   Xcode 26; a `development`/`release-testing` method produces a silently
+   un-uploadable `.ipa`). `release.sh` owns archive + export via raw
    `xcodebuild` and generates the `exportOptions.plist` at cut time (not
    committed); fastlane is the **uploader only** (next step).
 6. **Upload** — `fastlane upload_to_testflight(ipa:)` via the API Key.

--- a/docs/decisions/ADR-014.md
+++ b/docs/decisions/ADR-014.md
@@ -99,9 +99,10 @@ created and pushed *after* a successful upload**, not before (see rationale):
    `nm -a <archived>.app/Pastura | xcrun swift-demangle | grep -i ollama`
    must return zero matches. (Rationale below.)
 5. **Export** — `xcodebuild -exportArchive` to an `.ipa` with export method
-   **`app-store-connect`** (renamed from `app-store`, deprecated as of
-   Xcode 26; a `development`/`release-testing` method produces a silently
-   un-uploadable `.ipa`). `release.sh` owns archive + export via raw
+   **`app-store-connect`** (`app-store` is `xcodebuild`'s older, now-deprecated
+   name for the same method; a `development`/`release-testing` method
+   produces a silently un-uploadable `.ipa`). `release.sh` owns archive +
+   export via raw
    `xcodebuild` and generates the `exportOptions.plist` at cut time (not
    committed); fastlane is the **uploader only** (next step).
 6. **Upload** — `fastlane upload_to_testflight(ipa:)` via the API Key.

--- a/docs/release-setup.md
+++ b/docs/release-setup.md
@@ -76,10 +76,12 @@ git check-ignore fastlane/.env    # → prints "fastlane/.env" (ignored)
 ### 4. Set up code signing in Xcode
 
 `release.sh`'s export step uses the `app-store-connect` export method
-(`xcodebuild`'s post-Xcode-26 name for what was `app-store`), so this
-machine's Xcode must be new enough to recognize it — check with
-`xcodebuild -help` and grep the `-exportOptionsPlist` `method` key's option
-list.
+(`xcodebuild`'s current name for what the older, now-deprecated `app-store`
+also refers to), so this machine's Xcode must be new enough to recognize it:
+
+```bash
+xcodebuild -help | grep -c app-store-connect  # → non-zero means this Xcode supports it
+```
 
 `scripts/release.sh` archives and exports headlessly with automatic signing,
 passing `-allowProvisioningUpdates` so it resolves the App Store provisioning

--- a/docs/release-setup.md
+++ b/docs/release-setup.md
@@ -75,6 +75,12 @@ git check-ignore fastlane/.env    # → prints "fastlane/.env" (ignored)
 
 ### 4. Set up code signing in Xcode
 
+`release.sh`'s export step uses the `app-store-connect` export method
+(`xcodebuild`'s post-Xcode-26 name for what was `app-store`), so this
+machine's Xcode must be new enough to recognize it — check with
+`xcodebuild -help` and grep the `-exportOptionsPlist` `method` key's option
+list.
+
 `scripts/release.sh` archives and exports headlessly with automatic signing,
 passing `-allowProvisioningUpdates` so it resolves the App Store provisioning
 profile and the **cloud-managed** distribution certificate from the Developer

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -15,7 +15,7 @@
 #                CURRENT_PROJECT_VERSION override (no pbxproj edit)
 #   symbol     → re-run the ADR-005 §8.5 Ollama-symbol guard on the
 #                ARCHIVED binary (CI only checks the unsigned build product)
-#   export     → xcodebuild -exportArchive, method app-store, with an
+#   export     → xcodebuild -exportArchive, method app-store-connect, with an
 #                exportOptions.plist generated at cut time (never committed)
 #   upload     → fastlane upload_to_testflight
 #   tag        → annotated tag v<version>+<build>, pushed ONLY after the
@@ -258,7 +258,7 @@ cat > "$PLIST" <<PLIST_EOF
 <plist version="1.0">
 <dict>
 	<key>method</key>
-	<string>app-store</string>
+	<string>app-store-connect</string>
 	<key>teamID</key>
 	<string>$TEAM_ID</string>
 	<key>destination</key>
@@ -269,7 +269,7 @@ cat > "$PLIST" <<PLIST_EOF
 </plist>
 PLIST_EOF
 
-log "Exporting .ipa (method app-store)"
+log "Exporting .ipa (method app-store-connect)"
 # -allowProvisioningUpdates: same reason as the archive step — the export
 # re-signs with the cloud-managed distribution cert, which headless xcodebuild
 # can only resolve when allowed to contact the portal.


### PR DESCRIPTION
## Summary

- `xcodebuild -exportArchive` の export method を deprecated な `app-store` から `app-store-connect` へ改名する（`scripts/release.sh` の plist 値 + コメント2箇所、ADR-014 の規範記述、`.claude/skills/release/SKILL.md`）。
- `docs/release-setup.md` に、この環境の Xcode が `app-store-connect` を解釈できるかを確認するワンライナーを追記する。

## Test plan

- `scripts/xcodebuild.sh build --tail 80` — BUILD SUCCEEDED
- `swiftlint lint --quiet --strict` — クリーン
- ローカル Xcode 26.6 の `xcodebuild -help` で `-exportOptionsPlist` の `method` オプション一覧に `app-store-connect` があること、`app-store` が `deprecated: use app-store-connect` と明記されていることを確認済み
- `scripts/release.sh --dry-run` はこの変更（export ステップ）の手前で停止するため検証にならない。実際の export 検証は次回リリース実行時に持ち越し

## Review

- Reviewer: `code-reviewer` (Opus)
- Verdict: PASS
- Warning 1件（`app-store-connect` の導入バージョンを「Xcode 26」と記載していたが根拠を確認できなかった）→ 修正コミットでバージョン主張を削除し、確認手順をコピペ可能なワンライナーに変更
- Suggestion 1件 → 同上のコミットで反映

## Device QA

実機QA不要 — Swift ソース非タッチ、シミュレータ/実機のいずれにも影響しない doc + シェルスクリプトの文言変更のみ。

Part of #1544
