### PR TITLE
📝 docs: ADR-023 Stage 4 — S6 divergence-6 ruling (number literals accepted)

### DIFF
--- a/Pastura/PasturaTests/LLM/JSONResponseParserTests.swift
+++ b/Pastura/PasturaTests/LLM/JSONResponseParserTests.swift
@@ -76,7 +76,9 @@ struct JSONResponseParserTests {
   /// so ordering `as? Bool` ahead of `as? NSNumber` swallowed these into
   /// "false"/"true" (#1150). `1.0` / `0.0` render without the `.0` because
   /// `NSNumber.stringValue` normalizes the literal — that formatting difference
-  /// from the Kotlin port is a separate divergence, deferred to ADR-023 Stage 4.
+  /// from the Kotlin port is a separate divergence, accepted permanently
+  /// (ADR-023 §15, 2026-08-29): the Kotlin port keeps the literal and neither
+  /// side changes.
   @Test func normalizesNumbersInsideTheBoolBridgeWindow() throws {
     let input = #"{"zero": 0, "one": 1, "floatZero": 0.0, "floatOne": 1.0}"#
     let output = try parser.parse(input)

--- a/docs/decisions/ADR-023.md
+++ b/docs/decisions/ADR-023.md
@@ -668,6 +668,10 @@ interface StreamCallbacks {
   **The Swift Engine's own retirement is not decided by this ADR**, so neither is the
   linter's: the Swift copy is a Stage 3–4 parity twin like every other ported module, not a
   fork, and it retires with its siblings rather than on a schedule of its own.
+- **Accepted formatting divergence — `JSONResponseParser` number literals**: Swift renders
+  JSON numbers through `NSNumber.stringValue`, Kotlin keeps the literal; ruled permanent, neither
+  side changes (§15). New parity fixtures that carry a float field pin it as a
+  `NUMBER_LITERAL_FORMATTING` ledger entry rather than "fixing" either parser.
 
 ## 8. Relation to the LiteRT-LM track (#496 / #969)
 
@@ -1310,6 +1314,38 @@ RNG is the only way to pin the outcome (#501).
 (`random: RandomSource = SystemRandomSource()`), so — Pattern 3 in `kmp-interop.md` — the gate
 spike's Swift call site had to spell out all three again:
 `SimulationEngine(detector: nil, logger: NoopEngineLogger(), random: SystemRandomSource())`.
+
+## 15. Amendment 2026-08-29 — S6 divergence-6: number-literal formatting accepted permanently
+
+`DivergenceLedger.NUMBER_LITERAL_FORMATTING` is **accepted as a permanent cross-language
+divergence; neither engine changes** (#1629, Stage 4 slice S6 — the last Stage-4 residue). When
+an LLM response carries a JSON number, Swift's `JSONResponseParser.normalizeValues` renders it
+through `NSNumber.stringValue` (`1.0` → `"1"`, `1e3` → `"1000"`, `1.0e-7` → `"1e-07"`) while
+Kotlin keeps `JsonPrimitive.content` (`"1.0"`, `"1e3"`, `"1.0e-7"`). Nested numbers inside a
+re-serialized object or array (`canonicalJson`) fall in the same class. The two ledger entries
+(`targetScoreRaceDivergent`, `parityStructuralControl` — `fields.confidence` `"1"` vs `"1.0"`)
+stay as the permanent pins, and `JSONResponseParserParityTests` keeps asserting the Kotlin text.
+
+**Why no side changes.** The difference is formatting, not value, and nothing downstream can
+observe it as a value. The one place a `fields` value is read as a number is transitive:
+`ReflectHandler` / `AssignHandler` / `EventInjectHandler` copy field text into
+`state.variables`, and `ConditionEvaluator.compare` parses both operands
+(`Double(_:)` on Swift, the decimal-literal regex on Kotlin) — `1`, `1.0`, `1000`, `1e3`,
+`1e-07` all parse to the same `Double` on both sides, and the string comparison is taken only
+when an operand is non-numeric, where the formatting never differs. State the reason this way
+— *parses to the same number* — not as "no consumer parses `fields` numerically", which a grep of
+`ConditionEvaluator` refutes. Reachability is also low: `GBNFGrammarBuilder` constrains every
+field to `string`, so a number reaches the parser only from a schema-less call or the
+grammar-free Ollama dev backend. Both fixes were costed and rejected: matching
+`NSNumber.stringValue` in `commonMain` means a hand-written `%g`-style formatter whose own
+rounding and exponent rules would open a subtler divergence (`1e-07`); matching Kotlin on Swift
+means replacing `JSONSerialization` with a literal-preserving scanner to change shipped
+behaviour for a formatting nicety.
+
+**Accepted consequence at Stage 5.** On the schema-less path the Kotlin engine will persist and
+display `"1.0"` where Swift showed `"1"`, and the same text feeds the next turn's prompt through
+the conversation log — a visible-but-harmless change. `ReplayHashing` hashes the scenario YAML
+only, so Swift-era records still verify.
 
 ## Out of scope / deliberately not reopened
 

--- a/docs/decisions/ADR-023.md
+++ b/docs/decisions/ADR-023.md
@@ -1328,10 +1328,13 @@ stay as the permanent pins, and `JSONResponseParserParityTests` keeps asserting 
 
 **Why no side changes.** The difference is formatting, not value, and nothing downstream can
 observe it as a value. The one place a `fields` value is read as a number is transitive:
-`ReflectHandler` / `AssignHandler` / `EventInjectHandler` copy field text into
-`state.variables`, and `ConditionEvaluator.compare` parses both operands
-(`Double(_:)` on Swift, the decimal-literal regex on Kotlin) — `1`, `1.0`, `1000`, `1e3`,
-`1e-07` all parse to the same `Double` on both sides, and the string comparison is taken only
+`ReflectHandler` copies `fields["note"]` into `state.variables` (the only handler that writes
+parser output there — `Assign` / `EventInject` write scenario text; `SpeakAll` / `SpeakEach` /
+`Narrate` / `Whisper` route field text only into prompts and the conversation log), and
+`ConditionEvaluator.compare` parses both operands (`Double(_:)` on Swift,
+`ConditionEvaluator.numericLiteralRegex` on Kotlin — the ruling's load-bearing precondition:
+narrowing that regex below the exponent form reopens this without any test going red) — `1`,
+`1.0`, `1000`, `1e3`, `1e-07` all parse to the same `Double` on both sides, and the string comparison is taken only
 when an operand is non-numeric, where the formatting never differs. State the reason this way
 — *parses to the same number* — not as "no consumer parses `fields` numerically", which a grep of
 `ConditionEvaluator` refutes. Reachability is also low: `GBNFGrammarBuilder` constrains every

--- a/docs/kmp-migration-status.md
+++ b/docs/kmp-migration-status.md
@@ -32,7 +32,7 @@ _Last updated: 2026-08-29._
 | 1 | `shared/models` + CI infrastructure | ✅ done | #1052 #1055 #1059 |
 | 2 | Two-boundary vertical slice = GO/NO-GO gate | ✅ **GO** (2026-07-18) | #1063 #1137 #1172 · [ADR-023 §12](decisions/ADR-023.md) |
 | 3 | Bulk port to `commonMain` | ✅ done | ↓ Stage 3 breakdown |
-| 4 | Cross-language parity harness | 🔄 in progress | 1a #1387 · 1b #1458 · S3a [#1605](https://github.com/tyabu12/pastura/issues/1605) landed; S3b (RNG seam) [#1615](https://github.com/tyabu12/pastura/issues/1615) landed; S3b-2 (seeded fixtures) [#1618](https://github.com/tyabu12/pastura/issues/1618) landed; S4 (cancellation tail) [#1622](https://github.com/tyabu12/pastura/issues/1622) landed; S5 (suspend parity) [#1625](https://github.com/tyabu12/pastura/issues/1625) landed; S6 next · [#501](https://github.com/tyabu12/pastura/issues/501) |
+| 4 | Cross-language parity harness | 🔄 in progress | 1a #1387 · 1b #1458 · S3a [#1605](https://github.com/tyabu12/pastura/issues/1605) landed; S3b (RNG seam) [#1615](https://github.com/tyabu12/pastura/issues/1615) landed; S3b-2 (seeded fixtures) [#1618](https://github.com/tyabu12/pastura/issues/1618) landed; S4 (cancellation tail) [#1622](https://github.com/tyabu12/pastura/issues/1622) landed; S5 (suspend parity) [#1625](https://github.com/tyabu12/pastura/issues/1625) landed; S6 (divergence-6 ruling) [#1629](https://github.com/tyabu12/pastura/issues/1629) landed — Stage-4 residue cleared · [#501](https://github.com/tyabu12/pastura/issues/501) |
 | 5 | iOS consumption switch + code-merge | ⬜ not started | the remaining integration · adapter traps: [`kmp-interop.md`](../.claude/rules/kmp-interop.md) · ⚠️ en-only `ScenarioValidationMessage.render()` / `ScenarioLintMessage.render()` block this — [#1464](https://github.com/tyabu12/pastura/issues/1464), [#1562](https://github.com/tyabu12/pastura/issues/1562) |
 
 Legend: ✅ done · 🔄 in progress · 🟡 partial · ⬜ not started.
@@ -72,8 +72,8 @@ machine-checked — see the maintenance invariant above.
 
 ## Stages 4–5 — remaining integration
 
-- **Stage 4** (parity harness): 🔄 in progress — **both parity rungs are live**; the residue is
-  scope, not machinery. See [ADR-023](decisions/ADR-023.md) §6 Stage 4,
+- **Stage 4** (parity harness): 🔄 in progress — **both parity rungs are live** and every
+  planned slice (1a–S6) has landed; the row closes with the #501 board (operator call). See [ADR-023](decisions/ADR-023.md) §6 Stage 4,
   [#1387](https://github.com/tyabu12/pastura/issues/1387) (slice 1a, closed),
   [#1458](https://github.com/tyabu12/pastura/issues/1458) (slice 1b, closed),
   [#1605](https://github.com/tyabu12/pastura/issues/1605) (S3a, closed) and
@@ -117,8 +117,12 @@ machine-checked — see the maintenance invariant above.
   `callCount` now counts suspend re-issues on both sides and each side guards its schedule
   loudly (`suspendNeverFired` / the delivered-suspend assertion). Green on both rungs with an
   empty ledger; no engine code changed.
-  Residue, scope rather than mechanism: **S6** the divergence-6 ruling (pinned as a ledger
-  entry; deciding which side changes moves shipped Swift behaviour).
+  **S6** ([#1629](https://github.com/tyabu12/pastura/issues/1629)) ruled divergence-6 —
+  `NUMBER_LITERAL_FORMATTING`, Swift `NSNumber.stringValue` vs Kotlin's preserved literal —
+  **accepted permanently; neither engine changes** ([ADR-023 §15](decisions/ADR-023.md)). The
+  text parses to the same Double wherever a field is read numerically, so the difference is
+  unobservable as a value; the two ledger entries stay as the permanent pins. No Stage-4 residue
+  remains.
 - **Stage 5** (iOS switch + code-merge): ⬜ not started — the remaining iOS integration; the ported
   Kotlin loader still has no caller in `shared/engine`. See
   [ADR-023](decisions/ADR-023.md) §6 Stage 5.

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/JSONResponseParser.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/JSONResponseParser.kt
@@ -347,10 +347,15 @@ internal class JSONResponseParser {
      * Swift returns `"1"` / `"0"` as well, because `NSNumber.stringValue` drops the
      * `.0`, so those two only changed divergence class: from the Bool bridge to
      * exponent/float FORMATTING, which also covers `1e3` -> Swift `"1000"` vs
-     * Kotlin `"1e3"`. That class is a formatting choice with no correct side; see
+     * Kotlin `"1e3"`. That class is accepted as a permanent cross-language
+     * divergence — neither side changes (ADR-023 §15, 2026-08-29, #1629): the
+     * text parses to the same `Double` on both sides wherever a field is read
+     * numerically, via `ConditionEvaluator.compare` on `state.variables`, and
+     * nothing else reads a field numerically. Pinned by
+     * `DivergenceLedger.NUMBER_LITERAL_FORMATTING` and
      * `JSONResponseParserParityTests` § "Known Kotlin-side literal-preservation
-     * differences", and ADR-023 Stage 4 to decide the rule once for both engines.
-     * The same applies to numbers nested inside [canonicalJson].
+     * differences". The same applies to numbers nested inside [canonicalJson] —
+     * do not "fix" this side.
      *
      * ## Nested values
      *

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/DivergenceLedger.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/DivergenceLedger.kt
@@ -126,7 +126,9 @@ internal object DivergenceLedger {
         /**
          * Swift's `NSNumber.stringValue` drops a trailing `.0` and expands
          * exponents (`1.0` -> `"1"`, `1e3` -> `"1000"`); Kotlin preserves the
-         * literal. ADR-023 Stage 4 is asked to rule on which side changes.
+         * literal. Ruled permanent 2026-08-29 (ADR-023 §15, #1629): neither
+         * side changes — the text parses to the same Double wherever a field
+         * is read numerically (`ConditionEvaluator.compare`).
          */
         NUMBER_LITERAL_FORMATTING("JSONResponseParser.kt normalizeValues KDoc"),
 

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/JSONResponseParserParityTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/JSONResponseParserParityTests.kt
@@ -21,7 +21,7 @@ import kotlin.test.assertEquals
  * on cast success), so the integer cases agree now and are pinned on both
  * sides — this file is no longer their only coverage.
  *
- * ## The residual divergence — float formatting, still open
+ * ## The residual divergence — float formatting, accepted permanently
  *
  * The fix did NOT make `1.0` / `0.0` agree: Swift yields `"1"` / `"0"` because
  * `NSNumber.stringValue` normalizes the literal, while kotlinx's
@@ -29,8 +29,8 @@ import kotlin.test.assertEquals
  * `fields` is a `[String: String]`, so the text is what ships. Those two cases
  * only changed divergence *class*, from the Bool bridge to formatting; they
  * live under "Known Kotlin-side literal-preservation differences" below,
- * alongside `1e3`. Out of #1150's scope — ADR-023 Stage 4 should decide the
- * formatting rule once, for both engines.
+ * alongside `1e3`. Out of #1150's scope — ADR-023 §15 (2026-08-29, #1629)
+ * rules the formatting divergence permanent: neither engine changes.
  *
  * ## Reachability
  *
@@ -113,7 +113,7 @@ class JSONResponseParserParityTests {
         // Pinned as an accepted divergence rather than normalized: parsing to a
         // number and re-rendering would introduce float-formatting drift of its own
         // (Swift measured `1.0e-7` -> "1e-07"), trading one divergence for a subtler
-        // one. Stage 4 should decide the rule once, for both engines.
+        // one. Ruled permanent 2026-08-29 (ADR-023 §15) — neither side changes.
         assertEquals("1e3", field("1e3"))
     }
 

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/ParityGolden.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/ParityGolden.kt
@@ -222,7 +222,7 @@ internal object ParityGolden {
      *
      * The structural arm was re-armed in `parityStructuralControl` instead, because the surviving scriptable divergence costs Kotlin two extra backend calls and `responses` is positional — the surplus has to land on the run's LAST call, which here is a `vote` whose loss cascades through the tally. So do not read a clean structural comparison here as evidence the structural path is exercised; `someFixtureDrivesBothEntryKinds` is what keeps that honest.
      *
-     * The float-valued key below is this fixture's arm. Swift normalizes `1.0` to "1" because `NSNumber.stringValue` drops the `.0`; Kotlin preserves the literal as "1.0" — the VALUE divergence `JSONResponseParser.kt` routes to Stage 4 to rule on.
+     * The float-valued key below is this fixture's arm. Swift normalizes `1.0` to "1" because `NSNumber.stringValue` drops the `.0`; Kotlin preserves the literal as "1.0" — the VALUE divergence ruled permanent 2026-08-29 (ADR-023 §15); it stays pinned here rather than fixed on either side.
      */
     internal val targetScoreRaceDivergent: Fixture = Fixture(
         name = "targetScoreRaceDivergent",

--- a/tools/harness/Sources/PasturaHarnessKit/ParityFixtureEmitter+Specs.swift
+++ b/tools/harness/Sources/PasturaHarnessKit/ParityFixtureEmitter+Specs.swift
@@ -67,8 +67,9 @@ extension ParityFixtureEmitter {
 
         The float-valued key below is this fixture's arm. Swift normalizes \
         `1.0` to "1" because `NSNumber.stringValue` drops the `.0`; Kotlin \
-        preserves the literal as "1.0" — the VALUE divergence \
-        `JSONResponseParser.kt` routes to Stage 4 to rule on.
+        preserves the literal as "1.0" — the VALUE divergence ruled permanent \
+        2026-08-29 (ADR-023 §15); it stays pinned here rather than fixed on \
+        either side.
         """,
       overrides: [
         0: #"{"statement": "", "inner_thought": ""}"#,


### PR DESCRIPTION
## Summary

ADR-023 Stage 4, slice **S6 — the divergence-6 ruling** (the last Stage-4 residue on #501).

- **Ruling (operator, 2026-08-29): `NUMBER_LITERAL_FORMATTING` is accepted permanently — neither engine changes.** Swift renders JSON numbers via `NSNumber.stringValue` (`1.0`→`"1"`, `1e3`→`"1000"`), Kotlin keeps the literal. Recorded as ADR-023 **§15** (rationale, costed-and-rejected fixes, accepted Stage-5 consequence) and a **§7** standing obligation.
- The rationale is stated as *"parses to the same Double wherever a field is read numerically"* (`ConditionEvaluator.compare` via `state.variables`), not as "no consumer parses `fields` numerically" — the latter is refuted by grep and would age badly.
- The six "ADR-023 Stage 4 to decide" pointers now state the ruling: `JSONResponseParser.kt` KDoc, `JSONResponseParserParityTests.kt` (header + one test comment), `DivergenceLedger.kt`, `JSONResponseParserTests.swift`, `ParityFixtureEmitter+Specs.swift` → `ParityGolden.kt` regenerated through `parity-emit --write` (one comment line).
- `docs/kmp-migration-status.md`: S6 landed; every planned Stage-4 slice has now landed. The Stage-4 row stays 🔄 — flipping it to ✅ is an operator call on the #501 board.

Docs and comments only. No assertion, test name, or engine code changed.

## Test plan

- [x] `swift run pastura-harness parity-emit --check` → up to date (golden drift guard)
- [x] `./gradlew :shared:engine:jvmTest --tests JSONResponseParserParityTests --tests DivergenceLedgerTests` → green
- [x] `scripts/xcodebuild.sh test -only-testing PasturaTests/JSONResponseParserTests` → 65 tests pass
- [x] `swiftlint lint --quiet --strict` clean; pre-commit gates (kmp-status, port-ledger coverage, prompt-literal parity, iOS build) passed on commit
- Full unit suite skipped locally: the diff is comment/doc-only (CI runs the full path-gated set — `shared/**` is non-SAFE, so the KMP and parity jobs fire).

## Review

Reviewer: Opus (`code-reviewer`). Verdict PASS (0 critical). Warning applied: the §15 handler list overstated the transitive path — narrowed to `ReflectHandler` (`Assign` / `EventInject` write scenario text, not parser fields). Suggestion applied: the Kotlin precondition is cited by symbol (`ConditionEvaluator.numericLiteralRegex`) so the load-bearing regex stays greppable. Nothing rejected.

Plan critique (Opus `critic`) before implementation surfaced: two extra pointers in the generated golden + its emitter (fixed by regenerating), the missing `kmp-migration-status.md` update, §15 placement over the §4 table, and the rationale rewrite — all applied.

## Device QA

実機QA不要 — documentation and comment changes only; no runtime path touched.

Closes #1629. Part of #501.
