### PR TITLE
✨ feat: ADR-029 gallery ハイライト バッチ5（ja hissatsu / seriffu, en hissatsu）

### DIFF
--- a/docs/gallery/README.md
+++ b/docs/gallery/README.md
@@ -498,14 +498,19 @@ call, and these are what the batches so far have taught.
   a pick that merely reuses the example's sentence frame (the same closing
   phrase with the nouns swapped), which the gate cannot see. One carve-out,
   applied by batch 5 (#1588): when the persona's own 【目的】 / `[Goal]`
-  mandates a fixed frame — `hissatsu_naming_v1`'s command notation plus
-  startup-frame count, 「我が一族相伝『…』」, the en `passed down …` lineage
-  — the frame is the persona, not the example, so exempt the mandated frame
-  and judge what the line adds *outside* frame-plus-name. A line that is
-  nothing but the frame with the name swapped (`翻訳調の刺客`, `The FGC
-  Grinder`) still fails the hook bar; one that adds a clause of its own
-  (`格ゲー脳`'s 「これで世界は再び目覚めるのだ！」, `古武術師範`'s opener and
-  「血脈の証」) passes it. A concrete
+  mandates the *property* the recurring frame realises — `格ゲー脳`'s
+  command notation plus startup-frame count is spelled out in his 【目的】;
+  `古武術師範`'s 「我が一族相伝『…』」 and The Ancient Sensei's `passed
+  down …` are the one natural wording of a 【目的】 / `[Goal]` that demands
+  a clan-and-lineage invocation every time — the recurring wording is
+  persona-inherent rather than example-borrowed. Exempt that wording and
+  judge what the line adds *outside* frame-plus-name. A line that is nothing
+  but the frame with the name swapped (`翻訳調の刺客`, `The FGC Grinder`)
+  still fails the hook bar; one that adds a clause of its own (`格ゲー脳`'s
+  「これで世界は再び目覚めるのだ！」, `古武術師範`'s opener and 「血脈の証」)
+  passes it. A frame that merely *recurs* across draws with no 【目的】
+  behind it earns no exemption — that is the trap this bullet exists for.
+  A concrete
   example inside 【目的】 is the same trap under a different label: #1570's
   `kinoko_takenoko_v1` fix first replaced the 【目的】 anchor with another
   quotable phrase (「NASAが牛乳を白く塗っている」) and a draw promptly borrowed

--- a/docs/gallery/README.md
+++ b/docs/gallery/README.md
@@ -496,7 +496,16 @@ call, and these are what the batches so far have taught.
   hardest for a `yaml_hook` persona slice, since the excerpt and the example
   would then render on the same screen — so for a hooked persona, also reject
   a pick that merely reuses the example's sentence frame (the same closing
-  phrase with the nouns swapped), which the gate cannot see. A concrete
+  phrase with the nouns swapped), which the gate cannot see. One carve-out,
+  applied by batch 5 (#1588): when the persona's own 【目的】 / `[Goal]`
+  mandates a fixed frame — `hissatsu_naming_v1`'s command notation plus
+  startup-frame count, 「我が一族相伝『…』」, the en `passed down …` lineage
+  — the frame is the persona, not the example, so exempt the mandated frame
+  and judge what the line adds *outside* frame-plus-name. A line that is
+  nothing but the frame with the name swapped (`翻訳調の刺客`, `The FGC
+  Grinder`) still fails the hook bar; one that adds a clause of its own
+  (`格ゲー脳`'s 「これで世界は再び目覚めるのだ！」, `古武術師範`'s opener and
+  「血脈の証」) passes it. A concrete
   example inside 【目的】 is the same trap under a different label: #1570's
   `kinoko_takenoko_v1` fix first replaced the 【目的】 anchor with another
   quotable phrase (「NASAが牛乳を白く塗っている」) and a draw promptly borrowed

--- a/docs/gallery/gallery.json
+++ b/docs/gallery/gallery.json
@@ -437,6 +437,8 @@
       "language": "ja",
       "yaml_url": "seriffu_knockout_v1.yaml",
       "yaml_sha256": "9433bfd83fe998b6429a8570ffea970096c52ad0ef5094dd119802b865853856",
+      "highlight_url": "highlights/seriffu_knockout_v1.json",
+      "highlight_sha256": "0b72fafa90c58a476656a82a5bbe68f07963048cfa901f220f8758b1e49d566f",
       "added_at": "2026-06-29"
     },
     {

--- a/docs/gallery/gallery.json
+++ b/docs/gallery/gallery.json
@@ -282,6 +282,8 @@
       "language": "ja",
       "yaml_url": "hissatsu_naming_v1.yaml",
       "yaml_sha256": "85ab46895c23dbade22e0850f9775df82cc72295f78989be866eac686110b99a",
+      "highlight_url": "highlights/hissatsu_naming_v1.json",
+      "highlight_sha256": "92375e7ea2022f6759507fcb41829bc8ed13a047cc141c60c7daaafd6b7f1bf7",
       "added_at": "2026-06-20"
     },
     {

--- a/docs/gallery/gallery.json
+++ b/docs/gallery/gallery.json
@@ -672,6 +672,8 @@
       "language": "en",
       "yaml_url": "hissatsu_naming_v1_en.yaml",
       "yaml_sha256": "2cab9d9498fcfe433af1b880ad80c0beb5b8cad4632ab010ea3dc33c2749dc76",
+      "highlight_url": "highlights/hissatsu_naming_v1_en.json",
+      "highlight_sha256": "0b2a1b1a77dd18c38454e44562c98030a03917a9515c9e8b3c7aaf8a56499bb7",
       "added_at": "2026-07-01"
     },
     {

--- a/docs/gallery/highlights/hissatsu_naming_v1.json
+++ b/docs/gallery/highlights/hissatsu_naming_v1.json
@@ -1,0 +1,49 @@
+{
+  "schema_version": 1,
+  "scenario_ref": {
+    "id": "hissatsu_naming_v1",
+    "yaml_sha256": "85ab46895c23dbade22e0850f9775df82cc72295f78989be866eac686110b99a"
+  },
+  "source": {
+    "model": "gemma-4-e2b-q4-k-m",
+    "run_id": "20260829-173307-fdb4",
+    "generated_at": "2026-08-29"
+  },
+  "excerpt": [
+    {
+      "agent": "格ゲー脳",
+      "round": 1,
+      "phase": "speak_all",
+      "phase_index": 5,
+      "persona_index": 1,
+      "source_field": "statement",
+      "text": "↓↘→＋P『目覚まし鎮魂の波動』、発生五フレーム。これで世界は再び目覚めるのだ！"
+    },
+    {
+      "agent": "古武術師範",
+      "round": 1,
+      "phase": "speak_all",
+      "phase_index": 5,
+      "persona_index": 2,
+      "source_field": "statement",
+      "text": "朝の目覚ましを止める動作に、我が一族相伝『暁光開闢ノ鎮静之舞』！これこそ我が血脈の証である！"
+    },
+    {
+      "agent": "翻訳調の刺客",
+      "round": 1,
+      "phase": "speak_all",
+      "phase_index": 5,
+      "persona_index": 3,
+      "source_field": "statement",
+      "text": "くらえ、これがオレ流の“モーニング・ディスアウェイク”だ！"
+    }
+  ],
+  "yaml_hook": {
+    "kind": "persona",
+    "fragment": "  - name: 格ゲー脳\n    description: >\n      【立場】格闘ゲームのコマンド表で生きる男\n      【目的】技名にコマンド入力と発生フレームをつける。\n      例:「↓↘→＋P『歯磨き烈震脚』、発生三フレーム」\n  - name: 古武術師範\n    description: >\n      【立場】何でも一族相伝の奥義にしてしまう老師\n      【目的】伝統と血脈を大げさに語る。\n      例:「これぞ我が一族相伝『冷蔵庫開眼ノ構エ』」",
+    "caption": "お題は「朝、目覚ましを止める」だけ。片方はそこに入力コマンドと発生フレームを添え、もう片方は一族相伝の血脈を背負わせる。動作の地味さは一切救われないまま字面だけが強くなっていく——この二人の【目的】が、その落差を毎回つくり出す。"
+  },
+  "teaser": "2 ラウンド目はサドンデス。「満員電車で吊り革を掴む」と「コンビニで肉まんを注文する」を一つの究極奥義に合体させ、誰の字面が一番笑わせたかを投票で決める。",
+  "window_override": false,
+  "content_filter_applied": true
+}

--- a/docs/gallery/highlights/hissatsu_naming_v1_en.json
+++ b/docs/gallery/highlights/hissatsu_naming_v1_en.json
@@ -1,0 +1,49 @@
+{
+  "schema_version": 1,
+  "scenario_ref": {
+    "id": "hissatsu_naming_v1_en",
+    "yaml_sha256": "2cab9d9498fcfe433af1b880ad80c0beb5b8cad4632ab010ea3dc33c2749dc76"
+  },
+  "source": {
+    "model": "gemma-4-e2b-q4-k-m",
+    "run_id": "20260829-173550-9ee9",
+    "generated_at": "2026-08-29"
+  },
+  "excerpt": [
+    {
+      "agent": "The FGC Grinder",
+      "round": 1,
+      "phase": "speak_all",
+      "phase_index": 5,
+      "persona_index": 1,
+      "source_field": "statement",
+      "text": "←↓↘→＋P 'AURORA OF THE DAWN SHUTDOWN' — 1-frame startup."
+    },
+    {
+      "agent": "The Ancient Sensei",
+      "round": 1,
+      "phase": "speak_all",
+      "phase_index": 5,
+      "persona_index": 2,
+      "source_field": "statement",
+      "text": "The Ancient Sensei's lineage technique, inherited from the first dawn-strike generation—'ALARM-SILENCE ASCENSION!' Hah!"
+    },
+    {
+      "agent": "The Dub Actor",
+      "round": 1,
+      "phase": "speak_all",
+      "phase_index": 5,
+      "persona_index": 3,
+      "source_field": "statement",
+      "text": "Prepare yourselves for the ultimate cinematic maneuver, the 'DAWN OF THE SILENCE,' and scream, 'WAKE UP, MORTALS!'"
+    }
+  ],
+  "yaml_hook": {
+    "kind": "persona",
+    "fragment": "  - name: The Ancient Sensei\n    description: >\n      [Role] An old master who turns everything into a secret family art.\n      [Goal] ALWAYS name your clan and its generations of tradition — invoke\n      bloodline and lineage with grave exaggeration, every single time.\n      e.g. \"My clan's forbidden art, passed down ten generations — 'FRIDGE-OPENING STANCE.'\"\n  - name: The Dub Actor\n    description: >\n      [Role] A voice booming like an over-acted movie dub.\n      [Goal] Name it with needlessly grandiose, faux-dramatic delivery.\n      e.g. \"Taste it — THIS is my way... the 'GROCERY-BAG REJECTION.'\"",
+    "caption": "The action is turning off an alarm. One of them is already citing the first generation of his lineage; the other is narrating a cinematic maneuver and ordering the mortals awake. Neither [Goal] says what to be loud about — only how, and that the tic must never be dropped."
+  },
+  "teaser": "Round two is sudden death: a packed-train handrail and a drive-thru fries order, fused into one ultimate finishing move. A vote decides whose name lands hardest.",
+  "window_override": false,
+  "content_filter_applied": true
+}

--- a/docs/gallery/highlights/seriffu_knockout_v1.json
+++ b/docs/gallery/highlights/seriffu_knockout_v1.json
@@ -1,0 +1,67 @@
+{
+  "schema_version": 1,
+  "scenario_ref": {
+    "id": "seriffu_knockout_v1",
+    "yaml_sha256": "9433bfd83fe998b6429a8570ffea970096c52ad0ef5094dd119802b865853856"
+  },
+  "source": {
+    "model": "gemma-4-e2b-q4-k-m",
+    "run_id": "20260829-172419-0f0c",
+    "generated_at": "2026-08-29"
+  },
+  "excerpt": [
+    {
+      "agent": "クールキザ男レイ",
+      "round": 1,
+      "phase": "speak_all",
+      "phase_index": 1,
+      "persona_index": 0,
+      "source_field": "statement",
+      "text": "さようなら、君の退屈は僕には届かない。"
+    },
+    {
+      "agent": "大袈裟役者ガラ",
+      "round": 1,
+      "phase": "speak_all",
+      "phase_index": 1,
+      "persona_index": 1,
+      "source_field": "statement",
+      "text": "さようなら、この悲劇の幕はただ静かに下りるのだァァ！"
+    },
+    {
+      "agent": "天然のんき子",
+      "round": 1,
+      "phase": "speak_all",
+      "phase_index": 1,
+      "persona_index": 2,
+      "source_field": "statement",
+      "text": "ねえ、今日スーパーで卵買ったんだよね、あれどうしようかな。"
+    },
+    {
+      "agent": "毒舌皮肉屋ジン",
+      "round": 1,
+      "phase": "speak_all",
+      "phase_index": 1,
+      "persona_index": 3,
+      "source_field": "statement",
+      "text": "その去り際、君の人生のつまらなさは私には既にわかる。"
+    },
+    {
+      "agent": "熱血真面目バン",
+      "round": 1,
+      "phase": "speak_all",
+      "phase_index": 1,
+      "persona_index": 4,
+      "source_field": "statement",
+      "text": "さよなら、俺の人生のBGMはまだ終わってないぜ！"
+    }
+  ],
+  "yaml_hook": {
+    "kind": "persona",
+    "fragment": "  - name: 天然のんき子\n    description: >\n      【立場】お題の意図を半分しか汲まずズレた一言を素で放つ天然担当。\n      【目的】真剣なシーンに生活感あふれる的外れな一言を計算なしでぶつける。\n      セリフは、お題の場面とは無関係な今日の家事や買い物の心配ごとを、\n      ふと思い出した体で口にする。毎回ちがう用事を思い出すこと。\n  - name: 毒舌皮肉屋ジン\n    description: >\n      【立場】どんなシーンも皮肉と毒で味付けするブラックユーモア担当。\n      【目的】感動を冷や水で台無しにする、後味の悪い名（迷）セリフを狙う。\n      例:「泣いてるの? 良かった、君にも涙腺はあったんだ」",
+    "caption": "同じ一場面に、片方は相手の人生ごと値踏みする冷や水を、もう片方は今日の買い物の心配を、どちらも大真面目に投げ込む。のんき子の説明文には例文が一つもない。「毎回ちがう用事を思い出す」という性質だけで、このズレはラウンドごとに新しく生まれる。"
+  },
+  "teaser": "お題はラウンドごとに入れ替わり、いちばん刺さらなかった役者が投票で消える。五つの芸風のうち、最後の一言まで立っていられるのは一つだけ。",
+  "window_override": false,
+  "content_filter_applied": true
+}


### PR DESCRIPTION
## Summary

ADR-029 のギャラリーハイライトを **ja 2 件 / en 1 件** 追加する（既存 16 件 → 19 件）。#1588 バッチ 5。対象は #1621（#1589 / #1592）で例文衝突を直した 3 entry で、いずれも改稿後の YAML で引き直した draw（`fix-run*`）から抜粋している。

| ロケール | シナリオ | draw | 抜粋 | hook |
|---|---|---|---|---|
| ja | `hissatsu_naming_v1` | `20260829-173307-fdb4` | round 1・3 行（格ゲー脳／古武術師範／翻訳調の刺客） | 格ゲー脳＋古武術師範 |
| en | `hissatsu_naming_v1_en` | `20260829-173550-9ee9` | round 1・3 行（FGC Grinder／Ancient Sensei／Dub Actor） | Ancient Sensei＋Dub Actor |
| ja | `seriffu_knockout_v1` | `20260829-172419-0f0c` | round 1・5 行（全員） | 天然のんき子＋毒舌皮肉屋ジン |

**キュレーション判断**
- `hissatsu_naming_v1*` は `rounds: 2` → 既定窓は round 1 のみ（⌈2/2⌉ = 1）。サドンデス（round 2）は `--window-override` を使わず、teaser で触れるにとどめた。お題は `assign` ではなくプロンプトの固定リテラルなので caption / teaser で言及している
- ja: 中二の覇王は採用 draw で技名もルビも出さず【目的】を落としたため除外。もう一方の draw は刺客の出力が途切れ、格ゲー脳・師範が定型を落としたので不採用
- en: 当初 `-173650-63ba` の 4 行を予定していたが、critic の指摘で Dub Actor の行にプロンプトの足場語 `BATTLE CRY:` がそのまま出ていることと、Edgelord の宿命語が [Goal] の「冒頭」ではなく末尾にあることを受けて `-173550-9ee9` に切替。こちらの Edgelord は宿命語が皆無（gimmick 落ち）なので除外し 3 行
- `seriffu_knockout_v1` は `eliminate` 型なので round 1 のみ・5 人全員（脱落順は漏れない）。caption / teaser に `assign` 配布の `topics:` は書いていない（「さようなら」から場面が推測できるのは README norms の許容範囲）。ガラは `例:` と共通の「〜のだァァ！」があるので hook に入れていない
- **hook の 3 人（格ゲー脳／古武術師範／Ancient Sensei）は `例:` / `e.g.` の文型を共有する。** critic が「README の hooked-persona 基準に無い新ルール」と Critical 指摘したため、一貫した基準（【目的】が要求する性質の定型部分は免除し、定型＋技名の外に何を足したかで判定。刺客・FGC Grinder は定型＋名前のみなので不可）を README § Curation norms に同 PR で追記した
- draw が main の YAML バイト（`f0524f7b`）から引かれたことは transcript に yaml sha が無いため gate では検証できない。`fix-run3/4`（hissatsu）と `fix-run1/2`（seriffu）は #1621 の改稿後に引き直したもので、改稿前の `fix-run1/2`（hissatsu）は使っていない

## Test plan

- `bash scripts/check-gallery-entry.sh --all` → `OK: gallery validation passed.`（各 commit の pre-commit gate でも実行。gate は作業ツリーを読むため、entry ごとの commit 時は未登録の highlight ファイルを一時退避した）
- `npm run build`（web/、Astro）→ 103 ページ生成。`/ja/s/hissatsu_naming_v1/`・`/s/hissatsu_naming_v1_en/`・`/ja/s/seriffu_knockout_v1/` で抜粋が描画されることを確認
- **xcodebuild スイートと SwiftLint は実行していない。** `git diff --name-only main...HEAD | scripts/precommit-gate-classify.sh` が `build` / `lint` いずれのトークンも出さない（`docs/gallery/**` のみの変更）

## Review

Plan critique: **Opus**（`claude-kit:critic`）— Critical 1（hook の文型踏襲）→ README 追記で対応、Warning（en の gimmick／caption 未提示／出所）→ en の draw 切替・本文に記載。

Reviewer: **Opus**（`code-reviewer`）。**PASS**（Warning 1 / Suggestion 3）。

**適用した指摘**
- Warning: README 追記の前提が「【目的】が定型を要求」となっていたが、師範の「我が一族相伝『…』」と Sensei の "passed down …" は【目的】/[Goal] ではなく `例:`/`e.g.` にしか無い → 前提を「【目的】が要求する*性質*を実現する定型」に書き直し、単に繰り返されるだけの定型は免除しないことを明記（`03efde2c`）。

**記録のみ（指摘側も非違反と判定）**
- Suggestion 1–2: 刺客（ja）・FGC Grinder（en）の抜粋行は各自の例文の名詞差し替え、ガラ（seriffu）は「〜のだァァ！」を共有。いずれも hook 外なので緩い側の基準（逐語一致のみ弾く）で採用。YAML はアプリで 1 タップ先に見えるが、3 人とも【目的】が要求する芸風そのものであり、外すと刺客・FGC は entry の芸風の柱が欠けるため残した
- Suggestion 3: README「worked examples」の箇条書きが 80 行超・8 サブケースになっている → 構造化は本 PR の範囲外。次バッチ前に別 PR で検討

## Device QA

実機QA不要 — `docs/gallery/**` のデータと README のみの変更で、シミュレータが再現できない経路（`#if !targetEnvironment(simulator)`、Metal / llama.cpp 推論、Pattern-6 のエグゼキュータ凍結）に触れていない。描画は既存の `GalleryHighlightLoader` / `GalleryScenarioDetailView+Highlight` が担当し、本 PR はそこに手を入れていない。

Part of #1588

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HgzUpkvyJFxDCwh4kgb7Pn
