### PR TITLE
📝 docs: ADR-023 Stage 5 — rule deferred CI/umbrella/adapter questions, slice S5-1…S5-5

### DIFF
--- a/docs/decisions/ADR-023.md
+++ b/docs/decisions/ADR-023.md
@@ -565,7 +565,9 @@ interface StreamCallbacks {
     SwiftPM package at `tools/kmp-gate-spike/` with a local-path `.binaryTarget`, built by
     the nightly + `workflow_dispatch` only. **No per-PR lane acquires an XCFramework
     dependency** — not the iOS xcodebuild, not the root `Package.swift` harness build, not
-    a dev `swift build`. Rejected: *(A)* linking into the iOS app target — buys evidence
+    a dev `swift build`. *(Held in full until 2026-08-30; the Stage-5 ruling (a) below
+    narrows the iOS-lane clause to "never assembles" and keeps the other two verbatim.)*
+    Rejected: *(A)* linking into the iOS app target — buys evidence
     this gate does not need (iOS-runtime evidence is routed to H5/H7/Stage 5) at the cost
     of re-coupling every iOS build to XCFramework assembly, which Stage 1 deliberately
     stripped; *(B-root)* a `.binaryTarget` in the root `Package.swift` — relocates that
@@ -620,6 +622,7 @@ interface StreamCallbacks {
     and Stage 5 merges that wiring back. **At merge-back, retarget it to
     `PasturaSharedEngine` or drop it** — do not restore it as-is. The spike branch's H6
     framework-size check ("Expected 1 PasturaShared.framework") needs the same retarget.
+    *Ruled 2026-08-30 (ruling (b) below): retarget the wiring, drop the models umbrella.*
   - **Pattern-6 re-audit (from the Stage-2 gate, §12 row (i)).** The gate found that
     neither boundary adapter needs `@concurrent`
     (`tools/kmp-gate-spike/Tests/KMPGateSpikeTests/PatternSixProbeTests.swift:35`), but
@@ -628,15 +631,112 @@ interface StreamCallbacks {
     iOS app's MainActor-default call path, so **re-run the audit here**; a `nonisolated
     async` method reached from a MainActor caller runs on the MainActor and blocks the UI
     with no compiler diagnostic (`.claude/rules/swift-isolation.md` Pattern 6).
-  - **Open, informed by the #1135 probe**: whether the app's per-PR CI assembles the
-    XCFramework itself or consumes a prebuilt artifact. The nightly's
-    `workflow_dispatch`-only warm-cache probe measures the assembly lower bound against
-    the repo's ≤10-min per-PR budget; read it together with cache-restore time and a
-    key-miss margin, both of which the probe deliberately excludes.
-  - **Umbrella consolidation** — whether the two umbrellas collapse into one is a Stage-5
-    call *by design*: its inputs are the 2-gate SKIE-vs-vanilla and shim-budget
-    measurements, which do not exist until the gate runs. Deciding earlier would be
-    deciding without evidence.
+  - **Stage-5 rulings (2026-08-30, #1633).** The three questions this stage deferred *by
+    design* are ruled here, in the body, because none has shipped (CLAUDE.md § Decision
+    Records); the evidence each waited on is named inline. Until S5-4 fires, **the Swift
+    Engine remains the shipping engine** (Decision 6).
+    - **(a) Per-PR CI consumes a prebuilt `PasturaSharedEngine.xcframework`; no per-PR
+      lane assembles one as part of an iOS build.** Evidence: the `workflow_dispatch`
+      sizing probe (`kmp-nightly.yml` "Measure warm-cache assembly", run 29509388191,
+      2026-07-16) measured **5m19s** for the warm-cache assembly of both umbrellas after
+      `clean`, plus **52s** of `~/.konan` + `~/.gradle` cache restore in the same run —
+      a **6m11s lower bound** before the key-miss margin the probe excludes, against the
+      cold ~6m32s the same workflow records. That is most of the per-PR budget
+      (`ci.yml`'s tripwire is the 8-minute compile-only step of `kmp-build-test`), paid
+      by every iOS-touching PR on top of the iOS jobs themselves. Mechanism contract,
+      three lanes:
+      - *iOS lanes* (`lint-and-test`, `ui-test`, `release-build`) restore the umbrella
+        from a cache addressed by a **content key** — a hash over `shared/**` sources,
+        `gradle/**`, every `*.gradle.kts`, and the K/N toolchain version — so a hit can
+        never be stale. On a **miss** the lane assembles in place and emits a
+        `::warning::` naming the miss: the fallback is the correctness path, the cache
+        only the fast path, and the warning is the signal to fix the producer. Producer:
+        `kmp-build-test`'s existing full-native step, widened from "build-config touch"
+        to "key has no entry", plus every push to `main`, which always assembles and
+        publishes so the next PRs hit. The iOS lanes do **not** `needs:` the producer —
+        serialising ~4 min of KMP job ahead of every iOS job costs more wall-clock than
+        the occasional in-lane fallback.
+      - *Harness lane* (root `Package.swift`) and *dev `swift build`*: **B′ stands
+        verbatim** — no `.binaryTarget`, no umbrella import under `Models/` / `LLM/` /
+        `Engine/`. `PasturaCore` compiles those three directories straight from the app
+        tree, so a single `import PasturaSharedEngine` there breaks `swift build` for
+        every Engine-touching PR — the (B-root) coupling this section already rejected.
+        This is what fixes ruling (c).
+      - *Dev iOS lane* (`scripts/xcodebuild.sh`, the pre-commit build): stage the umbrella
+        via `scripts/kmp/assemble-xcframework.sh --if-missing`, restored from the spike
+        branch with its Gradle-`UP-TO-DATE` fast path (that script's header records why
+        an mtime short-circuit was rejected) — a Swift-only edit pays seconds, a `shared/`
+        edit pays one assembly. JDK 17 becomes a `scripts/setup.sh` prerequisite for iOS
+        builds; the script must say so when it is missing, never fail silently.
+      - **Re-open trigger**: if the in-lane fallback fires on more than a handful of PRs
+        per week, or the producer's assembly crosses the `kmp-build-test` job timeout,
+        the artifact moves to a published release asset keyed the same way. Not before —
+        that scheme adds a second publication channel to maintain for no measured gain.
+      - The B′ guard (`tools/kmp-gate-spike/scripts/check-b-prime-isolation.sh`) keeps
+        checks (1)/(2) and **inverts** (3)/(4): the pbxproj must reference exactly one
+        `.xcframework`, named `PasturaSharedEngine`, and no tracked `*.xcframework` may
+        exist under `Pastura/` (the staged copy stays gitignored, as on the spike branch).
+    - **(b) One umbrella — `PasturaSharedEngine`. The models-only `PasturaShared` export
+      is dropped, not retargeted.** Evidence: §11 (iv) found SKIE has nothing to act on
+      under §5's callback-only boundary and adoption stays out of scope, so no
+      SKIE-bearing second umbrella was ever going to exist; the engine umbrella already
+      re-exports `shared/models` (`api` dependency, "Enabled at 2-gate" above), which is
+      the whole mechanism behind the §9.7 two-umbrella landmine. Deleting the
+      `XCFramework("PasturaShared")` task in `shared/models/build.gradle.kts` and its
+      assembly in `ci.yml` / `kmp-nightly.yml` disarms the landmine mechanically rather
+      than by a guard. The spike branch's H6 footprint check is retargeted to
+      "exactly one `PasturaSharedEngine.framework` under `Pastura.app/Frameworks/`" and
+      lands with S5-1 as a **hard failure** on any other count — that is the
+      single-umbrella guard, at the only place a second copy could actually appear.
+    - **(c) The K/N boundary adapters live in `App/` — never in `LLM/` or `Engine/`.**
+      The dependency matrix (CLAUDE.md § Dependency Rules) gains no new edge:
+      `App/` may already depend on everything, and bridging Engine ↔ Data is the App
+      layer's job by ADR-001, so the Swift `LLMBackend` conformer wrapping `LLMService`,
+      the `SimulationEvent` relay, and the `SuspendController` port all sit under
+      `App/KMP/`. §5's `LLMBackend` precedent ("concrete implementations stay Swift
+      App-side per §4") already said this for the backend; (a)'s harness-lane clause
+      makes it structural for the rest.
+      S5-1 adds one line under the matrix — `PasturaSharedEngine` is imported from `App/`
+      only — and mirrors it to README.md and CONTRIBUTING.md in the same PR, as CLAUDE.md
+      requires for that section.
+    - **(d) Slice sequence.** Decision 6's triple gates the *switch*; H7 needs a
+      TestFlight build carrying K/N code, so linking precedes it. S5-1 and S5-2 are
+      infrastructure that changes no shipped behaviour and can land while Phase 3 is not
+      yet entered (`docs/ROADMAP.md` § "Phase 3: Community"); **S5-3 onward additionally require
+      Phase-3 entry**, because they spend TestFlight cycles and end in a shipping-engine
+      change the roadmap files under Phase 3.0.
+      - **S5-1 — link.** Restore the spike wiring retargeted per (a)/(b)/(c): pbxproj
+        Frameworks + Embed Frameworks phases, `scripts/kmp/assemble-xcframework.sh`,
+        `scripts/setup.sh`, the pre-commit hook, the CI producer/consumer steps, the
+        inverted B′ guard, the H6 hard check, the models-umbrella deletion, the
+        CLAUDE.md/README/CONTRIBUTING line. Also rehome the §10-permanent adapters from
+        `tools/kmp-gate-spike/Sources/KMPGateSpike/` under `App/KMP/` (the spike keeps
+        its copies until S5-5). Acceptance: app builds and links exactly one umbrella on
+        simulator and device; `SharedEngineLinkage.objcRuntimeNames`' equivalent resolves
+        from the app target; harness `swift build` unchanged; no iOS lane over budget.
+      - **S5-2 — adapters on the app's call path + isolation audits.** Re-run the
+        Pattern-6 audit above on the rehomed adapters as reached from
+        `SimulationViewModel`; run the Pattern-7 probe against the staged framework for
+        `LLMBackend` and the §5 detector/logger seams (that §5 paragraph says "before Stage 5
+        relies on it" — this is that point); give the ported Kotlin `ScenarioLoader` its
+        first caller (§4 records it has none). Acceptance: probe transcripts recorded on
+        #501; adapters exercised by a `PasturaTests` suite through `MockLLMService`.
+      - **S5-3 — H5 + H7** (ADR-004 §9.2): archive → ASC upload, then a TestFlight build
+        with an intentional Kotlin crash and K/N dSYM upload, symbolicated in Organizer.
+        Discharges Decision 6 (ii). Voids the ADR-004 Conditional GO on the R7 outcomes
+        that section names.
+      - **S5-4 — flag-gated switch + soak.** A Debug/TestFlight-only toggle selects the
+        Kotlin engine for a run; one TestFlight soak cycle discharges Decision 6 (iii).
+        #1632's residual — the `appleMain` `localizedFormat` actual is exercised by no
+        rung until a Kotlin `render()` reaches the UI — is discharged **here, not at
+        S5-1**: the Swift Engine still renders every message until this slice, so an
+        earlier "in-app `ja` check" has no call site. Acceptance: one catalog key
+        rendered under `ja` from the Kotlin engine on device; soak cycle recorded on #501.
+      - **S5-5 — code-merge and close-out.** Flip the default, delete the Swift run-path
+        the ledger marks `REPLACED`, and decide the gate spike's fate (retire, or keep as
+        the nightly macOS rung — its `macosArm64` parity role is Stage 4's, not this
+        stage's, so retirement must not take the parity harness with it). Decision 6
+        fires; ADR-004 §9.7 closes.
 
 ## 7. Cross-language parity obligations (standing, not stage-scoped)
 

--- a/docs/decisions/ADR-023.md
+++ b/docs/decisions/ADR-023.md
@@ -635,13 +635,19 @@ interface StreamCallbacks {
     design* are ruled here, in the body, because none has shipped (CLAUDE.md § Decision
     Records); the evidence each waited on is named inline. Until S5-4 fires, **the Swift
     Engine remains the shipping engine** (Decision 6).
-    - **(a) Per-PR CI consumes a prebuilt `PasturaSharedEngine.xcframework`; no per-PR
-      lane assembles one as part of an iOS build.** Evidence: the `workflow_dispatch`
+    - **(a) Per-PR CI consumes a prebuilt `PasturaSharedEngine.xcframework` on the
+      expected path; assembly is a cache-miss fallback, never a planned step of an iOS
+      build.** Evidence: the `workflow_dispatch`
       sizing probe (`kmp-nightly.yml` "Measure warm-cache assembly", run 29509388191,
       2026-07-16) measured **5m19s** for the warm-cache assembly of both umbrellas after
-      `clean`, plus **52s** of `~/.konan` + `~/.gradle` cache restore in the same run —
-      a **6m11s lower bound** before the key-miss margin the probe excludes, against the
-      cold ~6m32s the same workflow records. That is most of the per-PR budget
+      `clean` (Gradle's own `BUILD SUCCESSFUL in 5m 19s` line), plus **52s** of
+      `~/.konan` + `~/.gradle` cache restore in the same run — a **6m11s lower bound**
+      before the key-miss margin the probe excludes, against the cold ~6m32s the same
+      workflow records. The step table and Gradle lines are preserved on
+      [#1633](https://github.com/tyabu12/pastura/issues/1633#issuecomment-5463349343)
+      because run logs expire; the `ci.yml` comment on `kmp-build-test` records a
+      *different* 5m19s (#1135's per-PR Debug-engine step) — same digits, distinct
+      measurement. That is most of the per-PR budget
       (`ci.yml`'s tripwire is the 8-minute compile-only step of `kmp-build-test`), paid
       by every iOS-touching PR on top of the iOS jobs themselves. Mechanism contract,
       three lanes:
@@ -653,19 +659,26 @@ interface StreamCallbacks {
         only the fast path, and the warning is the signal to fix the producer. Producer:
         `kmp-build-test`'s existing full-native step, widened from "build-config touch"
         to "key has no entry", plus every push to `main`, which always assembles and
-        publishes so the next PRs hit. The iOS lanes do **not** `needs:` the producer —
-        serialising ~4 min of KMP job ahead of every iOS job costs more wall-clock than
-        the occasional in-lane fallback.
+        publishes so the next PRs hit. Main-push assembly **reverses** the `changes`
+        step's "deep full-native coverage on main is the nightly's job (PR-3)" routing
+        for the assembly alone — the nightly keeps the K/N *test* rung and the
+        gate-spike build; S5-1 rewrites that comment rather than deleting it. The iOS
+        lanes do **not** `needs:` the producer: serialising the whole `kmp-build-test`
+        job ahead of every iOS job (the `ci.yml` comment on that job records 7m30s for
+        its assembling path, and the compile-only path still runs the JVM suite first)
+        costs more wall-clock on every PR than an in-lane fallback costs on the few the
+        re-open trigger tolerates.
       - *Harness lane* (root `Package.swift`) and *dev `swift build`*: **B′ stands
         verbatim** — no `.binaryTarget`, no umbrella import under `Models/` / `LLM/` /
         `Engine/`. `PasturaCore` compiles those three directories straight from the app
         tree, so a single `import PasturaSharedEngine` there breaks `swift build` for
         every Engine-touching PR — the (B-root) coupling this section already rejected.
-        This is what fixes ruling (c).
+        This is what makes ruling (c) structural rather than conventional.
       - *Dev iOS lane* (`scripts/xcodebuild.sh`, the pre-commit build): stage the umbrella
         via `scripts/kmp/assemble-xcframework.sh --if-missing`, restored from the spike
-        branch with its Gradle-`UP-TO-DATE` fast path (that script's header records why
-        an mtime short-circuit was rejected) — a Swift-only edit pays seconds, a `shared/`
+        branch (`feature/kmp-spike-models` @ `f73bc48`, 2026-06-11) with its
+        Gradle-`UP-TO-DATE` fast path (that script's header records why an mtime
+        short-circuit was rejected) — a Swift-only edit pays seconds, a `shared/`
         edit pays one assembly. JDK 17 becomes a `scripts/setup.sh` prerequisite for iOS
         builds; the script must say so when it is missing, never fail silently.
       - **Re-open trigger**: if the in-lane fallback fires on more than a handful of PRs
@@ -673,9 +686,12 @@ interface StreamCallbacks {
         the artifact moves to a published release asset keyed the same way. Not before —
         that scheme adds a second publication channel to maintain for no measured gain.
       - The B′ guard (`tools/kmp-gate-spike/scripts/check-b-prime-isolation.sh`) keeps
-        checks (1)/(2) and **inverts** (3)/(4): the pbxproj must reference exactly one
-        `.xcframework`, named `PasturaSharedEngine`, and no tracked `*.xcframework` may
-        exist under `Pastura/` (the staged copy stays gitignored, as on the spike branch).
+        checks (1)/(2)/(4) and **inverts** (3): the pbxproj must reference exactly one
+        `.xcframework`, named `PasturaSharedEngine`. (4) — no tracked `*.xcframework`
+        under `Pastura/` — survives unchanged because the hole it plugs, a framework
+        swept in by a `PBXFileSystemSynchronizedRootGroup` with no pbxproj diff, is not
+        closed by there now being one legitimate umbrella; the staged copy stays
+        gitignored, as on the spike branch.
     - **(b) One umbrella — `PasturaSharedEngine`. The models-only `PasturaShared` export
       is dropped, not retargeted.** Evidence: §11 (iv) found SKIE has nothing to act on
       under §5's callback-only boundary and adoption stays out of scope, so no

--- a/docs/kmp-migration-status.md
+++ b/docs/kmp-migration-status.md
@@ -33,7 +33,7 @@ _Last updated: 2026-08-30._
 | 2 | Two-boundary vertical slice = GO/NO-GO gate | ✅ **GO** (2026-07-18) | #1063 #1137 #1172 · [ADR-023 §12](decisions/ADR-023.md) |
 | 3 | Bulk port to `commonMain` | ✅ done | ↓ Stage 3 breakdown |
 | 4 | Cross-language parity harness | ✅ done (2026-08-30) | 1a #1387 · 1b #1458 · S3a [#1605](https://github.com/tyabu12/pastura/issues/1605) landed; S3b (RNG seam) [#1615](https://github.com/tyabu12/pastura/issues/1615) landed; S3b-2 (seeded fixtures) [#1618](https://github.com/tyabu12/pastura/issues/1618) landed; S4 (cancellation tail) [#1622](https://github.com/tyabu12/pastura/issues/1622) landed; S5 (suspend parity) [#1625](https://github.com/tyabu12/pastura/issues/1625) landed; S6 (divergence-6 ruling) [#1629](https://github.com/tyabu12/pastura/issues/1629) landed — Stage-4 residue cleared · [#501](https://github.com/tyabu12/pastura/issues/501) |
-| 5 | iOS consumption switch + code-merge | ⬜ not started | the remaining integration · adapter traps: [`kmp-interop.md`](../.claude/rules/kmp-interop.md) · message localization leaf landed [#1631](https://github.com/tyabu12/pastura/issues/1631) (Apple actual: in-app `ja` check pending) |
+| 5 | iOS consumption switch + code-merge | 🔄 in progress | rulings + slices S5-1…S5-5 [#1633](https://github.com/tyabu12/pastura/issues/1633) · [ADR-023 §6 Stage 5](decisions/ADR-023.md) · adapter traps: [`kmp-interop.md`](../.claude/rules/kmp-interop.md) · message localization leaf landed [#1631](https://github.com/tyabu12/pastura/issues/1631) (Apple actual: in-app `ja` check → S5-4) |
 
 Legend: ✅ done · 🔄 in progress · 🟡 partial · ⬜ not started.
 
@@ -124,6 +124,8 @@ machine-checked — see the maintenance invariant above.
   text parses to the same Double wherever a field is read numerically, so the difference is
   unobservable as a value; the two ledger entries stay as the permanent pins. No Stage-4 residue
   remains.
-- **Stage 5** (iOS switch + code-merge): ⬜ not started — the remaining iOS integration; the ported
-  Kotlin loader still has no caller in `shared/engine`. See
-  [ADR-023](decisions/ADR-023.md) §6 Stage 5.
+- **Stage 5** (iOS switch + code-merge): 🔄 in progress — the three deferred questions were ruled on
+  2026-08-30 ([#1633](https://github.com/tyabu12/pastura/issues/1633)) and the stage is sliced
+  S5-1 link · S5-2 adapters + isolation audits (gives the Kotlin loader its first caller) ·
+  S5-3 H5/H7 · S5-4 flag-gated switch + soak · S5-5 code-merge; S5-1/S5-2 are pre-Phase-3
+  infrastructure, S5-3 onward need Phase-3 entry. See [ADR-023](decisions/ADR-023.md) §6 Stage 5.

--- a/docs/kmp-migration-status.md
+++ b/docs/kmp-migration-status.md
@@ -32,7 +32,7 @@ _Last updated: 2026-08-30._
 | 1 | `shared/models` + CI infrastructure | ✅ done | #1052 #1055 #1059 |
 | 2 | Two-boundary vertical slice = GO/NO-GO gate | ✅ **GO** (2026-07-18) | #1063 #1137 #1172 · [ADR-023 §12](decisions/ADR-023.md) |
 | 3 | Bulk port to `commonMain` | ✅ done | ↓ Stage 3 breakdown |
-| 4 | Cross-language parity harness | 🔄 in progress | 1a #1387 · 1b #1458 · S3a [#1605](https://github.com/tyabu12/pastura/issues/1605) landed; S3b (RNG seam) [#1615](https://github.com/tyabu12/pastura/issues/1615) landed; S3b-2 (seeded fixtures) [#1618](https://github.com/tyabu12/pastura/issues/1618) landed; S4 (cancellation tail) [#1622](https://github.com/tyabu12/pastura/issues/1622) landed; S5 (suspend parity) [#1625](https://github.com/tyabu12/pastura/issues/1625) landed; S6 (divergence-6 ruling) [#1629](https://github.com/tyabu12/pastura/issues/1629) landed — Stage-4 residue cleared · [#501](https://github.com/tyabu12/pastura/issues/501) |
+| 4 | Cross-language parity harness | ✅ done (2026-08-30) | 1a #1387 · 1b #1458 · S3a [#1605](https://github.com/tyabu12/pastura/issues/1605) landed; S3b (RNG seam) [#1615](https://github.com/tyabu12/pastura/issues/1615) landed; S3b-2 (seeded fixtures) [#1618](https://github.com/tyabu12/pastura/issues/1618) landed; S4 (cancellation tail) [#1622](https://github.com/tyabu12/pastura/issues/1622) landed; S5 (suspend parity) [#1625](https://github.com/tyabu12/pastura/issues/1625) landed; S6 (divergence-6 ruling) [#1629](https://github.com/tyabu12/pastura/issues/1629) landed — Stage-4 residue cleared · [#501](https://github.com/tyabu12/pastura/issues/501) |
 | 5 | iOS consumption switch + code-merge | ⬜ not started | the remaining integration · adapter traps: [`kmp-interop.md`](../.claude/rules/kmp-interop.md) · message localization leaf landed [#1631](https://github.com/tyabu12/pastura/issues/1631) (Apple actual: in-app `ja` check pending) |
 
 Legend: ✅ done · 🔄 in progress · 🟡 partial · ⬜ not started.
@@ -72,12 +72,13 @@ machine-checked — see the maintenance invariant above.
 
 ## Stages 4–5 — remaining integration
 
-- **Stage 4** (parity harness): 🔄 in progress — **both parity rungs are live** and every
-  planned slice (1a–S6) has landed; the row closes with the #501 board (operator call). See [ADR-023](decisions/ADR-023.md) §6 Stage 4,
+- **Stage 4** (parity harness): ✅ complete (closed 2026-08-30, operator call on
+  [#1633](https://github.com/tyabu12/pastura/issues/1633)) — **both parity rungs are live**, every
+  planned slice (1a–S6) has landed, and the ledger carries only the two permanent divergence-6 pins. See [ADR-023](decisions/ADR-023.md) §6 Stage 4,
   [#1387](https://github.com/tyabu12/pastura/issues/1387) (slice 1a, closed),
   [#1458](https://github.com/tyabu12/pastura/issues/1458) (slice 1b, closed),
   [#1605](https://github.com/tyabu12/pastura/issues/1605) (S3a, closed) and
-  [#501](https://github.com/tyabu12/pastura/issues/501) (remaining Stage-4 work).
+  [#501](https://github.com/tyabu12/pastura/issues/501) (umbrella).
 
   `EngineParityTests` replays each `ParityGolden` fixture through the Kotlin engine and walks
   the transcripts against `DivergenceLedger`. It runs per-PR on the JVM (`:shared:engine:jvmTest`


### PR DESCRIPTION
## Summary

ADR-023 Stage 4 is closed and Stage 5 is planned — docs only, no framework wiring.

- **Stage 4 → ✅** on the KMP status board (operator call; every slice 1a–S6 landed, both parity rungs live, ledger carries only the two permanent divergence-6 pins).
- **ADR-023 §6 Stage 5 edited in place** (Accepted ADR, decisions unshipped) to rule the three questions the stage deferred *by design*, now that their evidence exists:
  - **(a)** per-PR CI consumes a content-keyed prebuilt `PasturaSharedEngine.xcframework`; assembly is a cache-miss fallback with a `::warning::`, never a planned iOS-build step. Evidence: sizing probe run 29509388191 — warm assembly 5m19s + restore 52s = **6m11s lower bound** vs the 8-min compile-only tripwire (extract preserved on #1633). B′ narrows for the iOS lane only; harness + dev `swift build` clauses stand verbatim.
  - **(b)** one umbrella — the models-only `PasturaShared` export is deleted at S5-1; the H6 footprint check becomes the single-umbrella hard guard.
  - **(c)** K/N adapters live in `App/KMP/`, never `LLM/`/`Engine/` — `PasturaCore` (root `Package.swift`) compiles those directories from the app tree, so an umbrella import there would break the harness lane.
  - **(d)** slices S5-1 link → S5-2 adapters + Pattern-6/7 audits → S5-3 H5/H7 → S5-4 flag-gated switch + soak → S5-5 code-merge; S5-1/S5-2 are pre-Phase-3 infrastructure, S5-3 onward need Phase-3 entry in addition to Decision 6. #1632's in-app `ja` residual moves to S5-4, the first slice where a Kotlin `render()` has a call site.
- Status board Stage 5 row mirrors the slice sequence; the same summary is posted on #501.

## Test plan

- Docs-only: `scripts/precommit-gate-classify.sh` emits no `build`/`lint` token, so the unit suite and SwiftLint were skipped (CI path-gates the same way).
- `check-kmp-status.py` gate passed at each commit (14/14 handlers reconciled).
- `adr-writing.md` §1/§3 pass done by hand: every cited file, step name, section, SHA and date verified; 319 s + 52 s = 371 s = 6m11s.

## Review

Reviewer: **Opus** (`code-reviewer`). Verdict FAIL → all 7 findings applied in `022ca6dd`:
- Critical — ruling (a)'s headline contradicted its own fallback bullet → headline now names the fallback.
- Warning — 5m19s provenance unverifiable after log expiry and collides with an unrelated 5m19s in `ci.yml` → Gradle line cited, evidence extract posted on #1633, collision named as coincidental.
- Warning — unsourced "~4 min" → replaced by `ci.yml`'s recorded 7m30s producer path, stated as a mechanism.
- Warning — "inverts (3)/(4)" while (4) was unchanged → "keeps (1)/(2)/(4), inverts (3)", with why (4) survives.
- Warning — main-push assembly silently reversed the classify step's PR-3 routing → reversal named, nightly's remaining role stated.
- Suggestions — spike branch pinned to `f73bc48`; "fixes ruling (c)" reworded.
No findings rejected. No re-review: every fix applied the reviewer's own suggestion.

## Device QA

実機QA不要 — documentation only; no code, build settings, or on-device paths change.

Part of #501. Closes #1633.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EwYHKpGG1fa6XiTyUxmWwC
