### PR TITLE
✨ feat: ADR-023 Stage 4 — S4 cancellation event tail (fix Swift + parity fixture)

### DIFF
--- a/Pastura/Pastura/Engine/PhaseHandler.swift
+++ b/Pastura/Pastura/Engine/PhaseHandler.swift
@@ -15,7 +15,12 @@ import Foundation
 /// pause request is honored at sub-phase granularity. `.simulationPaused`
 /// is emitted by the runner through this hook — handlers must not emit it
 /// themselves. The returned `Bool` is `true` when the task was cancelled
-/// while paused, in which case the handler should return early.
+/// while paused, in which case the handler MUST abort the phase by throwing
+/// ``SimulationError/cancelled``. It must not return normally — the runner
+/// reads a normal return as "the phase finished" and emits that phase's
+/// `.phaseCompleted` for work that never ran — and it must not emit
+/// `.error(.cancelled)` itself: the runner emits it exactly once, on every
+/// cancellation path (ADR-023 S4, #1622).
 nonisolated public struct PhaseContext: Sendable {
   public let scenario: Scenario
   public let phase: Phase

--- a/Pastura/Pastura/Engine/Phases/ConditionalHandler.swift
+++ b/Pastura/Pastura/Engine/Phases/ConditionalHandler.swift
@@ -87,13 +87,20 @@ nonisolated struct ConditionalHandler: PhaseHandler {
     _ phases: [Phase], context: PhaseContext, state: inout SimulationState
   ) async throws {
     for (innerIndex, subPhase) in phases.enumerated() {
+      // Cancellation aborts by THROWING, never by returning. A silent return
+      // here read to the runner as "the conditional finished", so it emitted
+      // `.phaseCompleted(.conditional)` for a branch that was cut short and
+      // only then noticed the cancellation — on the pause path that also cost
+      // a second `.error(.cancelled)`, since `checkPaused` used to emit one
+      // itself. Throwing routes both paths through the runner's single
+      // `.error(.cancelled)` (ADR-023 S4, #1622).
       if Task.isCancelled {
-        return
+        throw SimulationError.cancelled
       }
 
       let innerPath = context.phasePath + [innerIndex]
       if await context.pauseCheck(innerPath) {
-        return
+        throw SimulationError.cancelled
       }
 
       // Resolve the handler BEFORE emitting `phaseStarted` so a

--- a/Pastura/Pastura/Engine/SimulationRunner.swift
+++ b/Pastura/Pastura/Engine/SimulationRunner.swift
@@ -1,3 +1,7 @@
+// The round loop, the pause gate, and the phase loop share the private
+// `ExecutionContext`, so splitting them into sibling files would have to widen
+// its access. Kept in one file past the 400-line cap instead.
+// swiftlint:disable file_length
 import Foundation
 import Synchronization
 
@@ -107,6 +111,11 @@ nonisolated public final class SimulationRunner: @unchecked Sendable {
   /// agent outputs, score updates, and completion/error events. The stream finishes
   /// when the simulation completes, is cancelled, or encounters a fatal error.
   ///
+  /// Cancellation arrives here only by terminating the stream, so the run's
+  /// final `.error(.cancelled)` is yielded to an already-terminated
+  /// continuation and dropped. A caller that must observe the cancellation
+  /// tail uses the `emitter:` overload below instead.
+  ///
   /// - Parameters:
   ///   - scenario: The scenario to execute.
   ///   - llm: The LLM service for inference.
@@ -130,25 +139,14 @@ nonisolated public final class SimulationRunner: @unchecked Sendable {
     resumingFrom seed: SimulationState? = nil,
     startRound: Int = 1
   ) -> AsyncStream<SimulationEvent> {
-    // Capture needed values to avoid retaining self in the Task
-    let dispatcher = self.dispatcher
-    let validator = self.validator
-    let pauseState = self.pauseState
-    let detector = self.detector
-    let logger = self.logger
-    let random = self.random
-
-    return AsyncStream { continuation in
+    AsyncStream { continuation in
+      // Delegates to the emitter overload so both entry points share one
+      // execution path. The Task holds `self` for the run's duration only —
+      // `onTermination` below cancels it, and nothing outlives the run.
       let task = Task {
-        await Self.executeSimulation(
-          scenario: scenario, llm: llm,
-          dispatcher: dispatcher, validator: validator,
-          pauseState: pauseState,
-          suspendController: suspendController,
-          detector: detector,
-          logger: logger,
-          random: random,
-          seed: seed, startRound: startRound,
+        await self.run(
+          scenario: scenario, llm: llm, suspendController: suspendController,
+          resumingFrom: seed, startRound: startRound,
           emitter: { continuation.yield($0) }
         )
         continuation.finish()
@@ -158,6 +156,38 @@ nonisolated public final class SimulationRunner: @unchecked Sendable {
         task.cancel()
       }
     }
+  }
+
+  /// Runs a simulation to completion in the CALLER's task, delivering every
+  /// event through `emitter` — including the terminal `.error(.cancelled)`
+  /// after the caller cancels its own task. The `AsyncStream` overload cannot
+  /// observe that tail: its only cancel path is terminating the stream, which
+  /// drops everything emitted afterwards. (ADR-023 S4, #1622)
+  ///
+  /// Parameters otherwise match
+  /// ``run(scenario:llm:suspendController:resumingFrom:startRound:)``.
+  ///
+  /// - Parameter emitter: Receives every ``SimulationEvent`` in emission order.
+  ///   Called synchronously from the run's own task, hence `@Sendable`.
+  public func run(
+    scenario: Scenario,
+    llm: LLMService,
+    suspendController: SuspendController,
+    resumingFrom seed: SimulationState? = nil,
+    startRound: Int = 1,
+    emitter: @escaping @Sendable (SimulationEvent) -> Void
+  ) async {
+    await Self.executeSimulation(
+      scenario: scenario, llm: llm,
+      dispatcher: dispatcher, validator: validator,
+      pauseState: pauseState,
+      suspendController: suspendController,
+      detector: detector,
+      logger: logger,
+      random: random,
+      seed: seed, startRound: startRound,
+      emitter: emitter
+    )
   }
 
   // MARK: - Private
@@ -223,7 +253,13 @@ nonisolated public final class SimulationRunner: @unchecked Sendable {
           return
         }
 
-        if await checkPaused(ctx: ctx, round: round) { return }
+        // `checkPaused` reports cancellation but no longer emits it — every
+        // cancellation path funnels through exactly one `.error(.cancelled)`
+        // emitted by its caller (ADR-023 S4, #1622).
+        if await checkPaused(ctx: ctx, round: round) {
+          ctx.emitter(.error(.cancelled))
+          return
+        }
 
         let activeCount = state.eliminated.values.filter { !$0 }.count
         if activeCount < 2 {
@@ -255,6 +291,12 @@ nonisolated public final class SimulationRunner: @unchecked Sendable {
   }
 
   /// Returns `true` if the task was cancelled while waiting for resume.
+  ///
+  /// Deliberately does **not** emit `.error(.cancelled)` itself: the nested
+  /// `pauseCheck` hook routes handler-side pauses through here too, and a
+  /// handler that then aborts its phase would produce a second error at the
+  /// runner's next cancellation check. Each caller emits the single
+  /// `.error(.cancelled)` for its own abort path instead (ADR-023 S4, #1622).
   ///
   /// Emits `.simulationPaused` exactly once, then suspends via
   /// `CheckedContinuation` until `isPaused` is set to `false` or the
@@ -319,11 +361,7 @@ nonisolated public final class SimulationRunner: @unchecked Sendable {
       cont?.resume()
     }
 
-    if Task.isCancelled {
-      ctx.emitter(.error(.cancelled))
-      return true
-    }
-    return false
+    return Task.isCancelled
   }
 
   /// Returns `true` if an error occurred and the simulation should stop.
@@ -344,6 +382,7 @@ nonisolated public final class SimulationRunner: @unchecked Sendable {
       // Check pause between phases so background switching can take effect
       // without waiting for the entire round to complete.
       if await checkPaused(ctx: ctx, round: currentRound, phasePath: phasePath) {
+        ctx.emitter(.error(.cancelled))
         return true
       }
 
@@ -364,6 +403,12 @@ nonisolated public final class SimulationRunner: @unchecked Sendable {
             // this between sub-phases so user pause requests are honored at
             // sub-phase granularity. Routes through the single `checkPaused`
             // so there's exactly one `.simulationPaused` emitter.
+            //
+            // A `true` result means cancelled: the handler must abort by
+            // throwing `SimulationError.cancelled`, which the `catch` below
+            // turns into the run's single `.error(.cancelled)`. Returning
+            // normally instead would let this phase's `.phaseCompleted` fire
+            // for work that never ran (ADR-023 S4, #1622).
             await checkPaused(ctx: ctx, round: currentRound, phasePath: nestedPath)
           },
           phasePath: phasePath,

--- a/Pastura/Pastura/Engine/SimulationRunner.swift
+++ b/Pastura/Pastura/Engine/SimulationRunner.swift
@@ -1,6 +1,9 @@
 // The round loop, the pause gate, and the phase loop share the private
 // `ExecutionContext`, so splitting them into sibling files would have to widen
 // its access. Kept in one file past the 400-line cap instead.
+// `SimulationRunner+SemanticLint.swift` could split off because it never
+// touches a `private` type-scope member of `SimulationRunner`; the round
+// loop, pause gate, and phase loop all read `ExecutionContext`, so they can't.
 // swiftlint:disable file_length
 import Foundation
 import Synchronization
@@ -141,8 +144,13 @@ nonisolated public final class SimulationRunner: @unchecked Sendable {
   ) -> AsyncStream<SimulationEvent> {
     AsyncStream { continuation in
       // Delegates to the emitter overload so both entry points share one
-      // execution path. The Task holds `self` for the run's duration only —
-      // `onTermination` below cancels it, and nothing outlives the run.
+      // execution path. The Task retains `self` for the run's duration;
+      // `onTermination` (stream finished, or the continuation deallocated)
+      // cancels it, so a consumer that stops iterating but still holds the
+      // stream keeps the runner alive until the run ends or the stream is
+      // dropped. An earlier version captured individual fields instead of
+      // `self` to avoid this retain; the emitter overload below now owns the
+      // execution path, so retaining `self` here is accepted.
       let task = Task {
         await self.run(
           scenario: scenario, llm: llm, suspendController: suspendController,
@@ -164,11 +172,17 @@ nonisolated public final class SimulationRunner: @unchecked Sendable {
   /// observe that tail: its only cancel path is terminating the stream, which
   /// drops everything emitted afterwards. (ADR-023 S4, #1622)
   ///
+  /// Runs on the global concurrent executor regardless of caller (`@concurrent`),
+  /// so a MainActor caller does not run inference on the main thread (swift-isolation.md
+  /// Pattern 6).
+  ///
   /// Parameters otherwise match
   /// ``run(scenario:llm:suspendController:resumingFrom:startRound:)``.
   ///
   /// - Parameter emitter: Receives every ``SimulationEvent`` in emission order.
-  ///   Called synchronously from the run's own task, hence `@Sendable`.
+  ///   `@Sendable` because the closure escapes across an isolation boundary
+  ///   (this method's body runs on the global executor, not the caller's).
+  @concurrent
   public func run(
     scenario: Scenario,
     llm: LLMService,

--- a/Pastura/PasturaTests/Engine/Phases/ConditionalHandlerTests+Cancellation.swift
+++ b/Pastura/PasturaTests/Engine/Phases/ConditionalHandlerTests+Cancellation.swift
@@ -1,0 +1,150 @@
+import Foundation
+import Testing
+import os
+
+@testable import Pastura
+
+/// Cancellation tail of a `conditional` branch (ADR-023 S4, #1622).
+///
+/// Invariant, matched to the Kotlin engine: a branch cut short by cancellation
+/// aborts by throwing ``SimulationError/cancelled`` rather than returning
+/// normally. That is what keeps the run's tail to exactly one
+/// `.error(.cancelled)` — the runner's `catch` emits it — with no
+/// `.phaseCompleted(.conditional)` for the branch that never finished and no
+/// `.simulationCompleted` after a cancel. A silent return produced all three
+/// defects, and on the pause path a second `.error(.cancelled)` as well.
+///
+/// The runner-side half of the invariant is asserted indirectly here: events
+/// emitted after cancellation are unobservable through
+/// `SimulationRunner.run`'s `AsyncStream` (cancelling the consumer terminates
+/// the stream, which is what cancels the runner's task in the first place), so
+/// the contract is pinned at the handler boundary where it is deterministic.
+extension ConditionalHandlerTests {
+
+  // MARK: - `Task.isCancelled` poll between sub-phases
+
+  @Test func cancellationBetweenSubPhasesThrowsCancelled() async throws {
+    let scenario = makeTestScenario(agentNames: ["Alice", "Bob"])
+    let conditional = Phase(
+      type: .conditional,
+      condition: "current_round == 0",
+      thenPhases: [
+        Phase(type: .summarize, template: "s0"),
+        Phase(type: .summarize, template: "s1")
+      ]
+    )
+    let collector = EventCollector()
+    let mock = MockLLMService(responses: [])
+
+    // The first sub-phase's pause check signals that it was reached, parks
+    // until the task is cancelled, and then reports "not paused". Sub-phase 0
+    // therefore runs to completion and the loop head for sub-phase 1 is
+    // reached with cancellation already pending — the `Task.isCancelled` poll,
+    // not the pause path. Cancelling before the handler starts would instead
+    // trip the poll at index 0, so the flag is what makes this deterministic.
+    let reachedFirstPauseCheck = OSAllocatedUnfairLock(initialState: false)
+    let context = makeCancellationContext(
+      scenario: scenario, phase: conditional, llm: mock, collector: collector,
+      pauseCheck: { path in
+        if path == [0, 0] {
+          reachedFirstPauseCheck.withLock { $0 = true }
+          while !Task.isCancelled { await Task.yield() }
+        }
+        return false
+      }
+    )
+
+    let task = Task<Void, Error> {
+      var state = SimulationState.initial(for: scenario)
+      try await ConditionalHandler().execute(context: context, state: &state)
+    }
+    while !reachedFirstPauseCheck.withLock({ $0 }) { await Task.yield() }
+    task.cancel()
+
+    await #expect(throws: SimulationError.cancelled) { try await task.value }
+
+    let summaries = collector.events.compactMap { event -> String? in
+      if case .summary(let text) = event { return text }
+      return nil
+    }
+    #expect(summaries.contains("s0"))
+    #expect(!summaries.contains("s1"))
+
+    // The completed sub-phase stays paired; the abandoned one never started.
+    #expect(completedPaths(collector) == [[0, 0]])
+    #expect(startedPaths(collector) == [[0, 0]])
+  }
+
+  // MARK: - Cancelled while parked on a pause between sub-phases
+
+  @Test func pauseCheckCancellationThrowsCancelledWithoutEmittingError() async throws {
+    let scenario = makeTestScenario(agentNames: ["Alice", "Bob"])
+    let conditional = Phase(
+      type: .conditional,
+      condition: "current_round == 0",
+      thenPhases: [
+        Phase(type: .summarize, template: "s0"),
+        Phase(type: .summarize, template: "s1")
+      ]
+    )
+    var state = SimulationState.initial(for: scenario)
+    let collector = EventCollector()
+    let mock = MockLLMService(responses: [])
+
+    // `true` == "cancelled while paused" — the runner's contract obliges the
+    // handler to throw, and to leave the single `.error(.cancelled)` to the
+    // runner.
+    let context = makeCancellationContext(
+      scenario: scenario, phase: conditional, llm: mock, collector: collector,
+      pauseCheck: { path in path == [0, 1] }
+    )
+
+    await #expect(throws: SimulationError.cancelled) {
+      try await ConditionalHandler().execute(context: context, state: &state)
+    }
+
+    let errors = collector.events.filter {
+      if case .error = $0 { return true }
+      return false
+    }
+    #expect(errors.isEmpty)
+    #expect(completedPaths(collector) == [[0, 0]])
+  }
+}
+
+/// Builds a top-level (`[0]`) conditional context with an explicit pause hook.
+///
+/// A sibling-file mirror of the suite's own `makeContext`, which is `private`
+/// (file-scoped) and therefore unreachable from this extension.
+private func makeCancellationContext(
+  scenario: Scenario,
+  phase: Phase,
+  llm: LLMService,
+  collector: EventCollector,
+  pauseCheck: @escaping @Sendable (_ phasePath: [Int]) async -> Bool
+) -> PhaseContext {
+  PhaseContext(
+    scenario: scenario,
+    phase: phase,
+    llm: llm,
+    suspendController: SuspendController(),
+    emitter: collector.emit,
+    pauseCheck: pauseCheck,
+    phasePath: [0],
+    turnGate: TurnFailureGate()
+  )
+}
+
+private func startedPaths(_ collector: EventCollector) -> [[Int]] {
+  collector.events.compactMap { event in
+    if case .phaseStarted(_, let path) = event { return path }
+    return nil
+  }
+}
+
+private func completedPaths(_ collector: EventCollector) -> [[Int]] {
+  collector.events.compactMap { event in
+    if case .phaseCompleted(_, let path) = event { return path }
+    return nil
+  }
+}

--- a/Pastura/PasturaTests/Engine/Phases/ConditionalHandlerTests.swift
+++ b/Pastura/PasturaTests/Engine/Phases/ConditionalHandlerTests.swift
@@ -211,13 +211,18 @@ struct ConditionalHandlerTests {
     let mock = MockLLMService(responses: [])
     let collector = EventCollector()
 
-    // pauseCheck returns true on the second sub-phase → handler returns
-    // early before executing sub1.
+    // pauseCheck returns true on the second sub-phase → the handler aborts
+    // before executing sub1. It throws rather than returning, so the runner
+    // does not mistake the cut-short branch for a completed one (ADR-023 S4,
+    // #1622) — the tail semantics are pinned in
+    // `ConditionalHandlerTests+Cancellation.swift`.
     let context = makeContext(
       scenario: scenario, phase: conditional, llm: mock, collector: collector,
       pauseCheck: { path in path == [0, 1] }
     )
-    try await handler.execute(context: context, state: &state)
+    await #expect(throws: SimulationError.cancelled) {
+      try await handler.execute(context: context, state: &state)
+    }
 
     let summaries = collector.events.compactMap { event -> String? in
       if case .summary(let text) = event { return text }

--- a/Pastura/PasturaTests/Engine/SimulationRunnerTests+Cancellation.swift
+++ b/Pastura/PasturaTests/Engine/SimulationRunnerTests+Cancellation.swift
@@ -1,0 +1,259 @@
+import Foundation
+import Testing
+import os
+
+@testable import Pastura
+
+/// Cancellation tail of a run (ADR-023 S4, #1622), matched to the Kotlin engine:
+/// every cancellation path emits **exactly one** `.error(.cancelled)` and it is
+/// the last event; `.simulationCompleted` never follows a cancel; and a
+/// `conditional` branch cut short emits no outer
+/// `.phaseCompleted(.conditional, [k])` — the sub-phases that did finish keep
+/// their `[k, n]` pairs.
+///
+/// These drive the `emitter:` overload of `run`, not the `AsyncStream` one: the
+/// stream's only cancel path is terminating the stream, which drops everything
+/// emitted afterwards, so the tail under test would be invisible there.
+///
+/// Each case cancels from inside the emitter — it runs synchronously on the
+/// run's own task, so cancellation is already pending when the runner reaches
+/// its next check. That is what makes the cut point exact instead of a sleep.
+extension SimulationRunnerTests {
+
+  // MARK: - (a) Cancelled between sub-phases inside a branch
+
+  @Test func cancelBetweenBranchSubPhasesEmitsSingleCancelledError() async throws {
+    let mock = MockLLMService(responses: [
+      #"{"statement": "hi"}"#,
+      #"{"statement": "hey"}"#
+    ])
+    try await mock.loadModel()
+
+    let scenario = makeTestScenario(
+      agentNames: ["Alice", "Bob"],
+      rounds: 1,
+      phases: [
+        Phase(
+          type: .conditional,
+          condition: "current_round == 1",
+          thenPhases: [
+            Phase(type: .speakAll, prompt: "Speak", outputSchema: ["statement": "string"]),
+            Phase(type: .summarize, template: "s1")
+          ]
+        )
+      ]
+    )
+
+    let runner = SimulationRunner()
+    let collector = EventCollector()
+    let box = RunTaskBox()
+
+    // Cancel the instant the branch's first sub-phase completes — i.e. after
+    // its last LLM call returned. The branch loop's next stop is the
+    // `Task.isCancelled` poll at the head of sub-phase 1.
+    let task = Task {
+      await runner.run(
+        scenario: scenario, llm: mock, suspendController: SuspendController(),
+        emitter: { event in
+          collector.emit(event)
+          if case .phaseCompleted(_, let path) = event, path == [0, 0] { box.cancel() }
+        })
+    }
+    box.arm(task)
+    await task.value
+
+    let events = collector.events
+    expectSingleCancelledTail(events)
+    #expect(completedPaths(events).contains([0, 0]))
+    #expect(!completedPaths(events).contains([0]))
+
+    // The abandoned sub-phase never ran.
+    let summaries = events.compactMap { event -> String? in
+      if case .summary(let text) = event { return text }
+      return nil
+    }
+    #expect(!summaries.contains("s1"))
+  }
+
+  // MARK: - (b) Cancelled while parked on a pause inside a branch
+
+  @Test func cancelWhileParkedInsideBranchEmitsSingleCancelledError() async throws {
+    let scenario = makeTestScenario(
+      agentNames: ["Alice", "Bob"],
+      rounds: 1,
+      phases: [
+        Phase(
+          type: .conditional,
+          condition: "current_round == 1",
+          thenPhases: [
+            Phase(type: .summarize, template: "s0"),
+            Phase(type: .summarize, template: "s1")
+          ]
+        )
+      ]
+    )
+
+    let runner = SimulationRunner()
+    let collector = EventCollector()
+    let box = RunTaskBox()
+
+    // Pause once the branch's first sub-phase is done, so the run parks at the
+    // sub-phase-1 pause check; cancel it there. This is the path that used to
+    // emit TWO `.error(.cancelled)` — one from `checkPaused`, one from the
+    // round loop after the handler returned silently.
+    let task = Task {
+      await runner.run(
+        scenario: scenario, llm: MockLLMService(responses: []),
+        suspendController: SuspendController(),
+        emitter: { event in
+          collector.emit(event)
+          switch event {
+          case .phaseCompleted(_, let path) where path == [0, 0]:
+            runner.isPaused = true
+          case .simulationPaused(_, let path) where path == [0, 1]:
+            box.cancel()
+          default:
+            break
+          }
+        })
+    }
+    box.arm(task)
+    await task.value
+
+    let events = collector.events
+    expectSingleCancelledTail(events)
+    #expect(completedPaths(events) == [[0, 0]])
+  }
+
+  // MARK: - (c) Cancelled while parked between top-level phases
+
+  @Test func cancelWhileParkedBetweenTopLevelPhasesEmitsSingleCancelledError() async throws {
+    let scenario = makeTestScenario(
+      agentNames: ["Alice", "Bob"],
+      rounds: 1,
+      phases: [
+        Phase(type: .summarize, template: "p0"),
+        Phase(type: .summarize, template: "p1")
+      ]
+    )
+
+    let runner = SimulationRunner()
+    let collector = EventCollector()
+    let box = RunTaskBox()
+
+    let task = Task {
+      await runner.run(
+        scenario: scenario, llm: MockLLMService(responses: []),
+        suspendController: SuspendController(),
+        emitter: { event in
+          collector.emit(event)
+          switch event {
+          case .phaseCompleted(_, let path) where path == [0]:
+            runner.isPaused = true
+          case .simulationPaused(_, let path) where path == [1]:
+            box.cancel()
+          default:
+            break
+          }
+        })
+    }
+    box.arm(task)
+    await task.value
+
+    let events = collector.events
+    expectSingleCancelledTail(events)
+    #expect(completedPaths(events) == [[0]])
+  }
+
+  // MARK: - (d) Cancelled while parked at the round-loop head
+
+  @Test func cancelWhileParkedBetweenRoundsEmitsSingleCancelledError() async throws {
+    let scenario = makeTestScenario(
+      agentNames: ["Alice", "Bob"],
+      rounds: 2,
+      phases: [Phase(type: .summarize, template: "p0")]
+    )
+
+    let runner = SimulationRunner()
+    let collector = EventCollector()
+    let box = RunTaskBox()
+
+    // Pause at the end of round 1 so the run parks at the round-2 loop head
+    // (`phasePath: []`), then cancel it there.
+    let task = Task {
+      await runner.run(
+        scenario: scenario, llm: MockLLMService(responses: []),
+        suspendController: SuspendController(),
+        emitter: { event in
+          collector.emit(event)
+          switch event {
+          case .roundCompleted(1, _):
+            runner.isPaused = true
+          case .simulationPaused(2, let path) where path.isEmpty:
+            box.cancel()
+          default:
+            break
+          }
+        })
+    }
+    box.arm(task)
+    await task.value
+
+    let events = collector.events
+    expectSingleCancelledTail(events)
+    let startedRounds = events.compactMap { event -> Int? in
+      if case .roundStarted(let round, _) = event { return round }
+      return nil
+    }
+    #expect(startedRounds == [1])
+  }
+}
+
+/// Holds the run's `Task` so the emitter — which runs inside that very task —
+/// can cancel it. `arm` is called synchronously right after `Task { }` returns,
+/// before the test task ever suspends, so the box is always populated by the
+/// time the run emits anything.
+private final class RunTaskBox: @unchecked Sendable {
+  private let stored = OSAllocatedUnfairLock(initialState: Task<Void, Never>?.none)
+
+  func arm(_ task: Task<Void, Never>) {
+    stored.withLock { $0 = task }
+  }
+
+  func cancel() {
+    stored.withLock { $0 }?.cancel()
+  }
+}
+
+/// The shared tail assertion: one `.error(.cancelled)`, last, and no
+/// `.simulationCompleted` anywhere.
+private func expectSingleCancelledTail(
+  _ events: [SimulationEvent], sourceLocation: SourceLocation = #_sourceLocation
+) {
+  let errors = events.compactMap { event -> SimulationError? in
+    if case .error(let error) = event { return error }
+    return nil
+  }
+  #expect(errors == [.cancelled], sourceLocation: sourceLocation)
+
+  if case .error(.cancelled)? = events.last {
+    // Tail is the cancellation error, as required.
+  } else {
+    Issue.record(
+      "expected `.error(.cancelled)` as the last event, got \(String(describing: events.last))",
+      sourceLocation: sourceLocation)
+  }
+
+  #expect(
+    !events.contains {
+      if case .simulationCompleted = $0 { return true }
+      return false
+    }, sourceLocation: sourceLocation)
+}
+
+private func completedPaths(_ events: [SimulationEvent]) -> [[Int]] {
+  events.compactMap { event in
+    if case .phaseCompleted(_, let path) = event { return path }
+    return nil
+  }
+}

--- a/Pastura/PasturaTests/Engine/SimulationRunnerTests+Cancellation.swift
+++ b/Pastura/PasturaTests/Engine/SimulationRunnerTests+Cancellation.swift
@@ -213,7 +213,7 @@ extension SimulationRunnerTests {
 /// can cancel it. `arm` is called synchronously right after `Task { }` returns,
 /// before the test task ever suspends, so the box is always populated by the
 /// time the run emits anything.
-private final class RunTaskBox: @unchecked Sendable {
+private final class RunTaskBox: Sendable {
   private let stored = OSAllocatedUnfairLock(initialState: Task<Void, Never>?.none)
 
   func arm(_ task: Task<Void, Never>) {

--- a/docs/kmp-migration-status.md
+++ b/docs/kmp-migration-status.md
@@ -32,7 +32,7 @@ _Last updated: 2026-08-29._
 | 1 | `shared/models` + CI infrastructure | ✅ done | #1052 #1055 #1059 |
 | 2 | Two-boundary vertical slice = GO/NO-GO gate | ✅ **GO** (2026-07-18) | #1063 #1137 #1172 · [ADR-023 §12](decisions/ADR-023.md) |
 | 3 | Bulk port to `commonMain` | ✅ done | ↓ Stage 3 breakdown |
-| 4 | Cross-language parity harness | 🔄 in progress | 1a #1387 · 1b #1458 · S3a [#1605](https://github.com/tyabu12/pastura/issues/1605) landed; S3b (RNG seam) [#1615](https://github.com/tyabu12/pastura/issues/1615) landed; S3b-2 (seeded fixtures) [#1618](https://github.com/tyabu12/pastura/issues/1618) landed; S4 next · [#501](https://github.com/tyabu12/pastura/issues/501) |
+| 4 | Cross-language parity harness | 🔄 in progress | 1a #1387 · 1b #1458 · S3a [#1605](https://github.com/tyabu12/pastura/issues/1605) landed; S3b (RNG seam) [#1615](https://github.com/tyabu12/pastura/issues/1615) landed; S3b-2 (seeded fixtures) [#1618](https://github.com/tyabu12/pastura/issues/1618) landed; S4 (cancellation tail) [#1622](https://github.com/tyabu12/pastura/issues/1622) landed; S5 next · [#501](https://github.com/tyabu12/pastura/issues/501) |
 | 5 | iOS consumption switch + code-merge | ⬜ not started | the remaining integration · adapter traps: [`kmp-interop.md`](../.claude/rules/kmp-interop.md) · ⚠️ en-only `ScenarioValidationMessage.render()` / `ScenarioLintMessage.render()` block this — [#1464](https://github.com/tyabu12/pastura/issues/1464), [#1562](https://github.com/tyabu12/pastura/issues/1562) |
 
 Legend: ✅ done · 🔄 in progress · 🟡 partial · ⬜ not started.
@@ -101,11 +101,16 @@ machine-checked — see the maintenance invariant above.
   ([#1618](https://github.com/tyabu12/pastura/issues/1618)) landed the first seeded fixtures —
   `word_wolf` and `last_fable` — which reached `assign random_one`, `event_inject`, `eliminate`,
   `narrate`, `reflect` and `relationship_update` with an empty ledger on the first replay.
-  Residue, all scope rather than mechanism: **S4** the cancellation event tail, **S5** ADR-023 §5.2 invariant 1's
+  **S4** ([#1622](https://github.com/tyabu12/pastura/issues/1622)) closed the cancellation
+  event tail by fixing Swift: `ConditionalHandler` now throws on cancellation and the runner
+  emits exactly one `.error(.cancelled)` per run, so `CANCELLATION_EVENT_TAIL` was deleted
+  from the ledger; `parityCancelConditional` cancels both engines on the same emitted
+  `phaseCompleted` (an event position, not a call index — Kotlin's `LLMCaller` observes
+  cancellation inside a backend call, the Swift responder does not) and both `EventLineMapper`s
+  now project the `error` line as the bare Swift case name.
+  Residue, all scope rather than mechanism: **S5** ADR-023 §5.2 invariant 1's
   suspend-then-succeed assertion, **S6** the divergence-6 ruling (pinned as a ledger entry;
-  deciding which side changes moves shipped Swift behaviour). `SimulationEvent.ErrorEvent`'s
-  projection is known to disagree across languages and is unexercised by every fixture — S4 is
-  the likely first driver.
+  deciding which side changes moves shipped Swift behaviour).
 - **Stage 5** (iOS switch + code-merge): ⬜ not started — the remaining iOS integration; the ported
   Kotlin loader still has no caller in `shared/engine`. See
   [ADR-023](decisions/ADR-023.md) §6 Stage 5.

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/Phases/ConditionalHandler.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/Phases/ConditionalHandler.kt
@@ -66,15 +66,14 @@ import com.pastura.models.SimulationState
  *
  * ## Divergences from the Swift original, all deliberate
  *
- * - **No `Task.isCancelled` poll.** Swift checks it at the loop head and returns
- *   early. Kotlin cancellation *throws*, and [PhaseContext.pauseCheck] — called at
- *   the same loop position — raises it as part of its documented contract, so a
- *   redundant `ensureActive()` here would assert that contract cannot be trusted.
- * - **Cancellation has an observably different event tail.** Swift's two early
- *   returns exit `execute` *normally*, so the runner goes on to emit
- *   `phaseCompleted(.conditional)`; Kotlin unwinds the run instead. A Stage-4 parity
- *   harness comparing transcripts will see this — it is a divergence, not an
- *   implementation detail.
+ * - **No `Task.isCancelled` poll.** Swift checks it at the loop head and throws
+ *   `SimulationError.cancelled`. Kotlin cancellation *throws* natively, and
+ *   [PhaseContext.pauseCheck] — called at the same loop position — raises it as part
+ *   of its documented contract, so a redundant `ensureActive()` here would assert
+ *   that contract cannot be trusted. The event tail is the same on both engines —
+ *   the inner `phaseCompleted`, no outer `phaseCompleted(.conditional)`, then one
+ *   `error(cancelled)` — since ADR-023 S4 (#1622) turned Swift's former silent
+ *   early returns into throws; `parityCancelConditional` pins it.
  * - **The `catch` is `Throwable`, wider than a typical port.** [NarrateHandler]
  *   narrowed *its* catch because that catch **absorbs** the error; this one rethrows
  *   unconditionally, so nothing is swallowed at any breadth. Narrower here would let

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/DivergenceLedger.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/DivergenceLedger.kt
@@ -69,11 +69,12 @@ internal object DivergenceLedger {
      * prescribed is unsatisfiable, and that property's KDoc records why.
      */
     internal enum class DivergenceClass(val documentedAt: String) {
-        /**
-         * Swift's early return still emits `phaseCompleted(.conditional)`;
-         * Kotlin unwinds the run instead.
-         */
-        CANCELLATION_EVENT_TAIL("ConditionalHandler.kt class KDoc, § Divergences"),
+        // `CANCELLATION_EVENT_TAIL` lived here — Swift's `ConditionalHandler` returned
+        // silently on cancellation, so its runner emitted `phaseCompleted(.conditional)`
+        // for a branch cut short where Kotlin unwinds. ADR-023 S4 (#1622) fixed Swift
+        // (cancellation now throws, one `.error(.cancelled)` per run) and
+        // `parityCancelConditional` pins the shared tail on both engines, so the case
+        // is DELETED for the same reason `SCHEMA_GUARD_POSITION` below was.
 
         // `SCHEMA_GUARD_POSITION` lived here — Swift returned a present-but-empty
         // canonical field as an `agentOutput` where Kotlin's parser guard exhausted
@@ -326,21 +327,21 @@ internal object DivergenceLedger {
      * [entries] rather than being edited.
      */
     internal val unreachableClasses: Map<DivergenceClass, String> = mapOf(
-        DivergenceClass.CANCELLATION_EVENT_TAIL to
-            "needs a mid-run cancellation `ParityFixtureEmitter` never performs (ADR-023 S4)",
         DivergenceClass.DETECTOR_UNINJECTED to
             "the emitter deliberately injects no detector — a real one wraps " +
             "NLLanguageRecognizer and would make the golden vary by host " +
             "(`parityRunEmitsNoLanguageMismatch` guards the omission)",
         DivergenceClass.LINT_PREDICATE_DIVERGENCE to
             "needs a condition operand that is non-finite/hex-float or non-ASCII with two " +
-            "findings in one condition; re-grepped 2026-08-29 over the six fixtures' five " +
+            "findings in one condition; re-grepped 2026-08-29 (S4) over the nine fixtures' eight " +
             "scenarios — `condition` across ParityGolden.kt, `if:` across " +
-            "tools/harness/Fixtures/*.yaml plus the four presets now used " +
-            "(target_score_race, prisoners_dilemma, bokete, DemoPresets/iiwake_battle_v1) — " +
-            "and target_score_race still holds the only condition in the set, the single " +
-            "ASCII decimal comparison `max_score >= 3`; the four other scenarios declare no " +
-            "conditional at all",
+            "tools/harness/Fixtures/*.yaml plus the six presets now used " +
+            "(target_score_race, prisoners_dilemma, bokete, word_wolf, last_fable, " +
+            "DemoPresets/iiwake_battle_v1) — and every condition in the set is a plain " +
+            "ASCII comparison of identifiers, decimal literals or a quoted ASCII string: " +
+            "target_score_race `max_score >= 3`, parity_cancel `current_round >= 1`, " +
+            "word_wolf `current_event != \"\"` and `vote_winner == wolf_name`; the four " +
+            "other scenarios declare no conditional at all",
         DivergenceClass.SCOREBOARD_ORDERING to
             "reaches the transcript through the summarize template, but needs agent names " +
             "where Unicode-scalar and UTF-16 order disagree, or two scoreboard keys that are " +

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/DivergenceLedger.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/DivergenceLedger.kt
@@ -340,7 +340,7 @@ internal object DivergenceLedger {
             "DemoPresets/iiwake_battle_v1) — and every condition in the set is a plain " +
             "ASCII comparison of identifiers, decimal literals or a quoted ASCII string: " +
             "target_score_race `max_score >= 3`, parity_cancel `current_round >= 1`, " +
-            "word_wolf `current_event != \"\"` and `vote_winner == wolf_name`; the four " +
+            "word_wolf `current_event != \"\"` and `vote_winner == wolf_name`; the five " +
             "other scenarios declare no conditional at all",
         DivergenceClass.SCOREBOARD_ORDERING to
             "reaches the transcript through the summarize template, but needs agent names " +

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/EngineParityTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/EngineParityTests.kt
@@ -2,7 +2,11 @@ package com.pastura.engine
 
 import com.pastura.engine.DivergenceLedger.LedgerEntry
 import com.pastura.models.Scenario
+import com.pastura.models.SimulationError
 import com.pastura.models.SimulationEvent
+import kotlin.concurrent.atomics.AtomicBoolean
+import kotlin.concurrent.atomics.AtomicReference
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -44,6 +48,7 @@ import kotlinx.serialization.json.Json
  * diverging call is the run's last the run *completes*, so the overrun surfaces
  * as extra `turn_skipped` / `inference_started` lines instead.
  */
+@OptIn(ExperimentalAtomicApi::class)
 class EngineParityTests {
 
     /**
@@ -120,6 +125,9 @@ class EngineParityTests {
     private suspend fun replay(fixture: ParityGolden.Fixture): Pair<List<SimulationEvent>, Int> {
         val backend = ScriptedLLMBackend(scriptsFor(fixture))
         val collector = Collector()
+        // Null for every fixture that runs to completion, so the callback below
+        // is exactly what it was before the cancelling arm landed.
+        val cutter = fixture.cancelAfterPhaseCompleted?.let { CancelOnPhaseCompleted(it) }
         // A seeded fixture must feed both engines the same stream, so the replay
         // rebuilds SplitMix64 from the seed the Swift run used; an unseeded one is
         // RNG-free by construction, where the source is unobservable. The Swift
@@ -130,14 +138,72 @@ class EngineParityTests {
             fixture.seed?.let { SplitMix64RandomSource(it) } ?: SystemRandomSource()
         val handle =
             SimulationEngine(random = random).run(scenarioOf(fixture), backend) {
+                // Recorded BEFORE the cut is requested, so the triggering event is
+                // itself in the transcript — it is the Swift golden's second-to-last
+                // line, not something the cancellation swallows.
                 collector.record(it)
+                cutter?.observe(it)
             }
+        // `run` installs the callback and only then returns the handle, so the
+        // trigger can fire before this line. [CancelOnPhaseCompleted] latches that
+        // case and cancels here instead of dropping it.
+        cutter?.adopt(handle)
         try {
             awaitTerminal(collector, timeoutMillis = 30_000)
         } finally {
             handle.cancel()
         }
+        if (cutter != null && !cutter.fired) {
+            throw AssertionError(
+                "${fixture.name}: the replay never emitted phase_completed " +
+                    "${fixture.cancelAfterPhaseCompleted}, so the run was never cancelled and " +
+                    "this fixture compared a completed run against a cancelled golden. The " +
+                    "Swift emitter raises `cancelTriggerNeverFired` on the same condition.",
+            )
+        }
         return collector.snapshot() to backend.callCount
+    }
+
+    /**
+     * Cancels the run the moment a `PhaseCompleted` with [path] is recorded.
+     *
+     * **The trigger is an emitted-event position, not a backend call index** —
+     * `ParityFixtureEmitter.FixtureSpec.cancelAfterPhaseCompleted` carries the
+     * reasoning, and this class is its Kotlin half: Kotlin's [LLMCaller] observes
+     * cancellation from *inside* a backend call while the Swift responder does
+     * not, so a call-indexed cut would land at different logical points on the two
+     * engines and the transcript diff would be about where the harness cut rather
+     * than about how the engines unwind. On the event position both are at the head
+     * of `ConditionalHandler`'s sub-phase loop, where Swift polls `Task.isCancelled`
+     * and Kotlin's `pauseCheck` raises.
+     *
+     * Atomics rather than plain fields because `onEvent` fires from
+     * `Dispatchers.Default` while [adopt] runs on the test's thread — the same
+     * reason [Collector] uses one — and because the latch must fire exactly once:
+     * a fixture whose path repeats across rounds would otherwise cancel twice,
+     * which is harmless today only by accident.
+     */
+    private class CancelOnPhaseCompleted(private val path: List<Int>) {
+        private val handle = AtomicReference<RunHandle?>(null)
+        private val pendingCancel = AtomicBoolean(false)
+        private val triggered = AtomicBoolean(false)
+
+        /** Whether the trigger event was ever seen. */
+        val fired: Boolean get() = triggered.load()
+
+        /** Stores the run's handle, cancelling now when the trigger already fired. */
+        fun adopt(runHandle: RunHandle) {
+            handle.store(runHandle)
+            if (pendingCancel.load()) runHandle.cancel()
+        }
+
+        /** Cancels the run when [event] is the trigger; ignores everything else. */
+        fun observe(event: SimulationEvent) {
+            if (event !is SimulationEvent.PhaseCompleted || event.phasePath != path) return
+            if (!triggered.compareAndSet(false, true)) return
+            val runHandle = handle.load()
+            if (runHandle == null) pendingCancel.store(true) else runHandle.cancel()
+        }
     }
 
     /**
@@ -149,7 +215,12 @@ class EngineParityTests {
      */
     private fun assertRunCompleted(fixture: ParityGolden.Fixture, events: List<SimulationEvent>) {
         val terminal = events.lastOrNull()
+        val cancelling = fixture.cancelAfterPhaseCompleted != null
         if (terminal is SimulationEvent.ErrorEvent) {
+            // A cancelling fixture's whole point is that `ErrorEvent(Cancelled)` IS
+            // the terminal event — checked before the overrun arm, which would
+            // otherwise report the expected tail as a failure.
+            if (cancelling && terminal.error == SimulationError.Cancelled) return
             val error = terminal.error.toString()
             val overran = "ScriptedLLMBackend exhausted" in error
             throw AssertionError(
@@ -161,6 +232,16 @@ class EngineParityTests {
                 } else {
                     "${fixture.name}: the run ended with an error rather than completing: $error"
                 },
+            )
+        }
+        // A cancelled run must NOT complete: `SimulationCompleted` here means the
+        // cut never took effect, which is the failure the Swift fix (#1622) exists
+        // to prevent — the branch would have gone on to run its second sub-phase.
+        if (cancelling) {
+            throw AssertionError(
+                "${fixture.name}: cancelled after phase_completed " +
+                    "${fixture.cancelAfterPhaseCompleted}, so the terminal event must be " +
+                    "ErrorEvent(Cancelled) — it was $terminal",
             )
         }
         assertTrue(

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/EngineParityTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/EngineParityTests.kt
@@ -111,7 +111,7 @@ class EngineParityTests {
      * `prisonersDilemmaNominal`, 36 for the three-round `lastFableNominal` —
      * doing prompt building, streaming callbacks and JSON parsing while polled
      * at `delay(1)`, and the `macosArm64` rung was the slower of the two when
-     * the bound was set (measured 2026-08-29 with eight fixtures: 0.15 s for
+     * the bound was set (measured 2026-08-29 with nine fixtures: 0.15 s for
      * the whole roster on `macosArm64`, 0.48 s on the JVM — so the bound is
      * headroom, not a budget). Under the old bound a
      * loaded runner would fail as a timeout that reads like a hang rather than
@@ -182,10 +182,17 @@ class EngineParityTests {
      * reason [Collector] uses one — and because the latch must fire exactly once:
      * a fixture whose path repeats across rounds would otherwise cancel twice,
      * which is harmless today only by accident.
+     *
+     * No pending-cancel flag: [observe]'s `compareAndSet` on [triggered] runs
+     * BEFORE its `handle.load()`, and [adopt]'s `handle.store` runs BEFORE its
+     * `triggered.load()`, so every interleaving of the two leaves at least one
+     * side seeing the other's write — either [observe] sees the stored handle
+     * and cancels directly, or [adopt] sees `triggered == true` and cancels
+     * directly. The two calling a redundant `cancel()` on the same run is safe
+     * because `RunHandleImpl` documents every method as idempotent.
      */
     private class CancelOnPhaseCompleted(private val path: List<Int>) {
         private val handle = AtomicReference<RunHandle?>(null)
-        private val pendingCancel = AtomicBoolean(false)
         private val triggered = AtomicBoolean(false)
 
         /** Whether the trigger event was ever seen. */
@@ -194,15 +201,14 @@ class EngineParityTests {
         /** Stores the run's handle, cancelling now when the trigger already fired. */
         fun adopt(runHandle: RunHandle) {
             handle.store(runHandle)
-            if (pendingCancel.load()) runHandle.cancel()
+            if (triggered.load()) runHandle.cancel()
         }
 
         /** Cancels the run when [event] is the trigger; ignores everything else. */
         fun observe(event: SimulationEvent) {
             if (event !is SimulationEvent.PhaseCompleted || event.phasePath != path) return
             if (!triggered.compareAndSet(false, true)) return
-            val runHandle = handle.load()
-            if (runHandle == null) pendingCancel.store(true) else runHandle.cancel()
+            handle.load()?.cancel()
         }
     }
 

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/EventLineMapper.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/EventLineMapper.kt
@@ -1,5 +1,6 @@
 package com.pastura.engine
 
+import com.pastura.models.SimulationError
 import com.pastura.models.SimulationEvent
 import kotlin.math.floor
 import kotlinx.serialization.json.JsonArray
@@ -156,23 +157,30 @@ internal object EventLineMapper {
                 "round" to JsonPrimitive(event.round),
                 "phase_path" to path(event.phasePath),
             )
-            // ⚠️ KNOWN TO DISAGREE WITH SWIFT, AND UNEXERCISED — but DETERMINISTIC,
-            // which `toString()` was not: `SimulationError`'s singletons are
-            // plain `object`s, so `toString()` falls through to `Any.toString()`
-            // and yields `…SimulationError$Cancelled@7ceb3185`, whose identity
-            // hash changes every run. No fixture reaches an error path today, so
-            // nothing was red; the first one that does would have made the
-            // golden drift against itself.
-            //
-            // `simpleName` still will not match Swift, which projects via
-            // `String(describing: error)` and yields the lowercase case
-            // (`cancelled` vs `Cancelled`); and a payload-carrying case loses
-            // its payload here where Swift keeps it. Whoever first drives an
-            // error path — S4's cancellation tail is the likely trigger — must
-            // close that with a ledger entry or a shared spelling.
+            // The `error` field projects the bare Swift `SimulationError` case
+            // name (never `simpleName`'s PascalCase, never a payload) so the
+            // `error` line compares across engines — see
+            // `EventLineMapper.swift`'s `errorCaseName`, the Swift twin of this
+            // `when`. Payloads are dropped on both sides on purpose: they carry
+            // localized / free text (an LLM failure description, a raw JSON
+            // parse snippet) that is not a parity contract. `when (event.error)`
+            // is exhaustive with no `else` (ADR-022) for the same reason as the
+            // outer `when` — a new `SimulationError` case must fail to compile
+            // here rather than silently reach neither engine's transcript. ADR-023
+            // S4 (#1622) is the first fixture to drive an error line.
             is SimulationEvent.ErrorEvent -> fields(
                 "event" to JsonPrimitive("error"),
-                "error" to JsonPrimitive(event.error::class.simpleName ?: "unknown"),
+                "error" to JsonPrimitive(
+                    when (event.error) {
+                        is SimulationError.ScenarioValidationFailed -> "scenarioValidationFailed"
+                        is SimulationError.LlmGenerationFailed -> "llmGenerationFailed"
+                        is SimulationError.JsonParseFailed -> "jsonParseFailed"
+                        is SimulationError.RetriesExhausted -> "retriesExhausted"
+                        is SimulationError.ModelNotLoaded -> "modelNotLoaded"
+                        is SimulationError.Cancelled -> "cancelled"
+                        is SimulationError.TurnFailureLimitReached -> "turnFailureLimitReached"
+                    },
+                ),
             )
             is SimulationEvent.InferenceStarted -> fields(
                 "event" to JsonPrimitive("inference_started"),

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/EventLineMapper.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/EventLineMapper.kt
@@ -167,7 +167,10 @@ internal object EventLineMapper {
             // is exhaustive with no `else` (ADR-022) for the same reason as the
             // outer `when` — a new `SimulationError` case must fail to compile
             // here rather than silently reach neither engine's transcript. ADR-023
-            // S4 (#1622) is the first fixture to drive an error line.
+            // S4 (#1622) is the first fixture to drive an error line. Each string
+            // literal below is kept in step with its case's `@SerialName` in
+            // `SimulationEvent.kt` by hand — the else-less `when` catches a new
+            // case, but nothing gates a rename of an existing one.
             is SimulationEvent.ErrorEvent -> fields(
                 "event" to JsonPrimitive("error"),
                 "error" to JsonPrimitive(

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/EventLineMapperTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/EventLineMapperTests.kt
@@ -104,11 +104,11 @@ class EventLineMapperTests {
         SimulationEvent.RoundCheckpoint(state = SimulationState.initial(scenario)) to null,
         SimulationEvent.SimulationPaused(round = 1, phasePath = listOf(0)) to
             """{"attempt":0,"event":"simulation_paused","phase_path":[0],"round":1,"t":0,"type":"event"}""",
-        // The case NAME, deliberately: `SimulationError`'s singletons are plain
-        // `object`s, so `toString()` yields an identity hash that changes every
-        // run. See the arm's comment in `EventLineMapper`.
+        // The bare Swift case name (`cancelled`, not `Cancelled`/`toString()`'s
+        // identity hash) — the parity contract with `EventLineMapper.swift`'s
+        // `errorCaseName`. See the arm's comment in `EventLineMapper`.
         SimulationEvent.ErrorEvent(error = SimulationError.Cancelled) to
-            """{"attempt":0,"error":"Cancelled","event":"error","t":0,"type":"event"}""",
+            """{"attempt":0,"error":"cancelled","event":"error","t":0,"type":"event"}""",
         SimulationEvent.InferenceStarted(agent = "a") to
             """{"agent":"a","attempt":0,"event":"inference_started","t":0,"type":"event"}""",
         SimulationEvent.InferenceCompleted(agent = "a", durationSeconds = 0.0, tokenCount = 7) to
@@ -197,6 +197,24 @@ class EventLineMapperTests {
             fractional.contains(""""t":1.5"""),
             "a fractional t lost its decimals — the renderer truncates instead of " +
                 "dropping a trailing .0: $fractional",
+        )
+    }
+
+    // ADR-023 S4 (#1622) — a payload-carrying `SimulationError` drops its
+    // payload just like the singleton cases above; only the bare case name
+    // survives into the `error` field.
+    @Test
+    fun payloadCarryingErrorProjectsToItsBareCaseNameOnly() {
+        val line = assertNotNull(
+            EventLineMapper.map(
+                SimulationEvent.ErrorEvent(
+                    error = SimulationError.LlmGenerationFailed(description = "boom"),
+                ),
+            ),
+        )
+        assertEquals(
+            """{"attempt":0,"error":"llmGenerationFailed","event":"error","t":0,"type":"event"}""",
+            line,
         )
     }
 

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/ParityGolden.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/ParityGolden.kt
@@ -12,6 +12,11 @@
 // `seed` is present only on a fixture whose scenario draws: the replay
 // builds `SplitMix64RandomSource(seed)` so both engines consume the same
 // stream. Absent means RNG-free, where the source is unobservable.
+//
+// `cancelAfterPhaseCompleted` is present only on a fixture the harness cut
+// short: the replay cancels its `RunHandle` the moment it records a
+// `PhaseCompleted` with that `phasePath`, which is where the Swift run was
+// cancelled too. Absent means the run went to `SimulationCompleted`.
 
 package com.pastura.engine
 
@@ -25,6 +30,7 @@ internal object ParityGolden {
         val transcript: List<String>,
         val callCount: Int,
         val seed: ULong? = null,
+        val cancelAfterPhaseCompleted: List<Int>? = null,
     )
 
     /**
@@ -1281,6 +1287,60 @@ internal object ParityGolden {
     )
 
     /**
+     * Cancellation control (ADR-023 S4, #1622). The only fixture whose run does NOT reach `simulation_completed`: the harness cancels it the moment `phase_completed [1, 0]` — the conditional branch's first sub-phase — is emitted, and what it freezes is the event tail both engines produce from there.
+     *
+     * **What it witnesses.** Swift used to exit `ConditionalHandler`'s sub-phase loop by RETURNING on cancellation, so the runner read the branch as finished and emitted `phase_completed [1]` for work that had been cut short — and on the pause path a second `error cancelled` on top. #1622 made both paths throw, so the tail is now exactly what Kotlin has always produced: `phase_completed [1, 0]` then `error cancelled` as the LAST line, with no `phase_completed` for the outer `[1]` and no `simulation_completed` at all. The branch's second sub-phase — a template `summarize` at `[1, 1]` — never starts, which is visible as an absent `phase_started` rather than only as a call count.
+     *
+     * **Why its own scenario.** No bundled preset has a conditional branch with two sub-phases: `target_score_race` and `word_wolf` each branch into a single `summarize`, so the cancel would have had nowhere to land between sub-phases and the fixture would have measured the branch's exit rather than its interruption.
+     *
+     * **Why the trigger is an event position and not a call index** is `FixtureSpec.cancelAfterPhaseCompleted`'s own doc: Kotlin observes cancellation inside a backend call and Swift's responder does not, so a call-indexed cut lands at different logical points on the two engines and the diff would be about the harness.
+     */
+    internal val parityCancelConditional: Fixture = Fixture(
+        name = "parityCancelConditional",
+        scenarioJson = """
+{"agentCount":3,"context":"A fixture scenario for cross-language parity testing. Content is irrelevant to the measurement; the responder never reads this.\n","description":"One round, one conditional whose taken branch holds two sub-phases. The parity harness cancels the run the moment the first sub-phase completes, so the cancellation event tail is what this fixture measures.\n","extraData":{},"id":"parity_cancel","language":"en","name":"Parity Cancellation Control","personas":[{"description":"A parity fixture participant. Speaks in one short sentence.\n","name":"Ada"},{"description":"A parity fixture participant. Speaks in one short sentence.\n","name":"Bo"},{"description":"A parity fixture participant. Speaks in one short sentence.\n","name":"Cy"}],"phases":[{"outputSchema":{"inner_thought":"string","statement":"string"},"prompt":"Say one short sentence about round {current_round}.\n","type":"speak_all"},{"condition":"current_round >= 1","thenPhases":[{"outputSchema":{"inner_thought":"string","statement":"string"},"prompt":"Say one more short sentence.\n","type":"speak_all"},{"template":"Round {current_round} wrap-up. This line must never appear in the cancellation fixture's transcript.\n","type":"summarize"}],"type":"conditional"}],"rounds":1}
+""".trimIndent(),
+        responses = listOf(
+            """{"statement": "statement 0", "inner_thought": "inner_thought 0"}""",
+            """{"statement": "statement 1", "inner_thought": "inner_thought 1"}""",
+            """{"statement": "statement 2", "inner_thought": "inner_thought 2"}""",
+            """{"statement": "statement 3", "inner_thought": "inner_thought 3"}""",
+            """{"statement": "statement 4", "inner_thought": "inner_thought 4"}""",
+            """{"statement": "statement 5", "inner_thought": "inner_thought 5"}""",
+        ),
+        transcript = listOf(
+            """{"attempt":0,"event":"round_started","round":1,"t":0,"total_rounds":1,"type":"event"}""",
+            """{"attempt":0,"event":"phase_started","phase_path":[0],"phase_type":"speak_all","t":0,"type":"event"}""",
+            """{"agent":"Ada","attempt":0,"event":"inference_started","t":0,"type":"event"}""",
+            """{"agent":"Ada","attempt":0,"duration_seconds":0,"event":"inference_completed","t":0,"type":"event"}""",
+            """{"agent":"Ada","attempt":0,"event":"agent_output","fields":{"inner_thought":"inner_thought 0","statement":"statement 0"},"phase_type":"speak_all","t":0,"type":"event"}""",
+            """{"agent":"Bo","attempt":0,"event":"inference_started","t":0,"type":"event"}""",
+            """{"agent":"Bo","attempt":0,"duration_seconds":0,"event":"inference_completed","t":0,"type":"event"}""",
+            """{"agent":"Bo","attempt":0,"event":"agent_output","fields":{"inner_thought":"inner_thought 1","statement":"statement 1"},"phase_type":"speak_all","t":0,"type":"event"}""",
+            """{"agent":"Cy","attempt":0,"event":"inference_started","t":0,"type":"event"}""",
+            """{"agent":"Cy","attempt":0,"duration_seconds":0,"event":"inference_completed","t":0,"type":"event"}""",
+            """{"agent":"Cy","attempt":0,"event":"agent_output","fields":{"inner_thought":"inner_thought 2","statement":"statement 2"},"phase_type":"speak_all","t":0,"type":"event"}""",
+            """{"attempt":0,"event":"phase_completed","phase_path":[0],"phase_type":"speak_all","t":0,"type":"event"}""",
+            """{"attempt":0,"event":"phase_started","phase_path":[1],"phase_type":"conditional","t":0,"type":"event"}""",
+            """{"attempt":0,"condition":"current_round >= 1","event":"conditional_evaluated","result":true,"t":0,"type":"event"}""",
+            """{"attempt":0,"event":"phase_started","phase_path":[1,0],"phase_type":"speak_all","t":0,"type":"event"}""",
+            """{"agent":"Ada","attempt":0,"event":"inference_started","t":0,"type":"event"}""",
+            """{"agent":"Ada","attempt":0,"duration_seconds":0,"event":"inference_completed","t":0,"type":"event"}""",
+            """{"agent":"Ada","attempt":0,"event":"agent_output","fields":{"inner_thought":"inner_thought 3","statement":"statement 3"},"phase_type":"speak_all","t":0,"type":"event"}""",
+            """{"agent":"Bo","attempt":0,"event":"inference_started","t":0,"type":"event"}""",
+            """{"agent":"Bo","attempt":0,"duration_seconds":0,"event":"inference_completed","t":0,"type":"event"}""",
+            """{"agent":"Bo","attempt":0,"event":"agent_output","fields":{"inner_thought":"inner_thought 4","statement":"statement 4"},"phase_type":"speak_all","t":0,"type":"event"}""",
+            """{"agent":"Cy","attempt":0,"event":"inference_started","t":0,"type":"event"}""",
+            """{"agent":"Cy","attempt":0,"duration_seconds":0,"event":"inference_completed","t":0,"type":"event"}""",
+            """{"agent":"Cy","attempt":0,"event":"agent_output","fields":{"inner_thought":"inner_thought 5","statement":"statement 5"},"phase_type":"speak_all","t":0,"type":"event"}""",
+            """{"attempt":0,"event":"phase_completed","phase_path":[1,0],"phase_type":"speak_all","t":0,"type":"event"}""",
+            """{"attempt":0,"error":"cancelled","event":"error","t":0,"type":"event"}""",
+        ),
+        callCount = 6,
+        cancelAfterPhaseCompleted = listOf(1, 0),
+    )
+
+    /**
      * Every fixture, so a consumer cannot silently scope itself to one.
      *
      * The named properties above are the readable handles; this is what
@@ -1296,5 +1356,6 @@ internal object ParityGolden {
         parityStructuralControl,
         wordWolfNominal,
         lastFableNominal,
+        parityCancelConditional,
     )
 }

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/TranscriptComparatorTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/TranscriptComparatorTests.kt
@@ -149,7 +149,7 @@ class TranscriptComparatorTests {
         expectedLine = line,
         // Any structural class serves — this fixture data is synthetic and the
         // comparator never reads the class, only the entry shape.
-        divergenceClass = DivergenceClass.CANCELLATION_EVENT_TAIL,
+        divergenceClass = DivergenceClass.MULTI_OBJECT_SALVAGE,
     )
 
     @Test

--- a/tools/harness/Fixtures/parity_cancel.yaml
+++ b/tools/harness/Fixtures/parity_cancel.yaml
@@ -1,0 +1,73 @@
+# ADR-023 Stage-4 parity fixture — NOT a shipped preset.
+#
+# Sibling of parity_structural.yaml, and here for the same reason: it is
+# machinery coverage, not content. `PresetLoader` never sees it,
+# `pastura-harness lint` does not glob this directory, and nothing bundles it
+# into the app.
+#
+# Shape is load-bearing and minimal on purpose:
+# - one round, three agents;
+# - phase 0 is a plain `speak_all`, so the run has a head that must survive
+#   intact whatever the cancellation does later;
+# - phase 1 is a `conditional` whose branch holds TWO sub-phases. No bundled
+#   preset has that: `target_score_race` and `word_wolf` each branch into a
+#   single template `summarize`, so a cancel landing between sub-phases had
+#   nowhere to land. Here `[1, 0]` runs and `[1, 1]` must never start.
+# - the branch's second sub-phase is a template `summarize`, which issues no
+#   backend call — so "it never ran" is visible in the transcript rather than
+#   only in `callCount`.
+#
+# `if: "current_round >= 1"` is variable-free in the sense that matters: both
+# operands are always present (`current_round` is written by the round loop
+# before any phase runs, and `1` is a literal), so the then-branch is taken on
+# every engine without depending on a score, a vote, or a draw. An
+# always-present operand also keeps the semantic linter (ADR-024 R13-R15)
+# silent, which a persona name or a `scores.<Name>` operand would not.
+#
+# Deterministic: the responder answers from the schema, never the prompt, and
+# no phase here injects RNG.
+id: parity_cancel
+language: en
+name: Parity Cancellation Control
+description: >
+  One round, one conditional whose taken branch holds two sub-phases. The
+  parity harness cancels the run the moment the first sub-phase completes, so
+  the cancellation event tail is what this fixture measures.
+agents: 3
+rounds: 1
+context: >
+  A fixture scenario for cross-language parity testing. Content is irrelevant
+  to the measurement; the responder never reads this.
+
+personas:
+  - name: Ada
+    description: >
+      A parity fixture participant. Speaks in one short sentence.
+  - name: Bo
+    description: >
+      A parity fixture participant. Speaks in one short sentence.
+  - name: Cy
+    description: >
+      A parity fixture participant. Speaks in one short sentence.
+
+phases:
+  - type: speak_all
+    prompt: >
+      Say one short sentence about round {current_round}.
+    output:
+      statement: string
+      inner_thought: string
+
+  - type: conditional
+    if: "current_round >= 1"
+    then:
+      - type: speak_all
+        prompt: >
+          Say one more short sentence.
+        output:
+          statement: string
+          inner_thought: string
+      - type: summarize
+        template: >
+          Round {current_round} wrap-up. This line must never appear in the
+          cancellation fixture's transcript.

--- a/tools/harness/Sources/PasturaHarnessKit/EventLineMapper.swift
+++ b/tools/harness/Sources/PasturaHarnessKit/EventLineMapper.swift
@@ -155,7 +155,11 @@ package enum EventLineMapper {
   /// worth cross-engine comparison, so both sides project the case name only
   /// (e.g. `cancelled`, `llmGenerationFailed`). No `default:` (ADR-022) so a
   /// new `SimulationError` case fails to compile here instead of silently
-  /// falling through `String(describing:)`.
+  /// falling through `String(describing:)`. The per-event run-log line
+  /// therefore loses the error payload for every mapper consumer
+  /// (`HarnessRunner` included) — accepted, since the message still survives
+  /// in the `run_end` line's `error` field and in `HarnessRunner`'s
+  /// `.failed(String(describing:))` outcome.
   private static func errorCaseName(_ error: SimulationError) -> String {
     switch error {
     case .scenarioValidationFailed:

--- a/tools/harness/Sources/PasturaHarnessKit/EventLineMapper.swift
+++ b/tools/harness/Sources/PasturaHarnessKit/EventLineMapper.swift
@@ -103,7 +103,7 @@ package enum EventLineMapper {
         phasePath: phasePath)
     case .error(let error):
       return EventLine(
-        t: t, attempt: attempt, event: "error", error: String(describing: error))
+        t: t, attempt: attempt, event: "error", error: errorCaseName(error))
     case .inferenceStarted(let agent):
       return EventLine(t: t, attempt: attempt, event: "inference_started", agent: agent)
     case .inferenceCompleted(let agent, let durationSeconds, let tokenCount):
@@ -146,6 +146,32 @@ package enum EventLineMapper {
       // this switch — the compile-time canary the upstream tiers' `default:`
       // forwarding would otherwise lose.
       return nil
+    }
+  }
+
+  /// Bare `SimulationError` case name, dropping any payload. This is the
+  /// parity contract with the Kotlin mapper (`EventLineMapper.kt`) for the
+  /// `error` field: payload strings carry localized / free text that is not
+  /// worth cross-engine comparison, so both sides project the case name only
+  /// (e.g. `cancelled`, `llmGenerationFailed`). No `default:` (ADR-022) so a
+  /// new `SimulationError` case fails to compile here instead of silently
+  /// falling through `String(describing:)`.
+  private static func errorCaseName(_ error: SimulationError) -> String {
+    switch error {
+    case .scenarioValidationFailed:
+      return "scenarioValidationFailed"
+    case .llmGenerationFailed:
+      return "llmGenerationFailed"
+    case .jsonParseFailed:
+      return "jsonParseFailed"
+    case .retriesExhausted:
+      return "retriesExhausted"
+    case .modelNotLoaded:
+      return "modelNotLoaded"
+    case .cancelled:
+      return "cancelled"
+    case .turnFailureLimitReached:
+      return "turnFailureLimitReached"
     }
   }
 }

--- a/tools/harness/Sources/PasturaHarnessKit/ParityFixtureEmitter+KotlinSource.swift
+++ b/tools/harness/Sources/PasturaHarnessKit/ParityFixtureEmitter+KotlinSource.swift
@@ -50,6 +50,11 @@ extension ParityFixtureEmitter {
       "// `seed` is present only on a fixture whose scenario draws: the replay",
       "// builds `SplitMix64RandomSource(seed)` so both engines consume the same",
       "// stream. Absent means RNG-free, where the source is unobservable.",
+      "//",
+      "// `cancelAfterPhaseCompleted` is present only on a fixture the harness cut",
+      "// short: the replay cancels its `RunHandle` the moment it records a",
+      "// `PhaseCompleted` with that `phasePath`, which is where the Swift run was",
+      "// cancelled too. Absent means the run went to `SimulationCompleted`.",
       "",
       "package com.pastura.engine",
       "",
@@ -63,6 +68,7 @@ extension ParityFixtureEmitter {
       "        val transcript: List<String>,",
       "        val callCount: Int,",
       "        val seed: ULong? = null,",
+      "        val cancelAfterPhaseCompleted: List<Int>? = null,",
       "    )"
     ]
   }
@@ -90,6 +96,13 @@ extension ParityFixtureEmitter {
     // to what it was before the seam landed and the field's default carries it.
     if let seed = fixture.seed {
       lines.append("        seed = \(seed)uL,")
+    }
+    // Same rule as `seed`: emitted only when set, so every run-to-completion
+    // fixture's block stays byte-identical to what it was before the seam
+    // landed and the field's default carries it.
+    if let path = fixture.cancelAfterPhaseCompleted {
+      let rendered = path.map(String.init).joined(separator: ", ")
+      lines.append("        cancelAfterPhaseCompleted = listOf(\(rendered)),")
     }
     lines.append("    )")
     return lines

--- a/tools/harness/Sources/PasturaHarnessKit/ParityFixtureEmitter+Specs.swift
+++ b/tools/harness/Sources/PasturaHarnessKit/ParityFixtureEmitter+Specs.swift
@@ -10,7 +10,7 @@ extension ParityFixtureEmitter {
   /// A spec whose scenario draws from the `RandomSource` (`assign random_one`,
   /// `event_inject`) sets `seed:`, and one that draws nothing must not —
   /// `seededSpecsAreExactlyTheDrawingOnes` holds both directions, derived from
-  /// the loaded scenario rather than from a name list. The six unseeded specs
+  /// the loaded scenario rather than from a name list. The seven unseeded specs
   /// are RNG-free by construction (S3a); `wordWolfNominal` and
   /// `lastFableNominal` are the seeded ones (S3b-2, #1618), and between them
   /// they witness every handler the unseeded roster could not reach.
@@ -261,6 +261,42 @@ extension ParityFixtureEmitter {
         35: #"{"vote": "カラス", "reason": "reason 35"}"#
       ],
       seed: 1
+    ),
+    FixtureSpec(
+      name: "parityCancelConditional",
+      scenarioPath: "tools/harness/Fixtures/parity_cancel.yaml",
+      purpose: """
+        Cancellation control (ADR-023 S4, #1622). The only fixture whose run \
+        does NOT reach `simulation_completed`: the harness cancels it the \
+        moment `phase_completed [1, 0]` — the conditional branch's first \
+        sub-phase — is emitted, and what it freezes is the event tail both \
+        engines produce from there.
+
+        **What it witnesses.** Swift used to exit `ConditionalHandler`'s \
+        sub-phase loop by RETURNING on cancellation, so the runner read the \
+        branch as finished and emitted `phase_completed [1]` for work that had \
+        been cut short — and on the pause path a second `error cancelled` on \
+        top. #1622 made both paths throw, so the tail is now exactly what \
+        Kotlin has always produced: `phase_completed [1, 0]` then \
+        `error cancelled` as the LAST line, with no `phase_completed` for the \
+        outer `[1]` and no `simulation_completed` at all. The branch's second \
+        sub-phase — a template `summarize` at `[1, 1]` — never starts, which \
+        is visible as an absent `phase_started` rather than only as a call \
+        count.
+
+        **Why its own scenario.** No bundled preset has a conditional branch \
+        with two sub-phases: `target_score_race` and `word_wolf` each branch \
+        into a single `summarize`, so the cancel would have had nowhere to \
+        land between sub-phases and the fixture would have measured the \
+        branch's exit rather than its interruption.
+
+        **Why the trigger is an event position and not a call index** is \
+        `FixtureSpec.cancelAfterPhaseCompleted`'s own doc: Kotlin observes \
+        cancellation inside a backend call and Swift's responder does not, so \
+        a call-indexed cut lands at different logical points on the two \
+        engines and the diff would be about the harness.
+        """,
+      cancelAfterPhaseCompleted: [1, 0]
     )
   ]
 }

--- a/tools/harness/Sources/PasturaHarnessKit/ParityFixtureEmitter.swift
+++ b/tools/harness/Sources/PasturaHarnessKit/ParityFixtureEmitter.swift
@@ -1,5 +1,6 @@
 import Foundation
 import PasturaCore
+import Synchronization
 
 /// Emits the ADR-023 Stage-4 cross-language parity fixtures: for one scenario
 /// and one scripted-response plan, the scenario, the exact model answers, and
@@ -50,16 +51,38 @@ package enum ParityFixtureEmitter {
     /// exercising `assign random_one` / `event_inject` needs, so the Kotlin
     /// replay consumes the identical stream in the identical order.
     package let seed: UInt64?
+    /// Cancel the run the moment a `phaseCompleted` with this `phasePath` is
+    /// emitted. `nil` (the default) never cancels.
+    ///
+    /// **The trigger is an emitted-event position, deliberately not a backend
+    /// call index.** A call-indexed cancel lands at *different logical points*
+    /// on the two engines: Kotlin's `LLMCaller` observes cancellation from
+    /// inside a backend call (`ensureActive()`, `suspendCancellableCoroutine`),
+    /// while the Swift responder does not observe it at all — so "cancel
+    /// before call N" would abort Kotlin mid-turn and Swift only at its next
+    /// poll, and the transcripts would diverge about *where the harness cut*
+    /// rather than about how the engines unwind.
+    ///
+    /// Cancelling on an emitted `phaseCompleted` removes that: both engines are
+    /// at the same place when the event fires — the head of
+    /// `ConditionalHandler`'s sub-phase loop is the next thing either runs, and
+    /// both check there (Swift's `Task.isCancelled` poll, Kotlin's `pauseCheck`
+    /// → `ensureActive()`). The path is therefore the contract; a run that
+    /// never emits it fails loudly with ``ParityFixtureError/cancelTriggerNeverFired``
+    /// rather than silently running to completion and freezing a golden that
+    /// measures nothing.
+    package let cancelAfterPhaseCompleted: [Int]?
 
     package init(
       name: String, scenarioPath: String, purpose: String, overrides: [Int: String] = [:],
-      seed: UInt64? = nil
+      seed: UInt64? = nil, cancelAfterPhaseCompleted: [Int]? = nil
     ) {
       self.name = name
       self.scenarioPath = scenarioPath
       self.purpose = purpose
       self.overrides = overrides
       self.seed = seed
+      self.cancelAfterPhaseCompleted = cancelAfterPhaseCompleted
     }
   }
 
@@ -100,12 +123,19 @@ package enum ParityFixtureEmitter {
     /// the replay can rebuild the same stream. `nil` for an RNG-free fixture —
     /// see ``FixtureSpec/seed``.
     package let seed: UInt64?
+    /// The `phaseCompleted` path the Swift run was cancelled on, carried into
+    /// the generated Kotlin so the replay cuts at the identical event. `nil`
+    /// for a fixture that runs to completion — see
+    /// ``FixtureSpec/cancelAfterPhaseCompleted`` for why the trigger is an
+    /// event position rather than a call index.
+    package let cancelAfterPhaseCompleted: [Int]?
 
     /// Explicit because the implicit memberwise init is `internal`, and the
     /// raw-string safety guard is tested from the sibling test module.
     package init(
       name: String, purpose: String, scenarioJSON: String,
-      responses: [String], transcript: [String], callCount: Int, seed: UInt64? = nil
+      responses: [String], transcript: [String], callCount: Int, seed: UInt64? = nil,
+      cancelAfterPhaseCompleted: [Int]? = nil
     ) {
       self.name = name
       self.purpose = purpose
@@ -114,6 +144,7 @@ package enum ParityFixtureEmitter {
       self.transcript = transcript
       self.callCount = callCount
       self.seed = seed
+      self.cancelAfterPhaseCompleted = cancelAfterPhaseCompleted
     }
   }
 
@@ -147,7 +178,6 @@ package enum ParityFixtureEmitter {
       choiceOptions: try choiceOptions(in: scenario),
       overrides: spec.overrides)
 
-    var transcript: [String] = []
     // No `detector:` — deliberate, and the inverse of what `HarnessRunner` does
     // eleven files away (it injects one precisely so `language_mismatch` is not
     // 0 by construction, #1234). Two reasons it must stay omitted here:
@@ -161,11 +191,45 @@ package enum ParityFixtureEmitter {
     // system source is unobservable and stays the default.
     let random: any RandomSource =
       spec.seed.map { SplitMix64RandomSource(seed: $0) as any RandomSource } ?? SystemRandomSource()
-    let stream = SimulationRunner(random: random).run(
-      scenario: scenario, llm: responder, suspendController: SuspendController())
-    for await event in stream {
-      guard let line = EventLineMapper.map(normalize(event), t: 0, attempt: 0) else { continue }
-      transcript.append(try JSONL.encode(line))
+    let sink = Mutex(CancelSink())
+    // Both the cancelling and the non-cancelling path run through the
+    // `emitter:` overload, so nothing about a nominal fixture's transcript
+    // depends on which arm was taken — verified by `parity-emit --check`
+    // reporting no drift on the seven pre-existing fixtures when this landed.
+    // The `AsyncStream` overload cannot serve the cancelling arm at all: its
+    // only cancel path terminates the stream, which drops the very
+    // `.error(.cancelled)` tail this fixture exists to freeze.
+    let emitter: @Sendable (SimulationEvent) -> Void = { event in
+      let pending = sink.withLock { $0.record(event, cancelPath: spec.cancelAfterPhaseCompleted) }
+      // Cancelled outside the lock (lock discipline: `Task.cancel` runs
+      // arbitrary cancellation handlers, including the runner's pause-gate
+      // one, which takes a lock of its own).
+      pending?.cancel()
+    }
+
+    let runner = SimulationRunner(random: random)
+    if spec.cancelAfterPhaseCompleted == nil {
+      await runner.run(
+        scenario: scenario, llm: responder, suspendController: SuspendController(),
+        emitter: emitter)
+    } else {
+      let task = Task {
+        await runner.run(
+          scenario: scenario, llm: responder, suspendController: SuspendController(),
+          emitter: emitter)
+      }
+      // The emitter may fire before this assignment — `Task` starts running
+      // immediately — so the sink records a *request* when it has no handle
+      // yet and hands it back here. Without this arm a fixture whose trigger
+      // is the run's first event would never be cancelled.
+      let pending = sink.withLock { $0.adopt(task) }
+      pending?.cancel()
+      await task.value
+    }
+
+    let recorded = sink.withLock { ($0.lines, $0.didCancel) }
+    if let path = spec.cancelAfterPhaseCompleted, !recorded.1 {
+      throw ParityFixtureError.cancelTriggerNeverFired(spec.name, path)
     }
 
     let fixture = Fixture(
@@ -173,10 +237,54 @@ package enum ParityFixtureEmitter {
       purpose: spec.purpose,
       scenarioJSON: try encodeScenario(scenario),
       responses: responder.recordedResponses,
-      transcript: transcript,
+      transcript: try recorded.0.map { try JSONL.encode($0) },
       callCount: responder.callCount,
-      seed: spec.seed)
+      seed: spec.seed,
+      cancelAfterPhaseCompleted: spec.cancelAfterPhaseCompleted)
     return Run(fixture: fixture, answeredFields: responder.recordedSchemaFields)
+  }
+
+  /// Transcript accumulator plus the cancel trigger's one-shot latch.
+  ///
+  /// One `Mutex`-guarded value rather than two, because the decision to cancel
+  /// is made *while* appending the event that triggers it: two locks would
+  /// admit an ordering where a second `phaseCompleted` slips between the
+  /// append and the latch and cancels twice.
+  ///
+  /// Lines are kept as ``EventLine`` and encoded after the run: `JSONL.encode`
+  /// throws, and the emitter is a non-throwing `@Sendable` closure. Mapping
+  /// stays inside the emitter so the transcript order is the emission order
+  /// even on the cancelling arm.
+  private struct CancelSink {
+    var lines: [EventLine] = []
+    private var task: Task<Void, Never>?
+    private var cancelRequested = false
+    /// Whether the trigger path was ever seen — the guard against a spec whose
+    /// path no run emits.
+    private(set) var didCancel = false
+
+    /// Maps and appends `event`, returning the task to cancel when it is the
+    /// trigger and a handle is already available.
+    mutating func record(_ event: SimulationEvent, cancelPath: [Int]?) -> Task<Void, Never>? {
+      if let line = EventLineMapper.map(ParityFixtureEmitter.normalize(event), t: 0, attempt: 0) {
+        lines.append(line)
+      }
+      guard let cancelPath, !didCancel,
+        case .phaseCompleted(_, let path) = event, path == cancelPath
+      else { return nil }
+      didCancel = true
+      guard let task else {
+        cancelRequested = true
+        return nil
+      }
+      return task
+    }
+
+    /// Stores the run's handle, returning it when the trigger already fired.
+    mutating func adopt(_ task: Task<Void, Never>) -> Task<Void, Never>? {
+      self.task = task
+      return cancelRequested ? task : nil
+    }
   }
 
   /// The option menu a scenario's `choose` phases offer, for the responder to
@@ -280,31 +388,5 @@ package enum ParityFixtureEmitter {
       throw ParityFixtureError.notUTF8(scenario.id)
     }
     return json
-  }
-}
-
-/// Why a parity fixture could not be produced.
-package enum ParityFixtureError: Error, CustomStringConvertible {
-  /// A scenario encoded to bytes that are not valid UTF-8.
-  case notUTF8(String)
-  /// A fixture contains bytes a Kotlin raw string cannot carry verbatim.
-  case rawStringUnsafe(String, String)
-  /// A scenario declares more than one distinct `choose` option menu, which
-  /// the schema-only ``RecordingResponder`` cannot disambiguate.
-  case ambiguousChoiceOptions(String, [[String]])
-
-  package var description: String {
-    switch self {
-    case .notUTF8(let name):
-      return "parity fixture '\(name)' encoded to non-UTF-8 bytes"
-    case .rawStringUnsafe(let name, let reason):
-      return
-        "parity fixture '\(name)' cannot be embedded in a Kotlin raw string: it contains \(reason)"
-    case .ambiguousChoiceOptions(let scenarioID, let menus):
-      let rendered = menus.map { "[\($0.joined(separator: ", "))]" }.joined(separator: " vs ")
-      return
-        "scenario '\(scenarioID)' declares \(menus.count) distinct choose option menus (\(rendered)); "
-        + "the parity responder reads only the schema, so it cannot tell which phase is calling"
-    }
   }
 }

--- a/tools/harness/Sources/PasturaHarnessKit/ParityFixtureEmitter.swift
+++ b/tools/harness/Sources/PasturaHarnessKit/ParityFixtureEmitter.swift
@@ -227,8 +227,8 @@ package enum ParityFixtureEmitter {
       await task.value
     }
 
-    let recorded = sink.withLock { ($0.lines, $0.didCancel) }
-    if let path = spec.cancelAfterPhaseCompleted, !recorded.1 {
+    let (recordedLines, triggerFired) = sink.withLock { ($0.lines, $0.triggerFired) }
+    if let path = spec.cancelAfterPhaseCompleted, !triggerFired {
       throw ParityFixtureError.cancelTriggerNeverFired(spec.name, path)
     }
 
@@ -237,7 +237,7 @@ package enum ParityFixtureEmitter {
       purpose: spec.purpose,
       scenarioJSON: try encodeScenario(scenario),
       responses: responder.recordedResponses,
-      transcript: try recorded.0.map { try JSONL.encode($0) },
+      transcript: try recordedLines.map { try JSONL.encode($0) },
       callCount: responder.callCount,
       seed: spec.seed,
       cancelAfterPhaseCompleted: spec.cancelAfterPhaseCompleted)
@@ -261,7 +261,7 @@ package enum ParityFixtureEmitter {
     private var cancelRequested = false
     /// Whether the trigger path was ever seen — the guard against a spec whose
     /// path no run emits.
-    private(set) var didCancel = false
+    private(set) var triggerFired = false
 
     /// Maps and appends `event`, returning the task to cancel when it is the
     /// trigger and a handle is already available.
@@ -269,10 +269,10 @@ package enum ParityFixtureEmitter {
       if let line = EventLineMapper.map(ParityFixtureEmitter.normalize(event), t: 0, attempt: 0) {
         lines.append(line)
       }
-      guard let cancelPath, !didCancel,
+      guard let cancelPath, !triggerFired,
         case .phaseCompleted(_, let path) = event, path == cancelPath
       else { return nil }
-      didCancel = true
+      triggerFired = true
       guard let task else {
         cancelRequested = true
         return nil

--- a/tools/harness/Sources/PasturaHarnessKit/ParityFixtureError.swift
+++ b/tools/harness/Sources/PasturaHarnessKit/ParityFixtureError.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+// Split from `ParityFixtureEmitter.swift` when that file passed SwiftLint's
+// `file_length` cap a second time (the first split sent the Kotlin rendering to
+// `+KotlinSource.swift`). The error enum is the natural next boundary: it is a
+// sibling type rather than a member, so nothing in it needs the emitter's
+// private storage.
+
+/// Why a parity fixture could not be produced.
+package enum ParityFixtureError: Error, CustomStringConvertible {
+  /// A scenario encoded to bytes that are not valid UTF-8.
+  case notUTF8(String)
+  /// A fixture contains bytes a Kotlin raw string cannot carry verbatim.
+  case rawStringUnsafe(String, String)
+  /// A scenario declares more than one distinct `choose` option menu, which
+  /// the schema-only ``RecordingResponder`` cannot disambiguate.
+  case ambiguousChoiceOptions(String, [[String]])
+  /// A spec asked to cancel on a `phaseCompleted` path the run never emitted.
+  ///
+  /// Loud rather than silent because the failure is invisible in the artefact:
+  /// the run simply completes, and the generated golden freezes a
+  /// `simulation_completed` tail that looks like a healthy fixture while
+  /// measuring no cancellation at all.
+  case cancelTriggerNeverFired(String, [Int])
+
+  package var description: String {
+    switch self {
+    case .notUTF8(let name):
+      return "parity fixture '\(name)' encoded to non-UTF-8 bytes"
+    case .rawStringUnsafe(let name, let reason):
+      return
+        "parity fixture '\(name)' cannot be embedded in a Kotlin raw string: it contains \(reason)"
+    case .ambiguousChoiceOptions(let scenarioID, let menus):
+      let rendered = menus.map { "[\($0.joined(separator: ", "))]" }.joined(separator: " vs ")
+      return
+        "scenario '\(scenarioID)' declares \(menus.count) distinct choose option menus (\(rendered)); "
+        + "the parity responder reads only the schema, so it cannot tell which phase is calling"
+    case .cancelTriggerNeverFired(let name, let path):
+      return
+        "parity fixture '\(name)' asked to cancel after phase_completed "
+        + "[\(path.map(String.init).joined(separator: ", "))], but the run never emitted that "
+        + "event — the fixture would freeze a completed run instead of a cancellation tail"
+    }
+  }
+}

--- a/tools/harness/Tests/PasturaHarnessKitTests/ParityFixtureEmitterTests+Cancel.swift
+++ b/tools/harness/Tests/PasturaHarnessKitTests/ParityFixtureEmitterTests+Cancel.swift
@@ -1,0 +1,113 @@
+import Foundation
+import PasturaCore
+import Testing
+
+@testable import PasturaHarnessKit
+
+// The cancellation arm (ADR-023 S4, #1622), split from the suite file for the
+// same reason `+Exercise.swift` and `+SeededExercise.swift` were — SwiftLint's
+// file-length cap — and because these cases assert on the transcript's TAIL,
+// where every other emitter case asserts on its body.
+extension ParityFixtureEmitterTests {
+
+  /// The registered cancelling fixture, so both cases below read the same spec
+  /// the generator freezes rather than a hand-built twin of it.
+  ///
+  /// Looked up by name and required to exist: a spec silently dropped from the
+  /// roster would otherwise make every case here vacuous, which is the failure
+  /// shape the sibling sweeps' "derived from the run, never hand-listed" rule
+  /// exists to avoid.
+  private func cancelSpec() throws -> ParityFixtureEmitter.FixtureSpec {
+    try #require(
+      ParityFixtureEmitter.specs.first { $0.name == "parityCancelConditional" },
+      "the cancelling fixture is no longer registered in `specs`")
+  }
+
+  @Test("the cancelling fixture's transcript ends at the cancellation, mid-branch")
+  func cancellingFixtureFreezesTheCancellationTail() async throws {
+    let spec = try cancelSpec()
+    #expect(
+      spec.cancelAfterPhaseCompleted == [1, 0],
+      "the trigger moved; every assertion below is written against [1, 0]")
+
+    let fixture = try await ParityFixtureEmitter.run(spec)
+
+    // The four claims are asserted separately rather than as one transcript
+    // equality: an equality pin would redden on any unrelated payload change
+    // (a persona rename, a prompt reword) and say nothing about *which* of the
+    // four properties broke. These are the properties #1622 changed.
+    //
+    // 1. The tail is the cancellation, and it is LAST. Before the fix the run
+    //    could emit a second `.error(.cancelled)` on the pause path, so
+    //    "contains an error line" is not the claim — "ends with exactly one" is.
+    #expect(
+      fixture.transcript.last?.contains(#""error":"cancelled""#) == true,
+      "the last line is not the cancellation error: \(fixture.transcript.last ?? "<empty>")")
+    #expect(
+      fixture.transcript.filter { $0.contains(#""event":"error""#) }.count == 1,
+      "the run emitted more than one error event")
+
+    // 2. The branch's FIRST sub-phase completed — the cancel lands after it,
+    //    not instead of it, which is what makes the fixture a mid-branch cut
+    //    rather than a cut before the branch ran at all.
+    #expect(
+      fixture.transcript.contains(where: aPhaseCompleted(path: "[1,0]")),
+      "the branch's first sub-phase never completed, so the trigger never fired")
+
+    // 3. The outer `conditional` started but must NOT complete. This is the
+    //    exact regression #1622 fixed: `ConditionalHandler.runBranch` used to
+    //    RETURN on cancellation, which read to the runner as "the branch
+    //    finished" and emitted `phase_completed [1]` for work that was cut
+    //    short.
+    #expect(
+      fixture.transcript.contains(where: aPhaseStarted(path: "[1]")),
+      "the conditional never started — the fixture is not exercising a branch")
+    #expect(
+      !fixture.transcript.contains(where: aPhaseCompleted(path: "[1]")),
+      "the cut-short conditional still reports `phase_completed [1]` (#1622's regression)")
+
+    // 4. The branch's SECOND sub-phase never ran, and the run never completed.
+    //    `[1, 1]` is a template `summarize`, so it issues no backend call —
+    //    its absence has to be read off the transcript, not off `callCount`.
+    #expect(
+      !fixture.transcript.contains(where: aPhaseStarted(path: "[1,1]")),
+      "the branch's second sub-phase started after the cancellation")
+    #expect(
+      !fixture.transcript.contains(where: { $0.contains(#""event":"simulation_completed""#) }),
+      "a cancelled run reported `simulation_completed`")
+  }
+
+  @Test("a cancel trigger no run emits fails loudly instead of completing")
+  func unreachableCancelTriggerIsRejected() async throws {
+    // The silent failure this guards: the emitter simply runs to completion and
+    // freezes a golden with a `simulation_completed` tail, which looks like a
+    // healthy fixture while measuring no cancellation at all. Nothing
+    // downstream would name it — the Kotlin replay would agree with it, because
+    // it would not cancel either.
+    let spec = ParityFixtureEmitter.FixtureSpec(
+      name: "unreachableTrigger",
+      scenarioPath: try cancelSpec().scenarioPath,
+      purpose: "test-only: a phase path this scenario has no phase at",
+      cancelAfterPhaseCompleted: [9, 9])
+
+    await #expect(throws: ParityFixtureError.self) {
+      _ = try await ParityFixtureEmitter.run(spec)
+    }
+  }
+
+  // MARK: - Line predicates
+
+  /// A `phase_started` line at `path`, rendered as the JSONL encoder writes it.
+  ///
+  /// Keyed on the event name AND the path together: `"phase_path":[1]` alone
+  /// would also be satisfied by a `phase_completed`, which is the very
+  /// distinction case 3 above turns on.
+  private func aPhaseStarted(path: String) -> (String) -> Bool {
+    { $0.contains(#""event":"phase_started""#) && $0.contains("\"phase_path\":\(path)") }
+  }
+
+  /// A `phase_completed` line at `path`. See ``aPhaseStarted(path:)``.
+  private func aPhaseCompleted(path: String) -> (String) -> Bool {
+    { $0.contains(#""event":"phase_completed""#) && $0.contains("\"phase_path\":\(path)") }
+  }
+}

--- a/tools/harness/Tests/PasturaHarnessKitTests/ParityFixtureEmitterTests+Cancel.swift
+++ b/tools/harness/Tests/PasturaHarnessKitTests/ParityFixtureEmitterTests+Cancel.swift
@@ -90,8 +90,14 @@ extension ParityFixtureEmitterTests {
       purpose: "test-only: a phase path this scenario has no phase at",
       cancelAfterPhaseCompleted: [9, 9])
 
-    await #expect(throws: ParityFixtureError.self) {
+    await #expect {
       _ = try await ParityFixtureEmitter.run(spec)
+    } throws: { error in
+      if case ParityFixtureError.cancelTriggerNeverFired = error {
+        return true
+      } else {
+        return false
+      }
     }
   }
 

--- a/tools/harness/Tests/PasturaHarnessKitTests/ParityFixtureEmitterTests.swift
+++ b/tools/harness/Tests/PasturaHarnessKitTests/ParityFixtureEmitterTests.swift
@@ -126,8 +126,17 @@ struct ParityFixtureEmitterTests {
       let fixture = try await ParityFixtureEmitter.run(spec)
 
       #expect(fixture.callCount == fixture.responses.count, "\(spec.name)")
-      #expect(
-        fixture.transcript.contains { $0.contains("\"simulation_completed\"") }, "\(spec.name)")
+      // "End to end" means *reaching its own terminal event*, which is not the
+      // same event for every spec: a cancelling fixture ends at
+      // `error cancelled` by construction, and asserting `simulation_completed`
+      // for it would demand the run keep going past the cut it exists to
+      // freeze. Both arms are asserted, so neither spec kind gets a pass —
+      // `ParityFixtureEmitterTests+Cancel.swift` then pins the cancelled tail
+      // in detail.
+      let terminal =
+        spec.cancelAfterPhaseCompleted == nil
+        ? "\"simulation_completed\"" : "\"error\":\"cancelled\""
+      #expect(fixture.transcript.contains { $0.contains(terminal) }, "\(spec.name)")
       // Keyed on the spec's own scenario path rather than a hard-coded preset
       // id, which was only ever true of the two `target_score_race` fixtures.
       // `#require`, not `?? ""`: `String.contains("")` is `true`, so an empty

--- a/tools/harness/Tests/PasturaHarnessKitTests/RunLogTests.swift
+++ b/tools/harness/Tests/PasturaHarnessKitTests/RunLogTests.swift
@@ -63,6 +63,23 @@ struct RunLogTests {
     #expect(line.error?.isEmpty == false)
   }
 
+  // ADR-023 S4 (#1622) — the `error` field projects the bare SimulationError
+  // case name (no payload) so it compares across engines against the Kotlin
+  // mirror's `when (event.error)` projection in `EventLineMapper.kt`.
+  @Test func mapsErrorToBareCaseName() throws {
+    let event = SimulationEvent.error(.cancelled)
+    let line = try #require(EventLineMapper.map(event, t: 3.0, attempt: 1))
+    #expect(line.event == "error")
+    #expect(line.error == "cancelled")
+  }
+
+  @Test func mapsPayloadCarryingErrorToBareCaseNameOnly() throws {
+    let event = SimulationEvent.error(.llmGenerationFailed(description: "Model load failed: oom"))
+    let line = try #require(EventLineMapper.map(event, t: 3.0, attempt: 1))
+    #expect(line.event == "error")
+    #expect(line.error == "llmGenerationFailed")
+  }
+
   @Test func mapsScoresAndVotes() throws {
     let scores = try #require(
       EventLineMapper.map(


### PR DESCRIPTION
## Summary

ADR-023 Stage 4, slice **S4 — cancellation event tail**. The last mechanism-shaped residue on #501; S5 / S6 remain.

- **Swift fixed, not ledgered** (ADR-023 §12 condition 3, dual-landing default — decided with the operator). `ConditionalHandler.runBranch`'s two silent early returns (the `Task.isCancelled` poll and the `pauseCheck == true` path) made the runner emit `phaseCompleted(.conditional)` for a branch cut short and only then `.error(.cancelled)` — twice on the pause path. Both now `throw SimulationError.cancelled`; `checkPaused` reports instead of emits and each of its three callers emits the run's single terminal error. Six new tests pin the invariant on every cancel path (branch sub-phase gap, paused-in-branch, paused at top level, paused at round head, plus two handler-level cases). App-side consumers were checked: `SimulationViewModel` reads `.phaseCompleted` only to pop inner paths and already treats `.error(.cancelled)` as the teardown signal.
- **`SimulationRunner.run(..., emitter:)`** — a new `public` `@concurrent` overload that runs in the caller's task and keeps delivering events after the caller cancels itself. The `AsyncStream` overload cannot observe the tail (its only cancel path terminates the stream) and now delegates to it.
- **Event-positioned cancel trigger** on both engines: `FixtureSpec.cancelAfterPhaseCompleted` cancels the Swift run the moment the named `phaseCompleted` is emitted; the Kotlin replay cuts on the same event. A call-indexed cut was rejected because Kotlin's `LLMCaller` observes cancellation *inside* a backend call (`ensureActive()` / `suspendCancellableCoroutine`) while the Swift responder does not, so it would land at different logical points.
- **New scenario `tools/harness/Fixtures/parity_cancel.yaml`** — no bundled preset has a conditional branch with ≥2 sub-phases (`target_score_race` / `word_wolf` branches are one template `summarize`), and `executePhases`' per-phase poll consumes any earlier cancel before the conditional is entered. `parityCancelConditional` freezes `phase_completed [1,0]` → `error cancelled` and replays green on both rungs **with no ledger change on the first run**.
- **`error` line unified**: both `EventLineMapper`s project the bare Swift case name via a default-less switch / else-less `when`. The harness run-log's per-event `error` line loses its payload as a consequence (accepted; `run_end.error` and the `.failed` outcome keep the message).
- **`DivergenceLedger.CANCELLATION_EVENT_TAIL` deleted** (precedent `SCHEMA_GUARD_POSITION`), `LINT_PREDICATE_DIVERGENCE`'s reason re-derived over the nine-fixture roster, `ConditionalHandler.kt` KDoc § Divergences retired, status board updated.

Out of scope, stated rather than assumed identical: a cancel delivered *during* a leaf handler's LLM call — Kotlin observes it inside the call, Swift at the next checkpoint.

## Test plan

- `scripts/xcodebuild.sh test -skip-testing:PasturaUITests` — 3616 tests / 289 suites green (`SimulationRunnerTests` 21, `ConditionalHandlerTests` 10).
- `swift test --no-parallel` (ADR-013 harness) — 93 tests green; `swift build` green.
- `./gradlew :shared:engine:jvmTest :shared:engine:macosArm64Test` — green on both rungs; `EngineParityTests` over nine fixtures.
- `swift run pastura-harness parity-emit --check` — up to date (CI drift guard).
- `swiftlint lint --quiet --strict` — clean.
- UI tests skipped: no view changes.

## Review

Plan critique (Opus `critic`) before implementation raised two Criticals that reshaped the plan: `target_score_race` cannot host the fixture (single-sub-phase branches), and a call-indexed cancel lands at different points on the two engines — hence the new scenario and the event-positioned trigger.

Reviewer: Opus (`code-reviewer`), split three ways on `SCOPE_TOO_LARGE` (Engine / Kotlin / harness). Verdict PASS ×3, 0 Critical / 7 Warning / 9 Suggestion.

Applied (commit `🐛 fix:`): Pattern-6 `@concurrent` on the emitter overload + corrected `@Sendable` rationale; the `AsyncStream` overload's `self`-retention comment restated as the fact that holds; `file_length` rationale names why the SemanticLint split was possible; `RunTaskBox` plain `Sendable`; `errorCaseName` doc states the run-log payload loss and where the message survives; `unreachableCancelTriggerIsRejected` asserts the specific case; `CancelSink.didCancel` → `triggerFired` + named tuple; Kotlin `CancelOnPhaseCompleted` lost-cancel interleaving removed (adopt tests the CAS'd flag; double `cancel()` is documented idempotent); "four" → "five other scenarios"; `@SerialName` hand-sync note; timeout KDoc fixture count.

Not applied: duplicated `completedPaths` test helpers (two files — fine to fold into `EngineTestHelpers` on the next guard change); comment on the two cooperative busy loops in `ConditionalHandlerTests+Cancellation` (covered by the suite time limit); the emitter's unstructured `Task` not propagating caller cancellation (CLI-only today).

## Device QA

実機QA不要 — Engine change is on the cancellation path only (no `#if !targetEnvironment(simulator)` block, no llama.cpp path); the one executor change (`@concurrent`) is exercised by the harness and unit tests on the same code path.

Closes #1622
Part of #501

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CsM3oKFF9Rpgg2HmT58Bxc
