### PR TITLE
✨ feat: ADR-023 Stage 5 prep — localize Kotlin message render() via expect/actual leaf

### DIFF
--- a/.claude/rules/kmp-interop.md
+++ b/.claude/rules/kmp-interop.md
@@ -122,13 +122,25 @@ integral `Double` drops its `.0`. The third bites silently: `TranscriptComparato
 never the fixtures' observed lines: a field no fixture populates is the one that bites later.
 `RunLogTests.fullyPopulatedLinePinsTheWireShape` is that measurement.
 
-**A Models-layer message type is dual-landed, and no gate compares the two sides.**
-`check-prompt-literal-parity.py` only scans `Engine/` + `LLM/` files containing `pickLanguage`, so
-it never reaches `Models/`. Reword a literal in `Pastura/Pastura/Models/*Message.swift` and the
-Kotlin twin plus its commonTest pins stay stale *and agree with each other* — nothing reddens on
-either side. The Swift file is the source of truth; a reword is a three-file hand edit (Swift, the
-`.kt`, the commonTest expected string). Applies to `ScenarioValidationMessage` (53) and
-`ScenarioLintMessage` (21). The same class, with a sharper edge: `Engine/PlaceholderAvailability.swift`
+**A Models-layer message type is dual-landed, and the Kotlin format string is now a *catalog key*.**
+`ScenarioValidationMessage` (53) and `ScenarioLintMessage` (22) render through `MessageRendering.kt`:
+`rendering()` carries the Swift `String(localized:)` literal verbatim as the key, and
+`localizedFormat` is an `expect` — JVM identity actual, `appleMain` actual
+`NSBundle.mainBundle.localizedStringForKey`. Apple lookup **falls back to the key**, so a Kotlin
+format that is no longer a live catalog key renders English in the app with no runtime signal.
+`MessageCatalogCoverageTests` (`shared/models/src/jvmTest/…`) is the detector: key present, not
+`extractionState: stale`, `ja` state `translated`, specifier multiset matching. It reddens only when
+the PR's changed paths trip `ci.yml`'s `kmp` filter, which now covers `Localizable.xcstrings` and
+`Models/Scenario{Validation,Lint}Message.swift` on top of `shared/**` — i.e. every file a reword
+must touch, so a PR that dodges the per-PR run has not changed any of the four either;
+`kmp-nightly.yml` is the backstop. `check-prompt-literal-parity.py` still never scans `Models/`.
+The Swift literal remains the source of truth and a reword is a **four-place** edit:
+Swift literal → catalog `ja` value (via the normal sync) → Kotlin `rendering()` format → commonTest
+expected string. What stays unchecked: whether the `ja` value still *means* the English key (only
+its specifiers are compared), and roster completeness — the coverage test reuses the commonTest
+rosters (`rosterWithExpectedRenderings()`, now `internal`), so a Kotlin case added without a
+roster entry reddens the existing count pins, not this test. The same class, with a sharper edge:
+`Engine/PlaceholderAvailability.swift`
 → `shared/engine/.../PlaceholderAvailability.kt` is a data map the Swift linter and two editor views
 **consume today**, so it keeps moving — a new `PhaseType` or handler-supplied token is a three-file
 hand edit (Swift, the `.kt`, its commonTest), and only the Swift union-guard test notices a Swift-side

--- a/.claude/rules/kmp-interop.md
+++ b/.claude/rules/kmp-interop.md
@@ -136,10 +136,14 @@ must touch, so a PR that dodges the per-PR run has not changed any of the four e
 `kmp-nightly.yml` is the backstop. `check-prompt-literal-parity.py` still never scans `Models/`.
 The Swift literal remains the source of truth and a reword is a **four-place** edit:
 Swift literal → catalog `ja` value (via the normal sync) → Kotlin `rendering()` format → commonTest
-expected string. What stays unchecked: whether the `ja` value still *means* the English key (only
-its specifiers are compared), and roster completeness — the coverage test reuses the commonTest
-rosters (`rosterWithExpectedRenderings()`, now `internal`), so a Kotlin case added without a
-roster entry reddens the existing count pins, not this test. The same class, with a sharper edge:
+expected string. The test sees the reword only **once `xcstringstool sync` has retired the old
+key** — the pre-commit hook skips that sync, so a reword committed un-synced leaves the old key live
+and the suite green until the next synced build; the full boundary is on the test's KDoc. Also
+unchecked: whether the `ja` value still *means* the English key (only its specifiers are compared),
+a Kotlin format that is a live key of some *other* surface, and roster completeness — the test
+reuses the commonTest rosters (`rosterWithExpectedRenderings()`, now `internal`), whose count pins
+redden only if the hand transcription was updated too; the `else`-free `when` in `swiftCaseNameOf`
+is the sole compile-time completeness guard. The same class, with a sharper edge:
 `Engine/PlaceholderAvailability.swift`
 → `shared/engine/.../PlaceholderAvailability.kt` is a data map the Swift linter and two editor views
 **consume today**, so it keeps moving — a new `PhaseType` or handler-supplied token is a three-file

--- a/.claude/rules/kmp-interop.md
+++ b/.claude/rules/kmp-interop.md
@@ -122,28 +122,20 @@ integral `Double` drops its `.0`. The third bites silently: `TranscriptComparato
 never the fixtures' observed lines: a field no fixture populates is the one that bites later.
 `RunLogTests.fullyPopulatedLinePinsTheWireShape` is that measurement.
 
-**A Models-layer message type is dual-landed, and the Kotlin format string is now a *catalog key*.**
-`ScenarioValidationMessage` (53) and `ScenarioLintMessage` (22) render through `MessageRendering.kt`:
-`rendering()` carries the Swift `String(localized:)` literal verbatim as the key, and
-`localizedFormat` is an `expect` — JVM identity actual, `appleMain` actual
-`NSBundle.mainBundle.localizedStringForKey`. Apple lookup **falls back to the key**, so a Kotlin
-format that is no longer a live catalog key renders English in the app with no runtime signal.
-`MessageCatalogCoverageTests` (`shared/models/src/jvmTest/…`) is the detector: key present, not
-`extractionState: stale`, `ja` state `translated`, specifier multiset matching. It reddens only when
-the PR's changed paths trip `ci.yml`'s `kmp` filter, which now covers `Localizable.xcstrings` and
-`Models/Scenario{Validation,Lint}Message.swift` on top of `shared/**` — i.e. every file a reword
-must touch, so a PR that dodges the per-PR run has not changed any of the four either;
-`kmp-nightly.yml` is the backstop. `check-prompt-literal-parity.py` still never scans `Models/`.
-The Swift literal remains the source of truth and a reword is a **four-place** edit:
-Swift literal → catalog `ja` value (via the normal sync) → Kotlin `rendering()` format → commonTest
-expected string. The test sees the reword only **once `xcstringstool sync` has retired the old
-key** — the pre-commit hook skips that sync, so a reword committed un-synced leaves the old key live
-and the suite green until the next synced build; the full boundary is on the test's KDoc. Also
-unchecked: whether the `ja` value still *means* the English key (only its specifiers are compared),
-a Kotlin format that is a live key of some *other* surface, and roster completeness — the test
-reuses the commonTest rosters (`rosterWithExpectedRenderings()`, now `internal`), whose count pins
-redden only if the hand transcription was updated too; the `else`-free `when` in `swiftCaseNameOf`
-is the sole compile-time completeness guard. The same class, with a sharper edge:
+**A Models-layer message type is dual-landed, and the Kotlin format string is a *catalog key*.**
+`ScenarioValidationMessage` (53) and `ScenarioLintMessage` (22) carry the Swift `String(localized:)`
+literal verbatim as the key `rendering()` hands to the `expect` `localizedFormat`
+(`MessageRendering.kt`); the Apple actual **falls back to the key**, so a Kotlin format that is no
+longer a live catalog key renders English in the app with no runtime signal. A reword is a
+**four-place** edit — Swift literal (source of truth) → catalog `ja` value via the normal sync →
+Kotlin `rendering()` format → commonTest expected string. The detector is
+`MessageCatalogCoverageTests` (`:shared:models:jvmTest`, run per-PR because `ci.yml`'s `kmp` filter
+covers the catalog and both `*Message.swift`), with two blind spots stated on its KDoc:
+it sees a reword only once `xcstringstool sync` has retired the old key (the
+pre-commit hook skips that sync), and it compares specifiers, not meaning. Roster completeness is not
+its job either — the commonTest count pins redden only if the hand transcription was updated too;
+the `else`-free `when` in `swiftCaseNameOf` is the sole compile-time guard.
+`check-prompt-literal-parity.py` still never scans `Models/`. The same class, with a sharper edge:
 `Engine/PlaceholderAvailability.swift`
 → `shared/engine/.../PlaceholderAvailability.kt` is a data map the Swift linter and two editor views
 **consume today**, so it keeps moving — a new `PhaseType` or handler-supplied token is a three-file

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,6 +211,8 @@ jobs:
           # reword or an `xcstringstool sync` broke that resolution — the Apple
           # `localizedFormat` falls back to the key, so the app just loses its
           # ja translation. Without these the check would run nightly only.
+          # It sees a reword only once the sync has retired the old key; the
+          # test's KDoc states that boundary.
           if printf '%s\n' "$FILES" | grep -qE '^(shared/|gradle/|gradlew|gradle\.properties$)|\.gradle\.kts$|^\.github/workflows/(ci|kmp-nightly)\.yml$|^Pastura/Pastura/Resources/Localizable\.xcstrings$|^Pastura/Pastura/Models/Scenario(Validation|Lint)Message\.swift$'; then
             echo "kmp=true" >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,7 +203,15 @@ jobs:
           #
           # Over-inclusive in the safe direction either way — it costs one
           # compile-only run (#1148 is the one real instance in 40 merges).
-          if printf '%s\n' "$FILES" | grep -qE '^(shared/|gradle/|gradlew|gradle\.properties$)|\.gradle\.kts$|^\.github/workflows/(ci|kmp-nightly)\.yml$'; then
+          #
+          # The last two tokens are Swift/resource paths, not Kotlin ones. The
+          # Kotlin message twins carry the Swift `String(localized:)` literals
+          # verbatim as catalog keys, and `MessageCatalogCoverageTests`
+          # (`:shared:models:jvmTest`) is the only per-PR signal that a Swift
+          # reword or an `xcstringstool sync` broke that resolution — the Apple
+          # `localizedFormat` falls back to the key, so the app just loses its
+          # ja translation. Without these the check would run nightly only.
+          if printf '%s\n' "$FILES" | grep -qE '^(shared/|gradle/|gradlew|gradle\.properties$)|\.gradle\.kts$|^\.github/workflows/(ci|kmp-nightly)\.yml$|^Pastura/Pastura/Resources/Localizable\.xcstrings$|^Pastura/Pastura/Models/Scenario(Validation|Lint)Message\.swift$'; then
             echo "kmp=true" >> "$GITHUB_OUTPUT"
           else
             echo "kmp=false" >> "$GITHUB_OUTPUT"

--- a/Pastura/Pastura/Models/ScenarioLintMessage.swift
+++ b/Pastura/Pastura/Models/ScenarioLintMessage.swift
@@ -14,7 +14,8 @@ import Foundation
 /// This is the message-model split for the KMP Engine port (ADR-023 Stage 3):
 /// the cases moved to Kotlin `commonMain` 1:1 as a sealed class
 /// (`shared/models/.../ScenarioLintMessage.kt`, landed in the same PR), and
-/// `localized` removed `CVarArg` and `String(format:)` from the Engine files.
+/// `localized` is what removed `CVarArg`, `String(format:)` and
+/// `String(localized:)` from the Engine files.
 ///
 /// Deliberately a **separate** type from ``ScenarioValidationMessage`` rather
 /// than folded into it: the two model different surfaces — a lint finding
@@ -35,7 +36,8 @@ import Foundation
 /// catalog `ja` value (the normal `xcstringstool` sync), the Kotlin
 /// `rendering()` format, and the commonTest expected string. Leaving the
 /// Kotlin side behind reddens `MessageCatalogCoverageTests`
-/// (`:shared:models:jvmTest`), run per-PR via the `ci.yml` `kmp` filter.
+/// (`:shared:models:jvmTest`), run per-PR via the `ci.yml` `kmp` filter —
+/// once the catalog sync has retired the old key (its KDoc states the boundary).
 nonisolated public enum ScenarioLintMessage: Sendable {
   // MARK: Ordering (ScenarioSemanticLinter+Ordering.swift, R1–R6/R19)
   case eliminateNeedsVote

--- a/Pastura/Pastura/Models/ScenarioLintMessage.swift
+++ b/Pastura/Pastura/Models/ScenarioLintMessage.swift
@@ -12,9 +12,9 @@ import Foundation
 /// string embedded in a ``LintFinding/message``.
 ///
 /// This is the message-model split for the KMP Engine port (ADR-023 Stage 3):
-/// the cases move to Kotlin `commonMain` 1:1 as a sealed class
-/// (`shared/models/.../ScenarioLintMessage.kt`, landing in the same PR), while
-/// `localized` becomes an `expect`/`actual` leaf.
+/// the cases moved to Kotlin `commonMain` 1:1 as a sealed class
+/// (`shared/models/.../ScenarioLintMessage.kt`, landed in the same PR), and
+/// `localized` removed `CVarArg` and `String(format:)` from the Engine files.
 ///
 /// Deliberately a **separate** type from ``ScenarioValidationMessage`` rather
 /// than folded into it: the two model different surfaces — a lint finding
@@ -25,6 +25,17 @@ import Foundation
 ///
 /// The rendered text is byte-identical to the pre-refactor Engine literals so
 /// `Localizable.xcstrings` keys are unchanged.
+///
+/// The Kotlin twin now resolves each of these literals through the same
+/// `expect`/`actual` `localizedFormat` leaf as ``ScenarioValidationMessage``'s
+/// Kotlin twin, so on iOS the Kotlin engine reads the same
+/// `Localizable.xcstrings` `ja` value this file's `String(localized:)`
+/// literal does (#1631). Each literal here **is** the Kotlin twin's catalog
+/// key, so rewording one is a four-place edit: this Swift literal, the
+/// catalog `ja` value (the normal `xcstringstool` sync), the Kotlin
+/// `rendering()` format, and the commonTest expected string. Leaving the
+/// Kotlin side behind reddens `MessageCatalogCoverageTests`
+/// (`:shared:models:jvmTest`), run per-PR via the `ci.yml` `kmp` filter.
 nonisolated public enum ScenarioLintMessage: Sendable {
   // MARK: Ordering (ScenarioSemanticLinter+Ordering.swift, R1–R6/R19)
   case eliminateNeedsVote

--- a/Pastura/Pastura/Models/ScenarioValidationMessage.swift
+++ b/Pastura/Pastura/Models/ScenarioValidationMessage.swift
@@ -29,7 +29,8 @@ import Foundation
 /// catalog `ja` value (the normal `xcstringstool` sync), the Kotlin
 /// `rendering()` format, and the commonTest expected string. Leaving the
 /// Kotlin side behind reddens `MessageCatalogCoverageTests`
-/// (`:shared:models:jvmTest`), run per-PR via the `ci.yml` `kmp` filter.
+/// (`:shared:models:jvmTest`), run per-PR via the `ci.yml` `kmp` filter —
+/// once the catalog sync has retired the old key (its KDoc states the boundary).
 nonisolated public enum ScenarioValidationMessage: Sendable {
   // MARK: Language membership (shared: ScenarioValidator + ScenarioLoader)
   case languageNotAccepted(allowed: String, got: String)

--- a/Pastura/Pastura/Models/ScenarioValidationMessage.swift
+++ b/Pastura/Pastura/Models/ScenarioValidationMessage.swift
@@ -9,16 +9,27 @@ import Foundation
 /// case into the display string.
 ///
 /// This is the message-model split for the KMP Phase 3.0 Engine port (issue
-/// #501, Stage 0 / S0.1): the cases move to Kotlin `commonMain` 1:1 as a sealed
-/// class, while `localized` becomes an `expect`/`actual` leaf. Concretely it
-/// removes `CVarArg` **and** `String(format:)` **and** `String(localized:)` —
-/// all Foundation/ObjC-isms — from the Engine files, which is the real
-/// portability delta, not merely relocating the `String(localized:)` token.
+/// #501, Stage 0 / S0.1): the cases moved to Kotlin `commonMain` 1:1 as a
+/// sealed class, and `localized` removed `CVarArg` **and** `String(format:)`
+/// **and** `String(localized:)` — all Foundation/ObjC-isms — from the Engine
+/// files, which was the real portability delta, not merely relocating the
+/// `String(localized:)` token.
 ///
 /// The rendered text is byte-identical to the pre-refactor Engine literals so
 /// `Localizable.xcstrings` keys are unchanged. Callers wrap the rendered string
 /// in ``SimulationError/scenarioValidationFailed(_:)`` (unchanged payload type —
 /// it is shared by many out-of-scope plain-literal throwers).
+///
+/// The Kotlin twin (`shared/models/.../ScenarioValidationMessage.kt`) now
+/// resolves each of these literals through its own `expect`/`actual`
+/// `localizedFormat` leaf, so on iOS the Kotlin engine reads the same
+/// `Localizable.xcstrings` `ja` value this file's `String(localized:)`
+/// literal does (#1631). Each literal here **is** the Kotlin twin's catalog
+/// key, so rewording one is a four-place edit: this Swift literal, the
+/// catalog `ja` value (the normal `xcstringstool` sync), the Kotlin
+/// `rendering()` format, and the commonTest expected string. Leaving the
+/// Kotlin side behind reddens `MessageCatalogCoverageTests`
+/// (`:shared:models:jvmTest`), run per-PR via the `ci.yml` `kmp` filter.
 nonisolated public enum ScenarioValidationMessage: Sendable {
   // MARK: Language membership (shared: ScenarioValidator + ScenarioLoader)
   case languageNotAccepted(allowed: String, got: String)

--- a/docs/decisions/ADR-023.md
+++ b/docs/decisions/ADR-023.md
@@ -275,7 +275,8 @@ precisely how §4 went stale in the first place.)
   `ScenarioLintMessage` (Swift) / `ScenarioLintMessage.kt` (Kotlin) — 22 cases, en-only
   `render()` carrying the same Stage-5 debt as `ScenarioValidationMessage` (#1562, PR D1a,
   2026-08-26) — since discharged by the `expect`/`actual` `localizedFormat` leaf and
-  `MessageCatalogCoverageTests` (#1631). Separate rather than folded into `ScenarioValidationMessage` because a lint
+  `MessageCatalogCoverageTests` (#1631; the Apple actual's in-app resolution is a Stage-5 QA
+  step). Separate rather than folded into `ScenarioValidationMessage` because a lint
   finding is collected with a severity, not thrown as a single failure, and the validator's
   53-case parity pin stays untouched. The linter's four Engine extensions now build the case
   and render it, so no `String(localized:)` / `String(format:)` remains in them. The

--- a/docs/decisions/ADR-023.md
+++ b/docs/decisions/ADR-023.md
@@ -274,7 +274,8 @@ precisely how §4 went stale in the first place.)
   message prep this row called for landed first as a **separate** Models type,
   `ScenarioLintMessage` (Swift) / `ScenarioLintMessage.kt` (Kotlin) — 22 cases, en-only
   `render()` carrying the same Stage-5 debt as `ScenarioValidationMessage` (#1562, PR D1a,
-  2026-08-26). Separate rather than folded into `ScenarioValidationMessage` because a lint
+  2026-08-26) — since discharged by the `expect`/`actual` `localizedFormat` leaf and
+  `MessageCatalogCoverageTests` (#1631). Separate rather than folded into `ScenarioValidationMessage` because a lint
   finding is collected with a severity, not thrown as a single failure, and the validator's
   53-case parity pin stays untouched. The linter's four Engine extensions now build the case
   and render it, so no `String(localized:)` / `String(format:)` remains in them. The

--- a/docs/kmp-migration-status.md
+++ b/docs/kmp-migration-status.md
@@ -22,7 +22,7 @@ At-a-glance progress for the KMP Engine migration (ADR-023 / [#501](https://gith
 > other section is hand-maintained; refresh it when a KMP PR merges (see
 > [`.claude/rules/kmp-interop.md`](../.claude/rules/kmp-interop.md)).
 
-_Last updated: 2026-08-29._
+_Last updated: 2026-08-30._
 
 ## Stages
 
@@ -33,7 +33,7 @@ _Last updated: 2026-08-29._
 | 2 | Two-boundary vertical slice = GO/NO-GO gate | ✅ **GO** (2026-07-18) | #1063 #1137 #1172 · [ADR-023 §12](decisions/ADR-023.md) |
 | 3 | Bulk port to `commonMain` | ✅ done | ↓ Stage 3 breakdown |
 | 4 | Cross-language parity harness | 🔄 in progress | 1a #1387 · 1b #1458 · S3a [#1605](https://github.com/tyabu12/pastura/issues/1605) landed; S3b (RNG seam) [#1615](https://github.com/tyabu12/pastura/issues/1615) landed; S3b-2 (seeded fixtures) [#1618](https://github.com/tyabu12/pastura/issues/1618) landed; S4 (cancellation tail) [#1622](https://github.com/tyabu12/pastura/issues/1622) landed; S5 (suspend parity) [#1625](https://github.com/tyabu12/pastura/issues/1625) landed; S6 (divergence-6 ruling) [#1629](https://github.com/tyabu12/pastura/issues/1629) landed — Stage-4 residue cleared · [#501](https://github.com/tyabu12/pastura/issues/501) |
-| 5 | iOS consumption switch + code-merge | ⬜ not started | the remaining integration · adapter traps: [`kmp-interop.md`](../.claude/rules/kmp-interop.md) · ⚠️ en-only `ScenarioValidationMessage.render()` / `ScenarioLintMessage.render()` block this — [#1464](https://github.com/tyabu12/pastura/issues/1464), [#1562](https://github.com/tyabu12/pastura/issues/1562) |
+| 5 | iOS consumption switch + code-merge | ⬜ not started | the remaining integration · adapter traps: [`kmp-interop.md`](../.claude/rules/kmp-interop.md) · message localization leaf landed [#1631](https://github.com/tyabu12/pastura/issues/1631) |
 
 Legend: ✅ done · 🔄 in progress · 🟡 partial · ⬜ not started.
 

--- a/docs/kmp-migration-status.md
+++ b/docs/kmp-migration-status.md
@@ -33,7 +33,7 @@ _Last updated: 2026-08-30._
 | 2 | Two-boundary vertical slice = GO/NO-GO gate | ✅ **GO** (2026-07-18) | #1063 #1137 #1172 · [ADR-023 §12](decisions/ADR-023.md) |
 | 3 | Bulk port to `commonMain` | ✅ done | ↓ Stage 3 breakdown |
 | 4 | Cross-language parity harness | 🔄 in progress | 1a #1387 · 1b #1458 · S3a [#1605](https://github.com/tyabu12/pastura/issues/1605) landed; S3b (RNG seam) [#1615](https://github.com/tyabu12/pastura/issues/1615) landed; S3b-2 (seeded fixtures) [#1618](https://github.com/tyabu12/pastura/issues/1618) landed; S4 (cancellation tail) [#1622](https://github.com/tyabu12/pastura/issues/1622) landed; S5 (suspend parity) [#1625](https://github.com/tyabu12/pastura/issues/1625) landed; S6 (divergence-6 ruling) [#1629](https://github.com/tyabu12/pastura/issues/1629) landed — Stage-4 residue cleared · [#501](https://github.com/tyabu12/pastura/issues/501) |
-| 5 | iOS consumption switch + code-merge | ⬜ not started | the remaining integration · adapter traps: [`kmp-interop.md`](../.claude/rules/kmp-interop.md) · message localization leaf landed [#1631](https://github.com/tyabu12/pastura/issues/1631) |
+| 5 | iOS consumption switch + code-merge | ⬜ not started | the remaining integration · adapter traps: [`kmp-interop.md`](../.claude/rules/kmp-interop.md) · message localization leaf landed [#1631](https://github.com/tyabu12/pastura/issues/1631) (Apple actual: in-app `ja` check pending) |
 
 Legend: ✅ done · 🔄 in progress · 🟡 partial · ⬜ not started.
 

--- a/shared/models/build.gradle.kts
+++ b/shared/models/build.gradle.kts
@@ -117,4 +117,15 @@ tasks.named<Test>("jvmTest") {
             .dir("Pastura/Pastura/Resources/Presets")
             .asFile.absolutePath,
     )
+    // Inject the LIVE string catalog for `MessageCatalogCoverageTests` — the only
+    // check that a Models-layer message's `Rendering.format` is still a live,
+    // translated catalog key. On Apple targets `localizedFormat` falls back to the
+    // key itself when the lookup misses, so drift loses the ja translation silently.
+    // Absolute path, same reason as `pastura.presetsDir` above.
+    systemProperty(
+        "pastura.xcstringsPath",
+        rootProject.layout.projectDirectory
+            .file("Pastura/Pastura/Resources/Localizable.xcstrings")
+            .asFile.absolutePath,
+    )
 }

--- a/shared/models/src/appleMain/kotlin/com/pastura/models/MessageRendering.apple.kt
+++ b/shared/models/src/appleMain/kotlin/com/pastura/models/MessageRendering.apple.kt
@@ -11,6 +11,13 @@ import platform.Foundation.NSBundle
  * Apple hosts (the macOS parity harness, the gate spike) no entry is found and
  * the supplied default — the key itself — comes back unchanged, which is what
  * keeps the English `commonTest` pins green on the `macosArm64Test` rung.
+ *
+ * ⚠️ **Unverified in-app until Stage 5.** No rung exercises the catalog path:
+ * `macosArm64Test` and the gate spike hit the fallback above, and the iOS app
+ * does not link the framework yet. The claim that this resolves the same
+ * table as `String(localized:)` is therefore a Foundation-documented
+ * expectation, not a measurement — the first Stage-5 build must render one
+ * key under `ja` from the app before the Stage-5 board row treats it as done.
  */
 internal actual fun localizedFormat(key: String): String =
     NSBundle.mainBundle.localizedStringForKey(key, key, null)

--- a/shared/models/src/appleMain/kotlin/com/pastura/models/MessageRendering.apple.kt
+++ b/shared/models/src/appleMain/kotlin/com/pastura/models/MessageRendering.apple.kt
@@ -1,0 +1,16 @@
+package com.pastura.models
+
+import platform.Foundation.NSBundle
+
+/**
+ * Resolves the key against `Bundle.main`'s `Localizable` table.
+ *
+ * The Swift side's `String(localized:)` resolves against exactly that table, so
+ * inside the iOS app this reads the same compiled `Localizable.xcstrings` the
+ * Swift twins do — which is the whole point of this leaf. On the catalog-less
+ * Apple hosts (the macOS parity harness, the gate spike) no entry is found and
+ * the supplied default — the key itself — comes back unchanged, which is what
+ * keeps the English `commonTest` pins green on the `macosArm64Test` rung.
+ */
+internal actual fun localizedFormat(key: String): String =
+    NSBundle.mainBundle.localizedStringForKey(key, key, null)

--- a/shared/models/src/commonMain/kotlin/com/pastura/models/MessageRendering.kt
+++ b/shared/models/src/commonMain/kotlin/com/pastura/models/MessageRendering.kt
@@ -41,8 +41,12 @@ internal data class Rendering(val format: String, val args: List<Any>) {
  * `String(format:)` too, so this is a documented house rule rather than a
  * behaviour to match.
  *
- * Arguments are rendered with `toString()` — `Int` / `Long` for `%lld`, `String`
- * for `%@`.
+ * Arguments are rendered with `toString()`, which constrains what [args] may
+ * hold: `String` for `%@`, `Int` / `Long` for `%lld`, nothing else — a `Double`
+ * would render Kotlin's `1.0E-4` where Swift formats differently, and no
+ * message case carries one. `%%` is **not** collapsed to `%` (Foundation
+ * does); the catalog coverage test rejects any `%` outside the four forms
+ * above, so the divergence cannot enter through a translation unnoticed.
  *
  * @param format the (possibly localized) format string.
  * @param args the arguments to substitute.
@@ -62,7 +66,7 @@ internal fun substitute(format: String, args: List<Any>): String {
         // Try `%N$` first: read the digits, then require the `$`.
         var j = i + 1
         var digitsEnd = j
-        while (digitsEnd < format.length && format[digitsEnd].isDigit()) digitsEnd++
+        while (digitsEnd < format.length && format[digitsEnd] in '0'..'9') digitsEnd++
         var argIndex: Int? = null
         var isPositional = false
         if (digitsEnd > j && digitsEnd < format.length && format[digitsEnd] == '$') {

--- a/shared/models/src/commonMain/kotlin/com/pastura/models/MessageRendering.kt
+++ b/shared/models/src/commonMain/kotlin/com/pastura/models/MessageRendering.kt
@@ -1,0 +1,110 @@
+package com.pastura.models
+
+/**
+ * Resolves an English catalog key to the platform's localized format string.
+ *
+ * The key **is** the English format string as it appears in
+ * `Pastura/Pastura/Resources/Localizable.xcstrings` (the Swift side's
+ * `String(localized:)` argument), so a platform with no catalog can honour the
+ * contract by returning the key itself — which is exactly what the JVM and the
+ * catalog-less Apple hosts (macOS harness, gate spike) do.
+ *
+ * @param key the English format string used as the catalog key.
+ * @return the localized format string, or [key] when no catalog entry exists.
+ */
+internal expect fun localizedFormat(key: String): String
+
+/**
+ * A localizable message: an English catalog key plus its positional arguments.
+ *
+ * Splitting the key from the arguments is what makes localization possible —
+ * the key is resolved through [localizedFormat] at render time, so a translated
+ * value (which may reorder its arguments via `%N$@` forms) can be substituted
+ * into instead of the English one.
+ *
+ * @property format the English format string, doubling as the catalog key.
+ * @property args the arguments, in the order the English format consumes them.
+ */
+internal data class Rendering(val format: String, val args: List<Any>) {
+    /** Resolves [format] through the platform catalog and substitutes [args]. */
+    fun render(): String = substitute(localizedFormat(format), args)
+}
+
+/**
+ * Substitutes [args] into a `String(format:)`-style [format] string.
+ *
+ * Recognises exactly the four specifier forms the Pastura catalog uses: `%@`
+ * and `%lld` (consuming arguments sequentially) and their positional
+ * counterparts `%N$@` and `%N$lld` (1-based index into [args]). The two kinds
+ * keep **independent** counters: a bare specifier advances only the sequential
+ * one and never the positional index. Mixing them is unspecified in Foundation's
+ * `String(format:)` too, so this is a documented house rule rather than a
+ * behaviour to match.
+ *
+ * Arguments are rendered with `toString()` — `Int` / `Long` for `%lld`, `String`
+ * for `%@`.
+ *
+ * @param format the (possibly localized) format string.
+ * @param args the arguments to substitute.
+ * @return the substituted string.
+ */
+internal fun substitute(format: String, args: List<Any>): String {
+    val out = StringBuilder(format.length + 16)
+    var i = 0
+    var nextSequentialArg = 0
+    while (i < format.length) {
+        val c = format[i]
+        if (c != '%') {
+            out.append(c)
+            i++
+            continue
+        }
+        // Try `%N$` first: read the digits, then require the `$`.
+        var j = i + 1
+        var digitsEnd = j
+        while (digitsEnd < format.length && format[digitsEnd].isDigit()) digitsEnd++
+        var argIndex: Int? = null
+        var isPositional = false
+        if (digitsEnd > j && digitsEnd < format.length && format[digitsEnd] == '$') {
+            val parsed = format.substring(j, digitsEnd).toIntOrNull()
+            if (parsed != null && parsed >= 1) {
+                argIndex = parsed - 1
+                isPositional = true
+                j = digitsEnd + 1
+            }
+        }
+        val conversion = when {
+            format.startsWith("@", j) -> "@"
+            format.startsWith("lld", j) -> "lld"
+            else -> null
+        }
+        if (conversion == null) {
+            // Any `%` sequence outside the recognised set — `%d`, `%%`, a bare
+            // trailing `%`, a `%0$@` — is copied through literally. This runs on
+            // the validator's throw path, where a malformed or unexpected
+            // localization value must degrade to slightly-wrong text rather than
+            // throw a second exception on top of the one being reported.
+            out.append(c)
+            i++
+            continue
+        }
+        if (!isPositional) {
+            argIndex = nextSequentialArg
+        }
+        val value = argIndex?.let { args.getOrNull(it) }
+        if (value == null) {
+            // Out-of-range index, or more specifiers than arguments: leave the
+            // whole specifier in the output rather than dropping it, so the
+            // mismatch is visible in the message instead of silently vanishing.
+            out.append(format, i, j + conversion.length)
+        } else {
+            // Appended verbatim and NOT re-scanned: arguments carry user-supplied
+            // scenario text, so an argument containing `%@` must survive as
+            // literal text and must never consume the next argument.
+            out.append(value.toString())
+            if (!isPositional) nextSequentialArg++
+        }
+        i = j + conversion.length
+    }
+    return out.toString()
+}

--- a/shared/models/src/commonMain/kotlin/com/pastura/models/ScenarioLintMessage.kt
+++ b/shared/models/src/commonMain/kotlin/com/pastura/models/ScenarioLintMessage.kt
@@ -147,102 +147,183 @@ public sealed class ScenarioLintMessage {
      * `Models/`. The mitigation is procedural only — the Swift file is the source
      * of truth, and a reword there is a two-file edit by hand.
      */
-    public fun render(): String = when (this) {
+    public fun render(): String = rendering().render()
+
+    /**
+     * Maps the case to its [Rendering] — English format string plus positional
+     * args, in the order the format consumes them.
+     *
+     * The format strings are byte-identical to the `String(localized:)` /
+     * `String(format:)` base values in Swift's `ScenarioLintMessage.localized`,
+     * with `%@` left in place as a catalog placeholder rather than substituted
+     * here — [Rendering.render] resolves the platform catalog and substitutes.
+     */
+    internal fun rendering(): Rendering = when (this) {
         // ── Ordering ────────────────────────────────────────────────────────
         is EliminateNeedsVote ->
-            "eliminate-needs-vote: an 'eliminate' phase does nothing without a 'vote' phase " +
-                "in the same round — add a 'vote' phase before it."
+            Rendering(
+                "eliminate-needs-vote: an 'eliminate' phase does nothing without a 'vote' " +
+                    "phase in the same round — add a 'vote' phase before it.",
+                emptyList(),
+            )
         is EliminateAfterVote ->
-            "eliminate-after-vote: this 'eliminate' runs before every 'vote' phase, so it " +
-                "acts on the previous round's stale tally — move it after the 'vote' phase."
+            Rendering(
+                "eliminate-after-vote: this 'eliminate' runs before every 'vote' phase, so it " +
+                    "acts on the previous round's stale tally — move it after the 'vote' phase.",
+                emptyList(),
+            )
         is PdNeedsRoundRobinChoose ->
-            "pd-needs-round-robin-choose: 'prisoners_dilemma' scoring needs a round-robin " +
-                "'choose' phase earlier in the round to populate pairings, or scores never " +
-                "change — add one before this 'score_calc'."
+            Rendering(
+                "pd-needs-round-robin-choose: 'prisoners_dilemma' scoring needs a " +
+                    "round-robin 'choose' phase earlier in the round to populate pairings, or " +
+                    "scores never change — add one before this 'score_calc'.",
+                emptyList(),
+            )
         is PairwisePayoffNeedsRoundRobinChoose ->
-            "pairwise-payoff-needs-round-robin-choose: 'pairwise_payoff' scoring needs a " +
-                "round-robin 'choose' phase earlier in the round to populate pairings, or " +
-                "scores never change — add one before this 'score_calc'."
+            Rendering(
+                "pairwise-payoff-needs-round-robin-choose: 'pairwise_payoff' scoring needs a " +
+                    "round-robin 'choose' phase earlier in the round to populate pairings, or " +
+                    "scores never change — add one before this 'score_calc'.",
+                emptyList(),
+            )
         is WordwolfNeedsAssignAndVote ->
-            "wordwolf-needs-assign-and-vote: 'wordwolf_judge' scoring needs both an 'assign' " +
-                "phase with target 'random_one' and a 'vote' phase earlier in the round, or it " +
-                "judges nothing — add the missing phase(s) before this 'score_calc'."
+            Rendering(
+                "wordwolf-needs-assign-and-vote: 'wordwolf_judge' scoring needs both an " +
+                    "'assign' phase with target 'random_one' and a 'vote' phase earlier in the " +
+                    "round, or it judges nothing — add the missing phase(s) before this " +
+                    "'score_calc'.",
+                emptyList(),
+            )
         is EventReactiveNeedsEventInject ->
-            "event-reactive-needs-event-inject: 'event_reactive' scoring needs an earlier " +
-                "'event_inject' phase with a dictionary event source and the default " +
-                "'as: current_event', or the favored action is never scored — fix the " +
-                "'event_inject' before this 'score_calc'."
+            Rendering(
+                "event-reactive-needs-event-inject: 'event_reactive' scoring needs an " +
+                    "earlier 'event_inject' phase with a dictionary event source and the " +
+                    "default 'as: current_event', or the favored action is never scored — fix " +
+                    "the 'event_inject' before this 'score_calc'.",
+                emptyList(),
+            )
         is RelationshipUpdatePlacement ->
-            "relationship-update-placement: this 'relationship_update' cannot see its " +
-                "vote/choose signals — place it after the producing 'vote'/'choose' phase and " +
-                "before any 'prisoners_dilemma' 'score_calc', with no 'speak'/'choose' phase " +
-                "between the vote and it."
+            Rendering(
+                "relationship-update-placement: this 'relationship_update' cannot see its " +
+                    "vote/choose signals — place it after the producing 'vote'/'choose' phase " +
+                    "and before any 'prisoners_dilemma' 'score_calc', with no " +
+                    "'speak'/'choose' phase between the vote and it.",
+                emptyList(),
+            )
         is VoteTallyNeedsVote ->
-            "vote-tally-needs-vote: 'vote_tally' scoring has no 'vote' phase earlier in the " +
-                "round, so it scores nothing or re-adds a stale tally — add a 'vote' phase " +
-                "before this 'score_calc'."
+            Rendering(
+                "vote-tally-needs-vote: 'vote_tally' scoring has no 'vote' phase earlier in " +
+                    "the round, so it scores nothing or re-adds a stale tally — add a 'vote' " +
+                    "phase before this 'score_calc'.",
+                emptyList(),
+            )
         // ── Config ──────────────────────────────────────────────────────────
         is ChooseShouldDeclareOptions ->
-            "choose-should-declare-options: this 'choose' phase has no 'options' list, so " +
-                "the agent's action is unconstrained free text — add an 'options' list to steer " +
-                "the choice."
+            Rendering(
+                "choose-should-declare-options: this 'choose' phase has no 'options' list, " +
+                    "so the agent's action is unconstrained free text — add an 'options' list " +
+                    "to steer the choice.",
+                emptyList(),
+            )
         is AssignSourceNonempty ->
-            "assign-source-nonempty: this 'assign' phase's source resolves to an empty list, " +
-                "so nothing is assigned (or every agent gets an empty value) — add at least one " +
-                "entry to the referenced source data."
+            Rendering(
+                "assign-source-nonempty: this 'assign' phase's source resolves to an empty " +
+                    "list, so nothing is assigned (or every agent gets an empty value) — add " +
+                    "at least one entry to the referenced source data.",
+                emptyList(),
+            )
         is SummarizePairingPlaceholders ->
-            "summarize-pairing-placeholders: this 'summarize' template references " +
-                "{agent1}-family placeholders, but no round-robin 'choose' phase runs earlier " +
-                "in the round, so the placeholders leak literally into the summary — add a " +
-                "round-robin 'choose' phase before this 'summarize', or remove the pairing " +
-                "placeholders."
+            Rendering(
+                "summarize-pairing-placeholders: this 'summarize' template references " +
+                    "{agent1}-family placeholders, but no round-robin 'choose' phase runs " +
+                    "earlier in the round, so the placeholders leak literally into the " +
+                    "summary — add a round-robin 'choose' phase before this 'summarize', or " +
+                    "remove the pairing placeholders.",
+                emptyList(),
+            )
         is MaxSentencesNoOp ->
-            "max-sentences-no-op: this phase emits no LLM statement, so its 'max_sentences' " +
-                "cap never reaches a prompt and has no effect — remove it, or move it to a " +
-                "phase that emits a statement (speak_all / speak_each / whisper)."
+            Rendering(
+                "max-sentences-no-op: this phase emits no LLM statement, so its " +
+                    "'max_sentences' cap never reaches a prompt and has no effect — remove " +
+                    "it, or move it to a phase that emits a statement (speak_all / " +
+                    "speak_each / whisper).",
+                emptyList(),
+            )
         is PairwisePayoffNoScorableRow ->
-            "pairwise-payoff-no-scorable-row: no 'payoff' row's 'when' tokens match the " +
-                "round-robin 'choose' options, so no pairing is ever scored — add a 'payoff' " +
-                "table whose 'when' rows use the 'choose' option tokens."
+            Rendering(
+                "pairwise-payoff-no-scorable-row: no 'payoff' row's 'when' tokens match the " +
+                    "round-robin 'choose' options, so no pairing is ever scored — add a " +
+                    "'payoff' table whose 'when' rows use the 'choose' option tokens.",
+                emptyList(),
+            )
         is PairwisePayoffDeadRow ->
-            "pairwise-payoff-dead-row: one or more 'payoff' rows use 'when' tokens that " +
-                "aren't in the round-robin 'choose' options, so those rows never fire — fix the " +
-                "tokens to match the 'choose' options, or remove the unused rows."
+            Rendering(
+                "pairwise-payoff-dead-row: one or more 'payoff' rows use 'when' tokens that " +
+                    "aren't in the round-robin 'choose' options, so those rows never fire — " +
+                    "fix the tokens to match the 'choose' options, or remove the unused rows.",
+                emptyList(),
+            )
         is LogWindowBelowAgentCount ->
-            "log-window-below-agent-count: 'log_window' is smaller than the agent count " +
-                "while a 'speak_each' phase is present, so same-round earlier speakers vanish " +
-                "from the addressee pool — raise 'log_window' to at least the agent count."
+            Rendering(
+                "log-window-below-agent-count: 'log_window' is smaller than the agent count " +
+                    "while a 'speak_each' phase is present, so same-round earlier speakers " +
+                    "vanish from the addressee pool — raise 'log_window' to at least the " +
+                    "agent count.",
+                emptyList(),
+            )
         is AssignAllSourceShorterThanRounds ->
-            "assign-all-source-shorter-than-rounds: this 'assign' phase has fewer source " +
-                "entries than the scenario's 'rounds', so the later rounds wrap back around to " +
-                "the first entry and repeat it — add one entry per round, or lower 'rounds'."
+            Rendering(
+                "assign-all-source-shorter-than-rounds: this 'assign' phase has fewer " +
+                    "source entries than the scenario's 'rounds', so the later rounds wrap " +
+                    "back around to the first entry and repeat it — add one entry per round, " +
+                    "or lower 'rounds'.",
+                emptyList(),
+            )
         // ── Placeholders ────────────────────────────────────────────────────
         is UnresolvablePlaceholder ->
-            "unresolvable-placeholder: the placeholder '{$token}' is supplied by no " +
-                "phase, so it leaks into the LLM prompt verbatim — check for a typo or remove it."
+            Rendering(
+                "unresolvable-placeholder: the placeholder '{%@}' is supplied by no phase, " +
+                    "so it leaks into the LLM prompt verbatim — check for a typo or remove it.",
+                listOf(token),
+            )
         is PlaceholderPhaseAvailability ->
-            "placeholder-phase-availability: the placeholder '{$token}' is only " +
-                "populated by a producing phase, but none runs earlier in the phase list, so it " +
-                "resolves to an empty value — move the producing phase before this one."
+            Rendering(
+                "placeholder-phase-availability: the placeholder '{%@}' is only populated " +
+                    "by a producing phase, but none runs earlier in the phase list, so it " +
+                    "resolves to an empty value — move the producing phase before this one.",
+                listOf(token),
+            )
         is PerPersonaPlaceholderInSummarize ->
-            "per-persona-placeholder-in-summarize: the per-persona placeholder " +
-                "'{$token}' is never populated in a 'summarize' phase (summaries aren't " +
-                "per-agent), so it leaks literally — remove it or move it to an LLM phase."
+            Rendering(
+                "per-persona-placeholder-in-summarize: the per-persona placeholder " +
+                    "'{%@}' is never populated in a 'summarize' phase (summaries aren't " +
+                    "per-agent), so it leaks literally — remove it or move it to an LLM phase.",
+                listOf(token),
+            )
         // ── Conditions ──────────────────────────────────────────────────────
         is SingleQuotedLiteralInCondition ->
-            "single-quoted-literal-in-condition: the operand $token is single-quoted, " +
-                "but the condition evaluator treats only double quotes as string literals — it " +
-                "is read as an undefined identifier and the comparison is always false. Use " +
-                "double quotes instead."
+            Rendering(
+                "single-quoted-literal-in-condition: the operand %@ is single-quoted, but " +
+                    "the condition evaluator treats only double quotes as string literals — " +
+                    "it is read as an undefined identifier and the comparison is always " +
+                    "false. Use double quotes instead.",
+                listOf(token),
+            )
         is BareIdentifierLooksLikeLiteral ->
-            "bare-identifier-looks-like-literal: the operand '$token' matches a persona " +
-                "name but is unquoted, so the condition evaluator reads it as an undefined " +
-                "identifier and the comparison is always false — wrap it in double quotes to " +
-                "compare against the name."
+            Rendering(
+                "bare-identifier-looks-like-literal: the operand '%@' matches a persona " +
+                    "name but is unquoted, so the condition evaluator reads it as an " +
+                    "undefined identifier and the comparison is always false — wrap it in " +
+                    "double quotes to compare against the name.",
+                listOf(token),
+            )
         is UnknownConditionIdentifier ->
-            "unknown-condition-identifier: '$token' is not a known condition " +
-                "variable (a derived variable, score, persona, extraData key, or " +
-                "engine-injected name), so it resolves to no value at runtime — check for a typo."
+            Rendering(
+                "unknown-condition-identifier: '%@' is not a known condition variable (a " +
+                    "derived variable, score, persona, extraData key, or engine-injected " +
+                    "name), so it resolves to no value at runtime — check for a typo.",
+                listOf(token),
+            )
     }
 
     public companion object {

--- a/shared/models/src/commonMain/kotlin/com/pastura/models/ScenarioLintMessage.kt
+++ b/shared/models/src/commonMain/kotlin/com/pastura/models/ScenarioLintMessage.kt
@@ -98,54 +98,38 @@ public sealed class ScenarioLintMessage {
     public data class UnknownConditionIdentifier(public val token: String) : ScenarioLintMessage()
 
     /**
-     * Renders the case to its display string, in **English only**.
+     * Renders the case to its display string, localized on Apple hosts that
+     * carry the app's string catalog.
      *
-     * The literals are byte-identical to the `String(localized:)` base values in
-     * Swift's `ScenarioLintMessage.localized`, with each `%@` replaced by the
-     * case's `token`. Swift substitutes through `String(format:)` with exactly
-     * one argument, which interpolates the token **verbatim** — no quoting, no
-     * escaping, and no second format pass over the result — so a plain Kotlin
-     * string template is the faithful port, and a token containing a quote or a
-     * `%` must survive untouched (the commonTest roster pins exactly that).
+     * The format strings are byte-identical to the `String(localized:)` base
+     * values in Swift's `ScenarioLintMessage.localized`, with each `%@` bound to
+     * the case's `token`. Swift substitutes through `String(format:)` with
+     * exactly one argument, which interpolates the token **verbatim** — no
+     * quoting, no escaping, and no second format pass over the result — so
+     * [substitute]'s plain scan is the faithful port, and a token containing a
+     * quote or a `%` must survive untouched (the commonTest roster pins exactly
+     * that).
      *
-     * ## Why en-only, and the Stage-5 debt it creates
-     *
-     * `commonMain` has no string catalog, and Kotlin/Native has no path to
-     * `Localizable.xcstrings`. ADR-023 §5 defines no boundary for this type and
-     * nothing consumes it in production until the linter port, so there is no
-     * localization contract to satisfy yet, and inventing one here would be
-     * guessing at Stage-5's design.
-     *
-     * Every one of these 22 literals **already has a `ja` translation** in
-     * `Pastura/Pastura/Resources/Localizable.xcstrings`. Lint findings are more
+     * Rendering goes through the same platform catalog leaf as
+     * [ScenarioValidationMessage.render] — see that KDoc for the full
+     * `expect`/`actual` shape, the four-place reword rule, and how
+     * `MessageCatalogCoverageTests` catches a stale side. Lint findings are more
      * exposed than validation messages: they surface in the scenario **editor
      * UI**, one row per finding, as ordinary browsing output rather than as a
-     * rare failure. If iOS starts consuming the Kotlin engine (Stage 5) while
-     * this is still en-only, Japanese users read English lint findings in the
-     * editor — a user-visible regression with **no compiler and no test signal**,
-     * since the Kotlin side would be internally consistent and the commonTest
-     * pins would stay green. A KDoc is only read by someone already in this file,
-     * which is the wrong audience for a debt that fires at Stage 5, so it is also
-     * recorded on the Stage-5 row of `docs/kmp-migration-status.md`.
+     * rare failure, so the debt that leaf discharges (#1631) mattered here
+     * first.
      *
-     * The Stage-5 fix is to make the rendering an `expect`/`actual` leaf, or to
-     * route the Apple side back through the Swift `localized`. Member naming here
-     * is chosen so either lands without moving callers: `render()` keeps its name
-     * and signature, and only its body delegates to the platform leaf. When
-     * budgeting that, count **source sets, not targets** — re-derive from
-     * `shared/models/build.gradle.kts`, whose four Apple targets share a parent
-     * source set under the default hierarchy template.
-     *
-     * ## No gate covers the dual landing of these 22 literals
+     * ## No gate covers the dual landing of these 22 literals beyond the catalog
      *
      * These literals are dual-landed with Swift's `ScenarioLintMessage.localized`
      * (that property's own doc comment says the same from the other side).
-     * Reword one there and the twin here, plus this module's expected-string
-     * pins, stay stale *and agree with each other* — so nothing reddens on either
-     * side. `check-prompt-literal-parity.py` does not close it: it only looks at
-     * `Engine/` + `LLM/` files containing `pickLanguage`, which never reaches
-     * `Models/`. The mitigation is procedural only — the Swift file is the source
-     * of truth, and a reword there is a two-file edit by hand.
+     * `check-prompt-literal-parity.py` does not cover this file: it only looks
+     * at `Engine/` + `LLM/` files containing `pickLanguage`, which never reaches
+     * `Models/`. `MessageCatalogCoverageTests` catches a Kotlin [rendering]
+     * format that no longer matches a catalog key or whose `%@` token count
+     * disagrees with the `ja` value, but it cannot catch a Swift-only reword
+     * that never touches the catalog at all — the Swift file stays the source
+     * of truth, and a reword there is still a four-place edit by hand.
      */
     public fun render(): String = rendering().render()
 

--- a/shared/models/src/commonMain/kotlin/com/pastura/models/ScenarioValidationMessage.kt
+++ b/shared/models/src/commonMain/kotlin/com/pastura/models/ScenarioValidationMessage.kt
@@ -340,128 +340,264 @@ public sealed class ScenarioValidationMessage {
      * than from this sentence — an earlier revision asserted "four targets, so
      * four `actual`s", which was wrong in both halves at once.
      */
-    public fun render(): String = when (this) {
+    public fun render(): String = rendering().render()
+
+    /**
+     * Maps the case to its [Rendering] — English format string plus positional
+     * args, in the order the format consumes them.
+     *
+     * The format strings are byte-identical to the `String(localized:)` base
+     * values in Swift's `ScenarioValidationMessage.localized`, with `%@` / `%lld`
+     * left in place as catalog placeholders rather than substituted here —
+     * [Rendering.render] resolves the platform catalog and substitutes.
+     */
+    internal fun rendering(): Rendering = when (this) {
         is LanguageNotAccepted ->
-            "Scenario: field 'language' must be one of {$allowed}, got '$got'"
+            Rendering(
+                "Scenario: field 'language' must be one of {%@}, got '%@'",
+                listOf(allowed, got),
+            )
         is SimulationLanguageNotAccepted ->
-            "Scenario: field 'simulationLanguage' must be one of {$allowed} or nil, got '$got'"
+            Rendering(
+                "Scenario: field 'simulationLanguage' must be one of {%@} or nil, got '%@'",
+                listOf(allowed, got),
+            )
         is SimulationLanguageYAMLNotAccepted ->
-            "Scenario: field 'simulation_language' must be one of {$allowed} or absent, got '$got'"
+            Rendering(
+                "Scenario: field 'simulation_language' must be one of {%@} or absent, got '%@'",
+                listOf(allowed, got),
+            )
         is AgentCountBelowMinimum ->
-            "Agent count ($count) is below minimum of 2"
+            Rendering("Agent count (%lld) is below minimum of 2", listOf(count))
         is AgentCountExceedsMaximum ->
-            "Agent count ($count) exceeds maximum of 10"
+            Rendering("Agent count (%lld) exceeds maximum of 10", listOf(count))
         is PersonaCountMismatch ->
-            "Persona count ($personaCount) does not match agent count ($agentCount)"
+            Rendering(
+                "Persona count (%lld) does not match agent count (%lld)",
+                listOf(personaCount, agentCount),
+            )
         is RoundCountExceedsMaximum ->
-            "Round count ($rounds) exceeds maximum of 30"
+            Rendering("Round count (%lld) exceeds maximum of 30", listOf(rounds))
         is LogWindowBelowMinimum ->
-            "Log window ($window) must be at least 1"
+            Rendering("Log window (%lld) must be at least 1", listOf(window))
         is EstimatedInferencesExceedsMaximum ->
-            "Estimated inferences ($estimated) exceeds maximum of 100"
+            Rendering("Estimated inferences (%lld) exceeds maximum of 100", listOf(estimated))
         is HighInferenceCount ->
-            "High inference count ($estimated). Simulation may take several minutes."
+            Rendering(
+                "High inference count (%lld). Simulation may take several minutes.",
+                listOf(estimated),
+            )
         is ConditionalMissingIf ->
-            "$label: missing or empty 'if' expression."
+            Rendering("%@: missing or empty 'if' expression.", listOf(label))
         is ConditionalEmptyBranches ->
-            "$label: must have at least one sub-phase in 'then' or 'else'."
+            Rendering(
+                "%@: must have at least one sub-phase in 'then' or 'else'.",
+                listOf(label),
+            )
         is NestedConditionalNotAllowed ->
-            "$label: nested 'conditional' inside another conditional is not allowed (depth-1 rule)."
+            Rendering(
+                "%@: nested 'conditional' inside another conditional is not allowed (depth-1 rule).",
+                listOf(label),
+            )
         is BranchNestedConditional ->
-            "$label is another conditional, which is not allowed (depth-1 rule)."
+            Rendering(
+                "%@ is another conditional, which is not allowed (depth-1 rule).",
+                listOf(label),
+            )
         is BranchReflectNotAllowed ->
-            "$label is a reflect phase, which is not allowed inside a conditional."
+            Rendering(
+                "%@ is a reflect phase, which is not allowed inside a conditional.",
+                listOf(label),
+            )
         is BranchWhisperNotAllowed ->
-            "$label is a whisper phase, which is not allowed inside a conditional."
+            Rendering(
+                "%@ is a whisper phase, which is not allowed inside a conditional.",
+                listOf(label),
+            )
         is BranchRelationshipUpdateNotAllowed ->
-            "$label is a relationship_update phase, which is not allowed inside a conditional."
+            Rendering(
+                "%@ is a relationship_update phase, which is not allowed inside a conditional.",
+                listOf(label),
+            )
         is BranchNarrateNotAllowed ->
-            "$label is a narrate phase, which is not allowed inside a conditional."
+            Rendering(
+                "%@ is a narrate phase, which is not allowed inside a conditional.",
+                listOf(label),
+            )
         is RequiresOutputField ->
-            "$label ($type) requires field '${field}' in output."
+            Rendering(
+                "%@ (%@) requires field '%@' in output.",
+                listOf(label, type, field),
+            )
         is SecondaryFieldMismatch ->
-            "$label ($type) secondary field must be '$canonical', not '$key'."
+            Rendering(
+                "%@ (%@) secondary field must be '%@', not '%@'.",
+                listOf(label, type, canonical, key),
+            )
         is RelationshipUpdateMissingRule ->
-            "$label ($type) requires at least one affinity rule: " +
-                "'vote_against' and/or 'action_deltas'."
+            Rendering(
+                "%@ (%@) requires at least one affinity rule: 'vote_against' and/or 'action_deltas'.",
+                listOf(label, type),
+            )
         is SourceNotFound ->
-            "$label: source '$source' not found in scenario data. " +
-                "Add a top-level '$source' field to the scenario YAML."
+            Rendering(
+                "%@: source '%@' not found in scenario data. " +
+                    "Add a top-level '%@' field to the scenario YAML.",
+                listOf(label, source, source),
+            )
         is AssignSourceGroupedForAll ->
-            "$label: source '$source' contains grouped values (e.g., majority/minority pairs). " +
-                "Use target: random_one to distribute these. " +
-                "Use target: all only for a flat list of strings or a single string."
+            Rendering(
+                "%@: source '%@' contains grouped values (e.g., majority/minority pairs). " +
+                    "Use target: random_one to distribute these. " +
+                    "Use target: all only for a flat list of strings or a single string.",
+                listOf(label, source),
+            )
         is AssignSourceNotGroupedForRandomOne ->
-            "$label: source '$source' must be a list of grouped values " +
-                "(e.g., majority/minority pairs) when target is random_one."
+            Rendering(
+                "%@: source '%@' must be a list of grouped values " +
+                    "(e.g., majority/minority pairs) when target is random_one.",
+                listOf(label, source),
+            )
         is InvalidYAMLFormat ->
-            "Invalid YAML format"
+            Rendering("Invalid YAML format", emptyList())
         is MissingRequiredField ->
-            "$label: missing required field '$key'"
+            Rendering("%@: missing required field '%@'", listOf(label, key))
         is FieldWrongType ->
-            "$label: field '$key' must be $expected, got $got"
+            Rendering(
+                "%@: field '%@' must be %@, got %@",
+                listOf(label, key, expected, got),
+            )
         is FieldNotDoubleOrInt ->
-            "$label: field '$key' must be Double or Int, got $got"
+            Rendering(
+                "%@: field '%@' must be Double or Int, got %@",
+                listOf(label, key, got),
+            )
         is AgentsPersonasCountMismatch ->
-            "agents ($agentCount) does not match personas count ($personaCount)"
+            Rendering(
+                "agents (%lld) does not match personas count (%lld)",
+                listOf(agentCount, personaCount),
+            )
         is InvalidTarget ->
-            "$label has invalid target: '$value'. Use 'all' or 'random_one'."
+            Rendering(
+                "%@ has invalid target: '%@'. Use 'all' or 'random_one'.",
+                listOf(label, value),
+            )
         is InvalidPairing ->
-            "$label has invalid pairing: '$value'. Use 'round_robin'."
+            Rendering(
+                "%@ has invalid pairing: '%@'. Use 'round_robin'.",
+                listOf(label, value),
+            )
         is InvalidLogic ->
-            "$label has invalid logic: '$value'. Expected one of: $allowed."
+            Rendering(
+                "%@ has invalid logic: '%@'. Expected one of: %@.",
+                listOf(label, value, allowed),
+            )
         is ActionDeltasNotDict ->
-            "$label: field 'action_deltas' must be a dictionary of Int values, got $got"
+            Rendering(
+                "%@: field 'action_deltas' must be a dictionary of Int values, got %@",
+                listOf(label, got),
+            )
         is ActionDeltasValueNotInt ->
-            "$label: action_deltas value for '$key' must be Int, got $got"
+            Rendering(
+                "%@: action_deltas value for '%@' must be Int, got %@",
+                listOf(label, key, got),
+            )
         is PayoffNotList ->
-            "$label: field 'payoff' must be a list of {when, points} rows, got $got"
+            Rendering(
+                "%@: field 'payoff' must be a list of {when, points} rows, got %@",
+                listOf(label, got),
+            )
         is PayoffRowInvalid ->
-            "$label: each 'payoff' row needs 'when' (2 strings) and 'points' (2 ints) — $detail"
+            Rendering(
+                "%@: each 'payoff' row needs 'when' (2 strings) and 'points' (2 ints) — %@",
+                listOf(label, detail),
+            )
         is PhaseMissingType ->
-            "$label missing 'type'"
+            Rendering("%@ missing 'type'", listOf(label))
         is PhaseInvalidType ->
-            "$label has invalid type: '$value'"
+            Rendering("%@ has invalid type: '%@'", listOf(label, value))
         is OutputNotDict ->
-            "$label: field 'output' must be a dictionary of String values, got $got"
+            Rendering(
+                "%@: field 'output' must be a dictionary of String values, got %@",
+                listOf(label, got),
+            )
         is OutputValueNotString ->
-            "$label: output schema value for '$key' must be String, got $got"
+            Rendering(
+                "%@: output schema value for '%@' must be String, got %@",
+                listOf(label, key, got),
+            )
         is BranchNotArray ->
-            "$label: '$branch' must be an array of phase objects"
+            Rendering("%@: '%@' must be an array of phase objects", listOf(label, branch))
         is ExtraDataArrayOfDictNotString ->
-            "Top-level field '$key': array-of-dict values must all be String. " +
-                "Quote non-string values (e.g. `majority: \"1\"`)."
+            Rendering(
+                "Top-level field '%@': array-of-dict values must all be String. " +
+                    "Quote non-string values (e.g. `majority: \"1\"`).",
+                listOf(key),
+            )
         is ExtraDataMixedArray ->
-            "Top-level field '$key': mixed-type arrays are not supported. " +
-                "Use a pure [String] or [[String: String]]."
+            Rendering(
+                "Top-level field '%@': mixed-type arrays are not supported. " +
+                    "Use a pure [String] or [[String: String]].",
+                listOf(key),
+            )
         is ExtraDataDictNotString ->
-            "Top-level field '$key': dictionary values must all be String. " +
-                "Quote non-string values."
+            Rendering(
+                "Top-level field '%@': dictionary values must all be String. " +
+                    "Quote non-string values.",
+                listOf(key),
+            )
         is ExtraDataUnsupportedType ->
-            "Top-level field '$key' has unsupported type $got. Supported shapes: $shapes."
+            Rendering(
+                "Top-level field '%@' has unsupported type %@. Supported shapes: %@.",
+                listOf(key, got, shapes),
+            )
         is EventInjectMissingSource ->
-            "$label: missing 'source'. event_inject requires a 'source' key naming a " +
-                "top-level YAML field that lists the event strings."
+            Rendering(
+                "%@: missing 'source'. event_inject requires a 'source' key naming a " +
+                    "top-level YAML field that lists the event strings.",
+                listOf(label),
+            )
         is EventInjectSourceEmptyStrings ->
-            "$label: source '$source' is empty. event_inject requires at least one string " +
-                "in the list; for a single fixed event use ['only_event']."
+            Rendering(
+                "%@: source '%@' is empty. event_inject requires at least one string " +
+                    "in the list; for a single fixed event use ['only_event'].",
+                listOf(label, source),
+            )
         is EventInjectSourceWrongShape ->
-            "$label: source '$source' must be a list of event strings or {text, favors} " +
-                "mappings; for a single fixed event use ['only_event']."
+            Rendering(
+                "%@: source '%@' must be a list of event strings or {text, favors} " +
+                    "mappings; for a single fixed event use ['only_event'].",
+                listOf(label, source),
+            )
         is EventInjectSourceEmptyEvents ->
-            "$label: source '$source' is empty. event_inject requires at least one event " +
-                "in the list; for a single fixed event use ['only_event']."
+            Rendering(
+                "%@: source '%@' is empty. event_inject requires at least one event " +
+                    "in the list; for a single fixed event use ['only_event'].",
+                listOf(label, source),
+            )
         is EventInjectEntryMissingText ->
-            "$label: source '$source' has an event entry missing a non-empty 'text'. " +
-                "Dict-shaped events require 'text' (and may add 'favors')."
+            Rendering(
+                "%@: source '%@' has an event entry missing a non-empty 'text'. " +
+                    "Dict-shaped events require 'text' (and may add 'favors').",
+                listOf(label, source),
+            )
         is EventInjectProbabilityOutOfRange ->
-            "$label: probability $probability is out of range. " +
-                "Must be between 0.0 and 1.0 inclusive."
+            Rendering(
+                "%@: probability %@ is out of range. " +
+                    "Must be between 0.0 and 1.0 inclusive.",
+                listOf(label, probability),
+            )
         is OutputFieldNameInvalid ->
-            "$label: output field name '$name' must be an ASCII identifier " +
-                "(letters, digits, and underscore, not starting with a digit or underscore). " +
-                "Agent text values may be any language."
+            Rendering(
+                "%@: output field name '%@' must be an ASCII identifier " +
+                    "(letters, digits, and underscore, not starting with a digit or underscore). " +
+                    "Agent text values may be any language.",
+                listOf(label, name),
+            )
         is MaxSentencesOutOfRange ->
-            "$label: max_sentences ($value) must be between 1 and 6"
+            Rendering(
+                "%@: max_sentences (%lld) must be between 1 and 6",
+                listOf(label, value),
+            )
     }
 }

--- a/shared/models/src/commonMain/kotlin/com/pastura/models/ScenarioValidationMessage.kt
+++ b/shared/models/src/commonMain/kotlin/com/pastura/models/ScenarioValidationMessage.kt
@@ -12,7 +12,7 @@ package com.pastura.models
  *
  * These 53 cases come from `ScenarioValidator` (+ its extensions) and
  * `ScenarioLoader` **only**. The ADR-024 semantic linter is a *separate* surface
- * with its own 21 messages (Ordering 8 / Config 7 / Placeholders 3 /
+ * with its own 22 messages (Ordering 8 / Config 8 / Placeholders 3 /
  * Conditions 3), and they live in their own type — [ScenarioLintMessage],
  * mirroring `Pastura/Pastura/Models/ScenarioLintMessage.swift`. That split is a
  * decision (#1562), not a staging accident: a lint finding carries a severity
@@ -296,49 +296,47 @@ public sealed class ScenarioValidationMessage {
     ) : ScenarioValidationMessage()
 
     /**
-     * Renders the case to its display string, in **English only**.
+     * Renders the case to its display string, localized on Apple hosts that
+     * carry the app's string catalog.
      *
-     * The literals are byte-identical to the `String(localized:)` base values in
-     * Swift's `ScenarioValidationMessage.localized`, with `%@` / `%lld`
-     * substituted positionally.
+     * The format strings are byte-identical to the `String(localized:)` base
+     * values in Swift's `ScenarioValidationMessage.localized`. Rendering goes
+     * through the platform catalog leaf — [localizedFormat] in
+     * `MessageRendering.kt` — an `expect`/`actual` with one `jvmMain` actual
+     * (identity: returns the English key unchanged) and one `appleMain` actual
+     * (`NSBundle.mainBundle.localizedStringForKey`). So the JVM and catalog-less
+     * Apple hosts (macOS harness, `tools/kmp-gate-spike`) get the English key
+     * back — the commonTest pins below are still the detector on both rungs —
+     * while the iOS app resolves the same `Localizable.xcstrings` `ja` value
+     * Swift does, because the format string doubles as the catalog key.
      *
-     * ## Why en-only, and why that is not a shortcut
+     * ⚠️ **"the parity harness runs in en, so en-only is fine" was never the
+     * reason this stayed en-only, and must not be restored as one now that it
+     * isn't.** Validation messages never reach a transcript at all, even now
+     * that the validator is wired into the run path (D3 #1591): a scenario
+     * Swift rejects produces no transcript to compare. The harness is silent
+     * about this type in either language — the localization leaf below exists
+     * for the iOS app, not for parity.
      *
-     * `commonMain` has no string catalog, and Kotlin/Native has no path to
-     * `Localizable.xcstrings`. ADR-023 §5 defines no boundary for this type, and
-     * nothing consumes it in production until Stage 5 — so there is no
-     * localization contract to satisfy yet, and inventing one here would be
-     * guessing at Stage-5's design.
+     * ## The Stage-5 debt this discharges
      *
-     * ⚠️ **"the parity harness runs in en, so en-only is fine" is NOT the
-     * reason, and must not be restored as one.** Validation messages never reach
-     * a transcript at all, even now that the validator is wired into the run
-     * path (D3 #1591): a scenario Swift rejects produces no transcript to
-     * compare. The harness is silent about this type in either language.
+     * Every one of these 53 literals has a `ja` translation in
+     * `Pastura/Pastura/Resources/Localizable.xcstrings`. Before this leaf
+     * landed (#1631), a Stage-5 iOS app consuming the Kotlin engine would have
+     * shown Japanese users English validation errors with no compiler or test
+     * signal — recorded on the Stage-5 row of `docs/kmp-migration-status.md`.
+     * That debt is discharged: `MessageCatalogCoverageTests`
+     * (`:shared:models:jvmTest`) is now the catalog-drift signal, failing
+     * whenever a [rendering] format is stale or its `%@`/`%lld` multiset
+     * disagrees with the catalog's `ja` value.
      *
-     * ## The Stage-5 debt this creates
-     *
-     * Every one of these 53 literals **already has a `ja` translation** in
-     * `Pastura/Pastura/Resources/Localizable.xcstrings`. If iOS starts consuming
-     * the Kotlin engine (Stage 5) while this is still en-only, Japanese users get
-     * English validation errors — a user-visible regression with **no compiler
-     * and no test signal**, since the Kotlin side would be internally consistent
-     * and the pins below would stay green. A KDoc is only read by someone already
-     * in this file, which is the wrong audience for a debt that fires at Stage 5,
-     * so it is also recorded on the Stage-5 row of `docs/kmp-migration-status.md`.
-     *
-     * The Stage-5 fix is to make the rendering an `expect`/`actual` leaf. Member
-     * naming here is chosen so that lands without moving callers: `render()`
-     * keeps its name and signature, and only its body delegates to the platform
-     * leaf.
-     *
-     * When budgeting that, count **source sets, not targets**. `shared/models`
-     * declares five targets (`jvm`, `iosArm64`, `iosSimulatorArm64`, `iosX64`,
-     * `macosArm64`), but the four Apple ones share a parent source set under the
-     * default hierarchy template, so the `actual`s land in far fewer places than
-     * there are targets. Re-derive from `shared/models/build.gradle.kts` rather
-     * than from this sentence — an earlier revision asserted "four targets, so
-     * four `actual`s", which was wrong in both halves at once.
+     * A Swift literal reword is therefore a **four-place edit**: the Swift
+     * `String(localized:)` literal, the catalog `ja` value (via the normal
+     * `xcstringstool` sync), this file's [rendering] format, and the
+     * commonTest expected string. Miss the Kotlin side and
+     * `MessageCatalogCoverageTests` reddens per-PR (`ci.yml`'s `kmp` filter
+     * fires on `Localizable.xcstrings` and the two Swift `*Message.swift`
+     * files); miss the catalog sync and the same test catches the stale key.
      */
     public fun render(): String = rendering().render()
 

--- a/shared/models/src/commonTest/kotlin/com/pastura/models/MessageRenderingTests.kt
+++ b/shared/models/src/commonTest/kotlin/com/pastura/models/MessageRenderingTests.kt
@@ -1,0 +1,119 @@
+package com.pastura.models
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Pins the format-substitution contract of [substitute] and [Rendering].
+ *
+ * These run on the `jvmTest` and `macosArm64Test` rungs, where
+ * [localizedFormat] is identity (no catalog is present in either), so
+ * `Rendering.render()` is observably `substitute(format, args)` here. The
+ * catalog-resolving behaviour of the `appleMain` actual can only be observed
+ * inside the iOS app bundle and is therefore out of scope for this suite.
+ */
+class MessageRenderingTests {
+
+    @Test
+    fun bareSpecifiersConsumeArgumentsInOrder() {
+        assertEquals(
+            "Scenario: 'a' has 3 items",
+            substitute("Scenario: '%@' has %lld items", listOf("a", 3)),
+        )
+    }
+
+    @Test
+    fun positionalSpecifiersReadTheirIndex() {
+        assertEquals(
+            "a 3",
+            substitute("%1\$@ %2\$lld", listOf("a", 3)),
+        )
+    }
+
+    @Test
+    fun positionalSpecifiersMayReorderArguments() {
+        // The `ja` catalog values reorder arguments; this is the shape that
+        // makes localization possible at all.
+        assertEquals(
+            "second first",
+            substitute("%2\$@ %1\$@", listOf("first", "second")),
+        )
+    }
+
+    @Test
+    fun substitutedArgumentTextIsNotRescanned() {
+        // Scenario text is user-supplied and may itself contain `%@`.
+        assertEquals(
+            "value=%@ rest=x",
+            substitute("value=%@ rest=%@", listOf("%@", "x")),
+        )
+        assertEquals(
+            "value=%1\$@ rest=x",
+            substitute("value=%@ rest=%@", listOf("%1\$@", "x")),
+        )
+    }
+
+    @Test
+    fun outOfRangePositionalIndexIsLeftLiteral() {
+        assertEquals(
+            "a %2\$@",
+            substitute("%1\$@ %2\$@", listOf("a")),
+        )
+    }
+
+    @Test
+    fun leftoverSpecifiersAreLeftLiteral() {
+        assertEquals(
+            "a %@",
+            substitute("%@ %@", listOf("a")),
+        )
+    }
+
+    @Test
+    fun surplusArgumentsAreIgnored() {
+        assertEquals(
+            "a",
+            substitute("%@", listOf("a", "b", 7)),
+        )
+    }
+
+    @Test
+    fun unrecognisedSpecifiersAreLeftLiteral() {
+        assertEquals(
+            "%d a",
+            substitute("%d %@", listOf("a")),
+        )
+        assertEquals(
+            "100% done a",
+            substitute("100% done %@", listOf("a")),
+        )
+        assertEquals(
+            "trailing %",
+            substitute("trailing %", emptyList()),
+        )
+    }
+
+    @Test
+    fun bareAndPositionalCountersAreIndependent() {
+        // Mixing is unspecified in `String(format:)`; the rule here is that a
+        // bare specifier advances only its own sequential counter.
+        assertEquals(
+            "a a",
+            substitute("%@ %1\$@", listOf("a", "b")),
+        )
+    }
+
+    @Test
+    fun renderDelegatesToSubstituteWhereNoCatalogExists() {
+        val rendering = Rendering("%@ needs %lld", listOf("phase", 2))
+        assertEquals(substitute(rendering.format, rendering.args), rendering.render())
+        assertEquals("phase needs 2", rendering.render())
+    }
+
+    @Test
+    fun emptyFormatAndArgumentsRenderEmpty() {
+        assertEquals("", substitute("", emptyList()))
+        assertEquals("", Rendering("", emptyList()).render())
+        assertEquals("literal", substitute("literal", emptyList()))
+    }
+}

--- a/shared/models/src/commonTest/kotlin/com/pastura/models/ScenarioLintMessageTests.kt
+++ b/shared/models/src/commonTest/kotlin/com/pastura/models/ScenarioLintMessageTests.kt
@@ -266,8 +266,12 @@ class ScenarioLintMessageTests {
      * exactly one `String`, so there is no argument-order hazard of the kind the
      * validation-message suite guards against, but a positional call still pins
      * that the parameter exists and is the first one.
+     *
+     * `internal` rather than `private` on purpose: `MessageCatalogCoverageTests`
+     * (jvmTest, same test compilation) reuses this roster so the catalog check
+     * covers every case without a second hand-maintained copy.
      */
-    private fun rosterWithExpectedRenderings(): List<Pair<ScenarioLintMessage, String>> = listOf(
+    internal fun rosterWithExpectedRenderings(): List<Pair<ScenarioLintMessage, String>> = listOf(
         // ── Ordering ────────────────────────────────────────────────────────
         ScenarioLintMessage.EliminateNeedsVote to
             "eliminate-needs-vote: an 'eliminate' phase does nothing without a 'vote' phase " +

--- a/shared/models/src/commonTest/kotlin/com/pastura/models/ScenarioValidationMessageTests.kt
+++ b/shared/models/src/commonTest/kotlin/com/pastura/models/ScenarioValidationMessageTests.kt
@@ -304,8 +304,12 @@ class ScenarioValidationMessageTests {
      * `personaCountMismatch` (both Ints ordered), `secondaryFieldMismatch` (all
      * four Strings ordered), and `sourceNotFound` (one argument rendered twice
      * in one literal).
+     *
+     * `internal` rather than `private` on purpose: `MessageCatalogCoverageTests`
+     * (jvmTest, same test compilation) reuses this roster so the catalog check
+     * covers every case without a second hand-maintained copy.
      */
-    private fun rosterWithExpectedRenderings(): List<Pair<ScenarioValidationMessage, String>> = listOf(
+    internal fun rosterWithExpectedRenderings(): List<Pair<ScenarioValidationMessage, String>> = listOf(
         // POSITIONAL on purpose — see the note on this function. Swift order is
         // (allowed, got).
         ScenarioValidationMessage.LanguageNotAccepted("en, ja", "fr") to

--- a/shared/models/src/jvmMain/kotlin/com/pastura/models/MessageRendering.jvm.kt
+++ b/shared/models/src/jvmMain/kotlin/com/pastura/models/MessageRendering.jvm.kt
@@ -1,0 +1,10 @@
+package com.pastura.models
+
+/**
+ * The JVM rung has no string catalog, so the English key is the format string.
+ *
+ * Identity is also what keeps the English pins in `commonTest` the detector for
+ * a message reword — a JVM lookup that could resolve to something else would
+ * make those pins depend on a resource bundle instead of on the literals.
+ */
+internal actual fun localizedFormat(key: String): String = key

--- a/shared/models/src/jvmTest/kotlin/com/pastura/models/MessageCatalogCoverageTests.kt
+++ b/shared/models/src/jvmTest/kotlin/com/pastura/models/MessageCatalogCoverageTests.kt
@@ -1,0 +1,160 @@
+package com.pastura.models
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Asserts that every `Rendering.format` produced by the two Models-layer message
+ * types is a LIVE, translated key of `Pastura/Pastura/Resources/Localizable.xcstrings`.
+ *
+ * ## Why this test exists
+ *
+ * On Apple targets `localizedFormat(key)` resolves through `NSBundle.mainBundle`,
+ * and Foundation's lookup **falls back to the key itself** when the key is absent,
+ * stale, or untranslated. So a Kotlin format string that has drifted from the
+ * Swift `String(localized:)` literal — a reword on the Swift side, a
+ * `xcstringstool sync` that retired the old key — produces a perfectly readable
+ * English string in the iOS app and silently loses its Japanese translation.
+ * Nothing else in the repo detects that: `check-prompt-literal-parity.py` scopes
+ * itself to `Engine/` + `LLM/` and never reaches `Models/`
+ * (`.claude/rules/kmp-interop.md` § Pattern 4), and the commonTest roster pins
+ * compare Kotlin against a hand-transcribed expectation, not against the catalog.
+ *
+ * ## What is checked, per case
+ *
+ * a. the format exists as a catalog key;
+ * b. it is not `extractionState == "stale"` (`xcstringstool sync` keeps retired
+ *    keys around with that marker, so mere presence proves nothing);
+ * c. it has a `ja` localization in state `translated`;
+ * d. the `ja` value's specifier multiset equals the key's. A translation that
+ *    drops or duplicates a `%@` / `%lld` renders wrong (or renders a stale
+ *    argument) at runtime, and (c) alone would pass it. Positional forms
+ *    (`%N$@` / `%N$lld`) are normalised to their bare counterparts first, since
+ *    a Japanese translation legitimately reorders arguments.
+ *
+ * Failures are collected and reported together: a Swift-side reword typically
+ * breaks a whole family of keys at once, and a first-failure abort would hide
+ * all but one.
+ *
+ * ## Roster source
+ *
+ * The case lists are the commonTest rosters (`rosterWithExpectedRenderings()`),
+ * reused rather than duplicated — jvmTest and commonTest are one test
+ * compilation. [rosterIsComplete] pins the totals so a roster that shrinks makes
+ * this file loud rather than quietly narrowing its own coverage.
+ */
+class MessageCatalogCoverageTests {
+
+    private companion object {
+        /** Case counts pinned by the two commonTest roster suites (53 + 22). */
+        const val VALIDATION_CASE_COUNT = 53
+        const val LINT_CASE_COUNT = 22
+
+        /**
+         * Injected by `shared/models/build.gradle.kts` as an absolute path, so
+         * the read does not depend on Gradle's test working directory.
+         */
+        const val CATALOG_PATH_PROPERTY = "pastura.xcstringsPath"
+    }
+
+    /** One roster entry: a human-readable case label plus the catalog key it renders through. */
+    private data class Entry(val label: String, val format: String)
+
+    private fun entries(): List<Entry> =
+        ScenarioValidationMessageTests().rosterWithExpectedRenderings().map { (message, _) ->
+            Entry("ScenarioValidationMessage.${message::class.simpleName}", message.rendering().format)
+        } + ScenarioLintMessageTests().rosterWithExpectedRenderings().map { (message, _) ->
+            Entry("ScenarioLintMessage.${message::class.simpleName}", message.rendering().format)
+        }
+
+    private fun catalogStrings(): JsonObject {
+        val path = System.getProperty(CATALOG_PATH_PROPERTY)
+        // Fail loudly rather than skipping: a silently-unconfigured property
+        // would turn this whole suite into a no-op that still reports green.
+        assertTrue(
+            !path.isNullOrBlank(),
+            "System property `$CATALOG_PATH_PROPERTY` is not set — " +
+                "see the `tasks.named<Test>(\"jvmTest\")` block in shared/models/build.gradle.kts.",
+        )
+        val file = File(path)
+        assertTrue(file.isFile, "String catalog not found at `$path` (from `$CATALOG_PATH_PROPERTY`).")
+        val root = Json.parseToJsonElement(file.readText()).jsonObject
+        val strings = root["strings"]
+        assertTrue(strings is JsonObject, "String catalog at `$path` has no `strings` object.")
+        return strings
+    }
+
+    /**
+     * Normalises a format string to its specifier multiset, sorted so the
+     * comparison is order-insensitive: `%N$@` / `%N$lld` collapse to `%@` /
+     * `%lld` because a translation may reorder arguments legitimately, while
+     * dropping or duplicating one is the defect this catches.
+     */
+    private fun specifiers(format: String): List<String> =
+        SPECIFIER_PATTERN.findAll(format)
+            .map { match -> if (match.value.endsWith("@")) "%@" else "%lld" }
+            .sorted()
+            .toList()
+
+    @Test
+    fun rosterIsComplete() {
+        val all = entries()
+        assertEquals(
+            VALIDATION_CASE_COUNT + LINT_CASE_COUNT,
+            all.size,
+            "Roster size changed — this suite's coverage is only as wide as the commonTest rosters " +
+                "it reuses. Update the pinned counts together with the roster.",
+        )
+    }
+
+    @Test
+    fun everyMessageFormatIsALiveTranslatedCatalogKey() {
+        val strings = catalogStrings()
+        val failures = mutableListOf<String>()
+
+        for ((label, format) in entries()) {
+            val entry = strings[format]?.jsonObject
+            if (entry == null) {
+                failures += "$label: format is not a catalog key — $format"
+                continue
+            }
+            val extractionState = entry["extractionState"]?.jsonPrimitive?.content
+            if (extractionState == "stale") {
+                failures += "$label: catalog key is `extractionState: stale` (retired by " +
+                    "`xcstringstool sync`; the app falls back to English) — $format"
+                continue
+            }
+            val japanese = entry["localizations"]?.jsonObject?.get("ja")?.jsonObject
+                ?.get("stringUnit")?.jsonObject
+            val state = japanese?.get("state")?.jsonPrimitive?.content
+            if (state != "translated") {
+                failures += "$label: `ja` localization is ${state ?: "absent"}, expected `translated` — $format"
+                continue
+            }
+            val value = japanese["value"]?.jsonPrimitive?.content.orEmpty()
+            val expected = specifiers(format)
+            val actual = specifiers(value)
+            if (actual != expected) {
+                failures += "$label: `ja` specifiers $actual do not match the key's $expected — " +
+                    "key=$format ja=$value"
+            }
+        }
+
+        assertTrue(
+            failures.isEmpty(),
+            "${failures.size} message format(s) do not resolve through Localizable.xcstrings.\n" +
+                "The Swift `String(localized:)` literal is the source of truth: reword it, run the " +
+                "catalog sync, then update the Kotlin twin and its commonTest expected string.\n" +
+                failures.joinToString("\n") { "  - $it" },
+        )
+    }
+}
+
+/** `%@`, `%lld` and their positional `%N$…` forms — the four the catalog uses. */
+private val SPECIFIER_PATTERN = Regex("""%(?:\d+\$)?(?:@|lld)""")

--- a/shared/models/src/jvmTest/kotlin/com/pastura/models/MessageCatalogCoverageTests.kt
+++ b/shared/models/src/jvmTest/kotlin/com/pastura/models/MessageCatalogCoverageTests.kt
@@ -26,6 +26,20 @@ import kotlin.test.assertTrue
  * (`.claude/rules/kmp-interop.md` § Pattern 4), and the commonTest roster pins
  * compare Kotlin against a hand-transcribed expectation, not against the catalog.
  *
+ * ## What it cannot see (the honest boundary — the docs that cite this test
+ * point here)
+ *
+ * - A Swift reword is detected only **once `xcstringstool sync` has retired the
+ *   old key**. The pre-commit hook skips that sync, so a reword committed with
+ *   the catalog un-synced leaves the old key live, non-stale and `translated`;
+ *   the Kotlin twin still resolves it and this suite stays green while the two
+ *   sides have diverged. The next synced build retires the key and reddens it.
+ * - A Kotlin format that happens to be a live, translated key **of some other
+ *   surface** passes every check below.
+ * - Only specifiers are compared, never meaning: a `ja` value that still fits
+ *   the key's `%@` / `%lld` multiset but says something else passes. An
+ *   explicit `en` block whose value drifted from the key is not compared either.
+ *
  * ## What is checked, per case
  *
  * a. the format exists as a catalog key;
@@ -37,6 +51,9 @@ import kotlin.test.assertTrue
  *    argument) at runtime, and (c) alone would pass it. Positional forms
  *    (`%N$@` / `%N$lld`) are normalised to their bare counterparts first, since
  *    a Japanese translation legitimately reorders arguments.
+ * e. neither the key nor the `ja` value carries a `%` outside those four forms.
+ *    `substitute` copies `%%` through literally where Foundation collapses it to
+ *    `%`, so a translator writing `100%%` would render `100%%` on Kotlin only.
  *
  * Failures are collected and reported together: a Swift-side reword typically
  * breaks a whole family of keys at once, and a first-failure abort would hide
@@ -46,8 +63,8 @@ import kotlin.test.assertTrue
  *
  * The case lists are the commonTest rosters (`rosterWithExpectedRenderings()`),
  * reused rather than duplicated — jvmTest and commonTest are one test
- * compilation. [rosterIsComplete] pins the totals so a roster that shrinks makes
- * this file loud rather than quietly narrowing its own coverage.
+ * compilation. [rosterIsComplete] pins each roster's size so a roster that shrinks
+ * makes this file loud rather than quietly narrowing its own coverage.
  */
 class MessageCatalogCoverageTests {
 
@@ -102,15 +119,22 @@ class MessageCatalogCoverageTests {
             .sorted()
             .toList()
 
+    /** True when [text] has a `%` that is not part of a recognised specifier. */
+    private fun strayPercent(text: String): Boolean =
+        text.count { it == '%' } != SPECIFIER_PATTERN.findAll(text).count()
+
     @Test
     fun rosterIsComplete() {
-        val all = entries()
+        // Pinned per roster, not as a sum: a shrink in one offset by growth in the
+        // other must not pass.
+        val hint = "Roster size changed — this suite's coverage is only as wide as the " +
+            "commonTest rosters it reuses. Update the pinned counts together with the roster."
         assertEquals(
-            VALIDATION_CASE_COUNT + LINT_CASE_COUNT,
-            all.size,
-            "Roster size changed — this suite's coverage is only as wide as the commonTest rosters " +
-                "it reuses. Update the pinned counts together with the roster.",
+            VALIDATION_CASE_COUNT,
+            ScenarioValidationMessageTests().rosterWithExpectedRenderings().size,
+            hint,
         )
+        assertEquals(LINT_CASE_COUNT, ScenarioLintMessageTests().rosterWithExpectedRenderings().size, hint)
     }
 
     @Test
@@ -130,8 +154,16 @@ class MessageCatalogCoverageTests {
                     "`xcstringstool sync`; the app falls back to English) — $format"
                 continue
             }
-            val japanese = entry["localizations"]?.jsonObject?.get("ja")?.jsonObject
-                ?.get("stringUnit")?.jsonObject
+            val jaLocalization = entry["localizations"]?.jsonObject?.get("ja")?.jsonObject
+            if (jaLocalization != null && "variations" in jaLocalization) {
+                // Plural / device variations are a sanctioned catalog shape, but no
+                // message here uses one and this test does not walk them — say so
+                // instead of reporting a translation that exists as "absent".
+                failures += "$label: `ja` uses a `variations` block, which this test does not " +
+                    "support — $format"
+                continue
+            }
+            val japanese = jaLocalization?.get("stringUnit")?.jsonObject
             val state = japanese?.get("state")?.jsonPrimitive?.content
             if (state != "translated") {
                 failures += "$label: `ja` localization is ${state ?: "absent"}, expected `translated` — $format"
@@ -143,6 +175,13 @@ class MessageCatalogCoverageTests {
             if (actual != expected) {
                 failures += "$label: `ja` specifiers $actual do not match the key's $expected — " +
                     "key=$format ja=$value"
+            }
+            if (strayPercent(format)) {
+                failures += "$label: key carries a `%` outside the %@ / %lld / %N\$… forms — $format"
+            }
+            if (strayPercent(value)) {
+                failures += "$label: `ja` value carries a `%` outside the %@ / %lld / %N\$… forms " +
+                    "(`substitute` does not collapse `%%`) — ja=$value"
             }
         }
 


### PR DESCRIPTION
## Summary

Discharges the ADR-023 Stage-5 debt recorded by #1464 / #1562: Kotlin `ScenarioValidationMessage.render()` (53) and `ScenarioLintMessage.render()` (22) rendered English only, so an iOS app consuming the Kotlin engine would have shown Japanese users English validation errors with no compiler or test signal.

- **Rendering leaf** (`shared/models/.../MessageRendering.kt`): `internal expect fun localizedFormat(key)` — `jvmMain` identity, `appleMain` `NSBundle.mainBundle.localizedStringForKey(key, key, null)` — plus `Rendering(format, args)` and a single-pass positional `substitute()` (`%@` / `%lld` / `%N$@` / `%N$lld`; substituted text is never re-scanned; a leftover specifier stays literal, never throws). Everything new is `internal`, so the K/N header is unchanged.
- **Both message types** now return the Swift `String(localized:)` literal verbatim as the catalog key from `rendering()`; `render()` keeps its name and signature. All 53 + 22 English commonTest pins pass unchanged (JVM identity), and they stay the detector on the `macosArm64Test` rung (no catalog ⇒ key returned).
- **`MessageCatalogCoverageTests`** (`:shared:models:jvmTest`): every format is a non-stale `Localizable.xcstrings` key with a `translated` `ja` value whose specifier multiset matches, and no stray `%` on either side. `ci.yml`'s `kmp` filter now also fires on the catalog and the two Swift `*Message.swift` twins so it runs per-PR on a Swift reword.
- **Docs**: both `.kt` KDocs, both Swift doc comments, `kmp-interop.md` Pattern 4, ADR-023 §4, status-board Stage 5 row; stale lint count 21 → 22.

Not in this PR (deliberately): the Stage 4 board row ✅ (closes on the #501 operator call, per the board's own rule), and Stage 5 itself.

## Test plan

- [x] `./gradlew :shared:models:jvmTest :shared:engine:jvmTest` green (incl. new `MessageRenderingTests` ×10, `MessageCatalogCoverageTests` ×2)
- [x] `./gradlew :shared:models:compileKotlinMacosArm64 :shared:models:compileKotlinIosSimulatorArm64` green (the `appleMain` actual resolves)
- [x] `scripts/xcodebuild.sh test -skip-testing:PasturaUITests` — 3616 tests / 289 suites passed (Swift changes are doc comments only; catalog untouched by the sync)
- [x] `swiftlint lint --quiet --strict` clean
- [x] TDD sanity: rewording one Kotlin format reddened `MessageCatalogCoverageTests` with the key named; reverted
- UI tests skipped — no view code touched

## Review

Reviewer: **Opus**, split into two scopes by added lines (915 added / 16 files > soft budget): A = Kotlin leaf + message rewires, B = catalog test, CI, docs. Both **PASS**.

Applied (`🐛 fix` commit): stray-`%` guard in the catalog test (`substitute` does not collapse `%%`); per-roster count pins instead of a sum; explicit `variations` shape message; ASCII-only digit scan; KDoc constraint on `args` types; per-PR signal qualified as "fires once the catalog sync has retired the old key" in `ci.yml`, both Swift docs and `kmp-interop.md`; `kmp-interop.md` no longer claims the count pins catch a roster omission (the `else`-free `when` is the only guard); ADR-023 §4 reflowed; Swift lint doc wording.

Rejected: A-S3 "`Rendering` need not be a `data class`" — `internal`, not exported, harmless.

Residual (stated, not fixed): the `appleMain` actual is exercised by **no rung** until the iOS app links the framework — recorded in its KDoc, ADR-023 §4 and the Stage 5 board row as an in-app `ja` check pending Stage 5.

Context-economy: `kmp-interop.md` Pattern 4 paragraph compressed 22 → 15 lines (+15 / −7 path-scoped lines vs main); dropped the leaf's mechanism and the check list (both live on the KDocs), kept the four-place reword rule and the detector's two blind spots — the traps a reader of this rule needs.

## Device QA

実機QA不要 — no simulator-only surface changed; the iOS app does not link `shared/` yet. The Apple actual's first in-app resolution check belongs to the Stage-5 switch PR.

Part of #501 · Closes #1631

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5uPqXXh3gMzCtmt9qp2J1
